### PR TITLE
SCAL-308277 Add metrics recorder core

### DIFF
--- a/src/bearer.ts
+++ b/src/bearer.ts
@@ -1,6 +1,7 @@
 import type { ThoughtSpotMCP } from ".";
 import type honoApp from "./handlers";
 import { validateAndSanitizeUrl } from "./oauth-manager/oauth-utils";
+import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "./routes";
 
 /**
  * Handler function for bearer/token authentication endpoints
@@ -62,12 +63,12 @@ function handleTokenAuth(
 
 	// Route to appropriate handler
 	const pathname = url.pathname;
-	if (pathname.endsWith("/mcp")) {
-		return MCPServer.serve("/mcp").fetch(req, env, ctx);
+	if (pathname.endsWith(PUBLIC_ROUTES.mcp)) {
+		return MCPServer.serve(PUBLIC_ROUTES.mcp).fetch(req, env, ctx);
 	}
 
-	if (pathname.endsWith("/sse")) {
-		return MCPServer.serveSSE("/sse").fetch(req, env, ctx);
+	if (pathname.endsWith(PUBLIC_ROUTES.sse)) {
+		return MCPServer.serveSSE(PUBLIC_ROUTES.sse).fetch(req, env, ctx);
 	}
 
 	return new Response("Not found", { status: 404 });
@@ -79,13 +80,13 @@ export function withBearerHandler(
 ) {
 	// These endpoints do NOT support api-version query params (will be removed in future)
 	// Use /token endpoints instead for new implementations
-	app.mount("/bearer", (req, env, ctx) => {
+	app.mount(PUBLIC_ROUTE_PREFIXES.bearer, (req, env, ctx) => {
 		return handleTokenAuth(req, env, ctx, MCPServer, false);
 	});
 
 	// NEW: /token endpoints - supports api-version query params
 	// Recommended for all new implementations
-	app.mount("/token", (req, env, ctx) => {
+	app.mount(PUBLIC_ROUTE_PREFIXES.token, (req, env, ctx) => {
 		return handleTokenAuth(req, env, ctx, MCPServer, true);
 	});
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -2,20 +2,21 @@ import type {
 	AuthRequest,
 	OAuthHelpers,
 } from "@cloudflare/workers-oauth-provider";
+import { type Span, SpanStatusCode, context, trace } from "@opentelemetry/api";
 import { Hono } from "hono";
-import type { Props } from "./utils";
-import { McpServerError } from "./utils";
+import { decodeBase64Url, encodeBase64Url } from "hono/utils/encode";
+import { any } from "zod";
+import { openApiSpecHandler } from "./api-schemas/open-api-spec";
+import { WithSpan, getActiveSpan } from "./metrics/tracing/tracing-utils";
 import {
+	buildSamlRedirectUrl,
 	parseRedirectApproval,
 	renderApprovalDialog,
-	buildSamlRedirectUrl,
 } from "./oauth-manager/oauth-utils";
 import { renderTokenCallback } from "./oauth-manager/token-utils";
-import { any } from "zod";
-import { encodeBase64Url, decodeBase64Url } from "hono/utils/encode";
-import { getActiveSpan, WithSpan } from "./metrics/tracing/tracing-utils";
-import { context, type Span, SpanStatusCode, trace } from "@opentelemetry/api";
-import { openApiSpecHandler } from "./api-schemas/open-api-spec";
+import { PUBLIC_ROUTES } from "./routes";
+import type { Props } from "./utils";
+import { McpServerError } from "./utils";
 
 const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
 
@@ -235,17 +236,17 @@ class Handler {
 
 const handler = new Handler();
 
-app.get("/", async (c) => {
+app.get(PUBLIC_ROUTES.root, async (c) => {
 	const response = await handler.serveIndex(c.env);
 	return response;
 });
 
-app.get("/hello", async (c) => {
+app.get(PUBLIC_ROUTES.hello, async (c) => {
 	const result = await handler.helloWorld();
 	return c.json(result);
 });
 
-app.get("/authorize", async (c) => {
+app.get(PUBLIC_ROUTES.authorize, async (c) => {
 	try {
 		const response = await handler.getAuthorize(
 			c.req.raw,
@@ -257,7 +258,7 @@ app.get("/authorize", async (c) => {
 	}
 });
 
-app.post("/authorize", async (c) => {
+app.post(PUBLIC_ROUTES.authorize, async (c) => {
 	try {
 		const redirectUrl = await handler.postAuthorize(c.req.raw, c.req.url);
 		return Response.redirect(redirectUrl);
@@ -272,7 +273,7 @@ app.post("/authorize", async (c) => {
 	}
 });
 
-app.get("/callback", async (c) => {
+app.get(PUBLIC_ROUTES.callback, async (c) => {
 	try {
 		const htmlContent = await handler.handleCallback(
 			c.req.raw,
@@ -300,7 +301,7 @@ app.get("/callback", async (c) => {
 	}
 });
 
-app.post("/store-token", async (c) => {
+app.post(PUBLIC_ROUTES.storeToken, async (c) => {
 	try {
 		const result = await handler.storeToken(c.req.raw, c.env.OAUTH_PROVIDER);
 		return new Response(JSON.stringify(result), {
@@ -329,10 +330,10 @@ app.post("/store-token", async (c) => {
 	}
 });
 
-app.get("/.well-known/openai-apps-challenge", (c) => {
+app.get(PUBLIC_ROUTES.openaiAppsChallenge, (c) => {
 	return c.text(process.env.OPEN_AI_TOKEN);
 });
 
-app.route("/openapi-spec", openApiSpecHandler);
+app.route(PUBLIC_ROUTES.openapiSpec, openApiSpecHandler);
 
 export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { instrumentedMCPServer } from "./cloudflare-utils";
 import { MCPServer } from "./servers/mcp-server";
 import { apiServer } from "./servers/api-server";
 import { withBearerHandler } from "./bearer";
+import { withRequestMetrics } from "./metrics/runtime/request-metrics";
 import { OpenAIDeepResearchMCPServer } from "./servers/openai-mcp-server";
 import { ConversationStorageServer } from "./servers/conversation-storage-server";
 
@@ -118,11 +119,13 @@ export default {
 		env: Env,
 		ctx: ExecutionContext,
 	): Promise<Response> {
-		if (HEADERS_TO_STRIP.some((header) => request.headers.has(header))) {
-			const headers = new Headers(request.headers);
-			HEADERS_TO_STRIP.forEach((header) => headers.delete(header));
-			request = new Request(request, { headers });
-		}
-		return instrumentedOAuthHandler.fetch!(request, env, ctx);
+		return withRequestMetrics(env as unknown as Record<string, unknown>, ctx, async () => {
+			if (HEADERS_TO_STRIP.some((header) => request.headers.has(header))) {
+				const headers = new Headers(request.headers);
+				HEADERS_TO_STRIP.forEach((header) => headers.delete(header));
+				request = new Request(request, { headers });
+			}
+			return instrumentedOAuthHandler.fetch!(request, env, ctx);
+		});
 	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
-import { trace } from "@opentelemetry/api";
+import OAuthProvider from "@cloudflare/workers-oauth-provider";
 import {
-	instrument,
 	type ResolveConfigFn,
 	type TraceConfig,
+	instrument,
 } from "@microlabs/otel-cf-workers";
-import OAuthProvider from "@cloudflare/workers-oauth-provider";
+import { trace } from "@opentelemetry/api";
 
-import handler from "./handlers";
-import { instrumentedMCPServer } from "./cloudflare-utils";
-import { MCPServer } from "./servers/mcp-server";
-import { apiServer } from "./servers/api-server";
 import { withBearerHandler } from "./bearer";
+import { instrumentedMCPServer } from "./cloudflare-utils";
+import handler from "./handlers";
 import { withRequestMetrics } from "./metrics/runtime/request-metrics";
+import { apiServer } from "./servers/api-server";
+import { MCPServer } from "./servers/mcp-server";
 import { OpenAIDeepResearchMCPServer } from "./servers/openai-mcp-server";
 import { ConversationStorageServer } from "./servers/conversation-storage-server";
 
@@ -119,13 +119,18 @@ export default {
 		env: Env,
 		ctx: ExecutionContext,
 	): Promise<Response> {
-		return withRequestMetrics(env as unknown as Record<string, unknown>, ctx, async () => {
-			if (HEADERS_TO_STRIP.some((header) => request.headers.has(header))) {
-				const headers = new Headers(request.headers);
-				HEADERS_TO_STRIP.forEach((header) => headers.delete(header));
-				request = new Request(request, { headers });
-			}
-			return instrumentedOAuthHandler.fetch!(request, env, ctx);
-		});
+		if (HEADERS_TO_STRIP.some((header) => request.headers.has(header))) {
+			const headers = new Headers(request.headers);
+			HEADERS_TO_STRIP.forEach((header) => headers.delete(header));
+			request = new Request(request, { headers });
+		}
+
+		return withRequestMetrics(
+			env as unknown as Record<string, unknown>,
+			ctx,
+			async () => {
+				return instrumentedOAuthHandler.fetch!(request, env, ctx);
+			},
+		);
 	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,11 @@ import { withBearerHandler } from "./bearer";
 import { instrumentedMCPServer } from "./cloudflare-utils";
 import handler from "./handlers";
 import { withRequestMetrics } from "./metrics/runtime/request-metrics";
+import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "./routes";
 import { apiServer } from "./servers/api-server";
+import { ConversationStorageServer } from "./servers/conversation-storage-server";
 import { MCPServer } from "./servers/mcp-server";
 import { OpenAIDeepResearchMCPServer } from "./servers/openai-mcp-server";
-import { ConversationStorageServer } from "./servers/conversation-storage-server";
 
 export { ConversationStorageServer };
 
@@ -70,20 +71,34 @@ function createMCPRouter(
 // Create the OAuth provider instance
 const oauthProvider = new OAuthProvider({
 	apiHandlers: {
-		"/mcp": createMCPRouter("/mcp", ThoughtSpotMCP, "serve") as any,
-		"/sse": createMCPRouter("/sse", ThoughtSpotMCP, "serveSSE") as any,
-		"/openai/mcp": ThoughtSpotOpenAIDeepResearchMCP.serve("/openai/mcp", {
-			binding: "OPENAI_DEEP_RESEARCH_MCP_OBJECT",
-		}) as any, // TODO: Remove 'any'
-		"/openai/sse": ThoughtSpotOpenAIDeepResearchMCP.serveSSE("/openai/sse", {
-			binding: "OPENAI_DEEP_RESEARCH_MCP_OBJECT",
-		}) as any, // TODO: Remove 'any'
-		"/api": apiServer as any, // TODO: Remove 'any'
+		[PUBLIC_ROUTES.mcp]: createMCPRouter(
+			PUBLIC_ROUTES.mcp,
+			ThoughtSpotMCP,
+			"serve",
+		) as any,
+		[PUBLIC_ROUTES.sse]: createMCPRouter(
+			PUBLIC_ROUTES.sse,
+			ThoughtSpotMCP,
+			"serveSSE",
+		) as any,
+		[PUBLIC_ROUTES.openaiMcp]: ThoughtSpotOpenAIDeepResearchMCP.serve(
+			PUBLIC_ROUTES.openaiMcp,
+			{
+				binding: "OPENAI_DEEP_RESEARCH_MCP_OBJECT",
+			},
+		) as any, // TODO: Remove 'any'
+		[PUBLIC_ROUTES.openaiSse]: ThoughtSpotOpenAIDeepResearchMCP.serveSSE(
+			PUBLIC_ROUTES.openaiSse,
+			{
+				binding: "OPENAI_DEEP_RESEARCH_MCP_OBJECT",
+			},
+		) as any, // TODO: Remove 'any'
+		[PUBLIC_ROUTE_PREFIXES.api]: apiServer as any, // TODO: Remove 'any'
 	},
 	defaultHandler: withBearerHandler(handler, ThoughtSpotMCP) as any, // TODO: Remove 'any'
-	authorizeEndpoint: "/authorize",
-	tokenEndpoint: "/token",
-	clientRegistrationEndpoint: "/register",
+	authorizeEndpoint: PUBLIC_ROUTES.authorize,
+	tokenEndpoint: PUBLIC_ROUTES.oauthToken,
+	clientRegistrationEndpoint: PUBLIC_ROUTES.register,
 });
 
 // Wrap the OAuth provider with a handler that includes tracing

--- a/src/metrics/runtime/composite-sink.ts
+++ b/src/metrics/runtime/composite-sink.ts
@@ -1,0 +1,20 @@
+import type { MetricsFlushPayload, MetricsSink } from "./metrics-sink";
+
+export class CompositeMetricsSink implements MetricsSink {
+	constructor(private readonly sinks: readonly MetricsSink[]) {}
+
+	async flush(payload: MetricsFlushPayload): Promise<void> {
+		const results = await Promise.allSettled(
+			this.sinks.map((sink) => sink.flush(payload)),
+		);
+
+		for (const [index, result] of results.entries()) {
+			if (result.status === "rejected") {
+				console.error(
+					`[metrics] Sink at index ${index} failed during flush`,
+					result.reason,
+				);
+			}
+		}
+	}
+}

--- a/src/metrics/runtime/metric-context.ts
+++ b/src/metrics/runtime/metric-context.ts
@@ -1,0 +1,133 @@
+import type {
+	ApiSurface,
+	AuthMode,
+	RouteGroup,
+	StatusClass,
+	Transport,
+} from "./metric-types";
+
+export function getRouteGroup(pathname: string): RouteGroup {
+	switch (pathname) {
+		case "/":
+			return "root";
+		case "/authorize":
+			return "authorize";
+		case "/callback":
+			return "callback";
+		case "/store-token":
+			return "store_token";
+		case "/mcp":
+			return "mcp";
+		case "/sse":
+			return "sse";
+		case "/openai/mcp":
+			return "openai_mcp";
+		case "/openai/sse":
+			return "openai_sse";
+		case "/bearer/mcp":
+			return "bearer_mcp";
+		case "/bearer/sse":
+			return "bearer_sse";
+		case "/token/mcp":
+			return "token_mcp";
+		case "/token/sse":
+			return "token_sse";
+		default:
+			if (pathname.startsWith("/api")) {
+				return "api";
+			}
+			return "unknown";
+	}
+}
+
+export function getTransport(pathname: string): Transport {
+	if (pathname.endsWith("/mcp") || pathname === "/mcp") {
+		return "mcp";
+	}
+	if (pathname.endsWith("/sse") || pathname === "/sse") {
+		return "sse";
+	}
+	return "http";
+}
+
+export function getApiSurface(pathname: string): ApiSurface {
+	if (pathname.startsWith("/openai/")) {
+		return "openai_mcp";
+	}
+	if (pathname.startsWith("/api")) {
+		return "api";
+	}
+	if (
+		pathname === "/mcp" ||
+		pathname === "/sse" ||
+		pathname.startsWith("/bearer/") ||
+		pathname.startsWith("/token/")
+	) {
+		return "mcp";
+	}
+	if (
+		pathname === "/" ||
+		pathname === "/authorize" ||
+		pathname === "/callback" ||
+		pathname === "/store-token"
+	) {
+		return pathname === "/" ? "static" : "oauth";
+	}
+	return "unknown";
+}
+
+export function getAuthMode(pathname: string): AuthMode {
+	if (pathname.startsWith("/bearer/")) {
+		return "bearer";
+	}
+	if (pathname.startsWith("/token/")) {
+		return "token";
+	}
+	if (
+		pathname === "/mcp" ||
+		pathname === "/sse" ||
+		pathname.startsWith("/openai/") ||
+		pathname.startsWith("/api")
+	) {
+		return "oauth";
+	}
+	if (
+		pathname === "/" ||
+		pathname === "/authorize" ||
+		pathname === "/callback" ||
+		pathname === "/store-token"
+	) {
+		return "none";
+	}
+	return "unknown";
+}
+
+export function getStatusClass(status: number): StatusClass {
+	if (status >= 100 && status < 200) {
+		return "1xx";
+	}
+	if (status >= 200 && status < 300) {
+		return "2xx";
+	}
+	if (status >= 300 && status < 400) {
+		return "3xx";
+	}
+	if (status >= 400 && status < 500) {
+		return "4xx";
+	}
+	if (status >= 500 && status < 600) {
+		return "5xx";
+	}
+	return "unknown";
+}
+
+export function resolveRequestMetricContext(request: Request) {
+	const pathname = new URL(request.url).pathname;
+
+	return {
+		routeGroup: getRouteGroup(pathname),
+		transport: getTransport(pathname),
+		apiSurface: getApiSurface(pathname),
+		authMode: getAuthMode(pathname),
+	};
+}

--- a/src/metrics/runtime/metric-context.ts
+++ b/src/metrics/runtime/metric-context.ts
@@ -129,6 +129,13 @@ const API_ROUTE_CONTEXT: RequestMetricContext = {
 	authMode: "oauth",
 };
 
+const OPENAPI_SPEC_ROUTE_CONTEXT: RequestMetricContext = {
+	routeGroup: "openapi_spec",
+	transport: "http",
+	apiSurface: "static",
+	authMode: "none",
+};
+
 const UNKNOWN_ROUTE_CONTEXT: RequestMetricContext = {
 	routeGroup: "unknown",
 	transport: "http",
@@ -177,7 +184,7 @@ function inferApiSurface(pathname: string): ApiSurface {
 		pathname === PUBLIC_ROUTES.root ||
 		pathname === PUBLIC_ROUTES.hello ||
 		pathname === PUBLIC_ROUTES.openaiAppsChallenge ||
-		pathname === PUBLIC_ROUTES.openapiSpec
+		matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.openapiSpec)
 	) {
 		return "static";
 	}
@@ -217,7 +224,7 @@ function inferAuthMode(pathname: string): AuthMode {
 		pathname === PUBLIC_ROUTES.oauthToken ||
 		pathname === PUBLIC_ROUTES.register ||
 		pathname === PUBLIC_ROUTES.openaiAppsChallenge ||
-		pathname === PUBLIC_ROUTES.openapiSpec
+		matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.openapiSpec)
 	) {
 		return "none";
 	}
@@ -234,6 +241,10 @@ export function resolvePathMetricContext(
 
 	if (matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.api)) {
 		return API_ROUTE_CONTEXT;
+	}
+
+	if (matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.openapiSpec)) {
+		return OPENAPI_SPEC_ROUTE_CONTEXT;
 	}
 
 	return {

--- a/src/metrics/runtime/metric-context.ts
+++ b/src/metrics/runtime/metric-context.ts
@@ -1,3 +1,4 @@
+import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "../../routes";
 import type {
 	ApiSurface,
 	AuthMode,
@@ -17,77 +18,107 @@ export type RequestMetricContext = {
 // requires a single metadata update instead of touching multiple helper
 // functions.
 export const EXPLICIT_ROUTE_CONTEXTS = {
-	"/": {
+	[PUBLIC_ROUTES.root]: {
 		routeGroup: "root",
 		transport: "http",
 		apiSurface: "static",
 		authMode: "none",
 	},
-	"/authorize": {
+	[PUBLIC_ROUTES.hello]: {
+		routeGroup: "hello",
+		transport: "http",
+		apiSurface: "static",
+		authMode: "none",
+	},
+	[PUBLIC_ROUTES.authorize]: {
 		routeGroup: "authorize",
 		transport: "http",
 		apiSurface: "oauth",
 		authMode: "none",
 	},
-	"/callback": {
+	[PUBLIC_ROUTES.callback]: {
 		routeGroup: "callback",
 		transport: "http",
 		apiSurface: "oauth",
 		authMode: "none",
 	},
-	"/store-token": {
+	[PUBLIC_ROUTES.storeToken]: {
 		routeGroup: "store_token",
 		transport: "http",
 		apiSurface: "oauth",
 		authMode: "none",
 	},
-	"/mcp": {
+	[PUBLIC_ROUTES.oauthToken]: {
+		routeGroup: "oauth_token",
+		transport: "http",
+		apiSurface: "oauth",
+		authMode: "none",
+	},
+	[PUBLIC_ROUTES.register]: {
+		routeGroup: "register",
+		transport: "http",
+		apiSurface: "oauth",
+		authMode: "none",
+	},
+	[PUBLIC_ROUTES.mcp]: {
 		routeGroup: "mcp",
 		transport: "mcp",
 		apiSurface: "mcp",
 		authMode: "oauth",
 	},
-	"/sse": {
+	[PUBLIC_ROUTES.sse]: {
 		routeGroup: "sse",
 		transport: "sse",
 		apiSurface: "mcp",
 		authMode: "oauth",
 	},
-	"/openai/mcp": {
+	[PUBLIC_ROUTES.openaiMcp]: {
 		routeGroup: "openai_mcp",
 		transport: "mcp",
 		apiSurface: "openai_mcp",
 		authMode: "oauth",
 	},
-	"/openai/sse": {
+	[PUBLIC_ROUTES.openaiSse]: {
 		routeGroup: "openai_sse",
 		transport: "sse",
 		apiSurface: "openai_mcp",
 		authMode: "oauth",
 	},
-	"/bearer/mcp": {
+	[PUBLIC_ROUTES.bearerMcp]: {
 		routeGroup: "bearer_mcp",
 		transport: "mcp",
 		apiSurface: "mcp",
 		authMode: "bearer",
 	},
-	"/bearer/sse": {
+	[PUBLIC_ROUTES.bearerSse]: {
 		routeGroup: "bearer_sse",
 		transport: "sse",
 		apiSurface: "mcp",
 		authMode: "bearer",
 	},
-	"/token/mcp": {
+	[PUBLIC_ROUTES.tokenMcp]: {
 		routeGroup: "token_mcp",
 		transport: "mcp",
 		apiSurface: "mcp",
 		authMode: "token",
 	},
-	"/token/sse": {
+	[PUBLIC_ROUTES.tokenSse]: {
 		routeGroup: "token_sse",
 		transport: "sse",
 		apiSurface: "mcp",
 		authMode: "token",
+	},
+	[PUBLIC_ROUTES.openaiAppsChallenge]: {
+		routeGroup: "openai_apps_challenge",
+		transport: "http",
+		apiSurface: "static",
+		authMode: "none",
+	},
+	[PUBLIC_ROUTES.openapiSpec]: {
+		routeGroup: "openapi_spec",
+		transport: "http",
+		apiSurface: "static",
+		authMode: "none",
 	},
 } as const satisfies Record<string, RequestMetricContext>;
 
@@ -113,38 +144,49 @@ function getExplicitRouteContext(
 	];
 }
 
+function matchesRoutePrefix(pathname: string, prefix: string): boolean {
+	return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
 function inferTransport(pathname: string): Transport {
-	if (pathname.endsWith("/mcp") || pathname === "/mcp") {
+	if (pathname.endsWith(PUBLIC_ROUTES.mcp) || pathname === PUBLIC_ROUTES.mcp) {
 		return "mcp";
 	}
-	if (pathname.endsWith("/sse") || pathname === "/sse") {
+	if (pathname.endsWith(PUBLIC_ROUTES.sse) || pathname === PUBLIC_ROUTES.sse) {
 		return "sse";
 	}
 	return "http";
 }
 
 function inferApiSurface(pathname: string): ApiSurface {
+	if (matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.api)) {
+		return "api";
+	}
 	if (pathname.startsWith("/openai/")) {
 		return "openai_mcp";
 	}
-	if (pathname.startsWith("/api")) {
-		return "api";
-	}
 	if (
-		pathname === "/mcp" ||
-		pathname === "/sse" ||
-		pathname.startsWith("/bearer/") ||
-		pathname.startsWith("/token/")
+		pathname === PUBLIC_ROUTES.mcp ||
+		pathname === PUBLIC_ROUTES.sse ||
+		matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.bearer) ||
+		matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.token)
 	) {
 		return "mcp";
 	}
-	if (pathname === "/") {
+	if (
+		pathname === PUBLIC_ROUTES.root ||
+		pathname === PUBLIC_ROUTES.hello ||
+		pathname === PUBLIC_ROUTES.openaiAppsChallenge ||
+		pathname === PUBLIC_ROUTES.openapiSpec
+	) {
 		return "static";
 	}
 	if (
-		pathname === "/authorize" ||
-		pathname === "/callback" ||
-		pathname === "/store-token"
+		pathname === PUBLIC_ROUTES.authorize ||
+		pathname === PUBLIC_ROUTES.callback ||
+		pathname === PUBLIC_ROUTES.storeToken ||
+		pathname === PUBLIC_ROUTES.oauthToken ||
+		pathname === PUBLIC_ROUTES.register
 	) {
 		return "oauth";
 	}
@@ -152,25 +194,30 @@ function inferApiSurface(pathname: string): ApiSurface {
 }
 
 function inferAuthMode(pathname: string): AuthMode {
-	if (pathname.startsWith("/bearer/")) {
+	if (matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.bearer)) {
 		return "bearer";
 	}
-	if (pathname.startsWith("/token/")) {
+	if (matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.token)) {
 		return "token";
 	}
 	if (
-		pathname === "/mcp" ||
-		pathname === "/sse" ||
+		pathname === PUBLIC_ROUTES.mcp ||
+		pathname === PUBLIC_ROUTES.sse ||
 		pathname.startsWith("/openai/") ||
-		pathname.startsWith("/api")
+		matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.api)
 	) {
 		return "oauth";
 	}
 	if (
-		pathname === "/" ||
-		pathname === "/authorize" ||
-		pathname === "/callback" ||
-		pathname === "/store-token"
+		pathname === PUBLIC_ROUTES.root ||
+		pathname === PUBLIC_ROUTES.hello ||
+		pathname === PUBLIC_ROUTES.authorize ||
+		pathname === PUBLIC_ROUTES.callback ||
+		pathname === PUBLIC_ROUTES.storeToken ||
+		pathname === PUBLIC_ROUTES.oauthToken ||
+		pathname === PUBLIC_ROUTES.register ||
+		pathname === PUBLIC_ROUTES.openaiAppsChallenge ||
+		pathname === PUBLIC_ROUTES.openapiSpec
 	) {
 		return "none";
 	}
@@ -185,7 +232,7 @@ export function resolvePathMetricContext(
 		return explicitContext;
 	}
 
-	if (pathname.startsWith("/api")) {
+	if (matchesRoutePrefix(pathname, PUBLIC_ROUTE_PREFIXES.api)) {
 		return API_ROUTE_CONTEXT;
 	}
 

--- a/src/metrics/runtime/metric-context.ts
+++ b/src/metrics/runtime/metric-context.ts
@@ -6,41 +6,114 @@ import type {
 	Transport,
 } from "./metric-types";
 
-export function getRouteGroup(pathname: string): RouteGroup {
-	switch (pathname) {
-		case "/":
-			return "root";
-		case "/authorize":
-			return "authorize";
-		case "/callback":
-			return "callback";
-		case "/store-token":
-			return "store_token";
-		case "/mcp":
-			return "mcp";
-		case "/sse":
-			return "sse";
-		case "/openai/mcp":
-			return "openai_mcp";
-		case "/openai/sse":
-			return "openai_sse";
-		case "/bearer/mcp":
-			return "bearer_mcp";
-		case "/bearer/sse":
-			return "bearer_sse";
-		case "/token/mcp":
-			return "token_mcp";
-		case "/token/sse":
-			return "token_sse";
-		default:
-			if (pathname.startsWith("/api")) {
-				return "api";
-			}
-			return "unknown";
-	}
+export type RequestMetricContext = {
+	routeGroup: RouteGroup;
+	transport: Transport;
+	apiSurface: ApiSurface;
+	authMode: AuthMode;
+};
+
+// Keep explicit route classifications here so adding a new public path only
+// requires a single metadata update instead of touching multiple helper
+// functions.
+export const EXPLICIT_ROUTE_CONTEXTS = {
+	"/": {
+		routeGroup: "root",
+		transport: "http",
+		apiSurface: "static",
+		authMode: "none",
+	},
+	"/authorize": {
+		routeGroup: "authorize",
+		transport: "http",
+		apiSurface: "oauth",
+		authMode: "none",
+	},
+	"/callback": {
+		routeGroup: "callback",
+		transport: "http",
+		apiSurface: "oauth",
+		authMode: "none",
+	},
+	"/store-token": {
+		routeGroup: "store_token",
+		transport: "http",
+		apiSurface: "oauth",
+		authMode: "none",
+	},
+	"/mcp": {
+		routeGroup: "mcp",
+		transport: "mcp",
+		apiSurface: "mcp",
+		authMode: "oauth",
+	},
+	"/sse": {
+		routeGroup: "sse",
+		transport: "sse",
+		apiSurface: "mcp",
+		authMode: "oauth",
+	},
+	"/openai/mcp": {
+		routeGroup: "openai_mcp",
+		transport: "mcp",
+		apiSurface: "openai_mcp",
+		authMode: "oauth",
+	},
+	"/openai/sse": {
+		routeGroup: "openai_sse",
+		transport: "sse",
+		apiSurface: "openai_mcp",
+		authMode: "oauth",
+	},
+	"/bearer/mcp": {
+		routeGroup: "bearer_mcp",
+		transport: "mcp",
+		apiSurface: "mcp",
+		authMode: "bearer",
+	},
+	"/bearer/sse": {
+		routeGroup: "bearer_sse",
+		transport: "sse",
+		apiSurface: "mcp",
+		authMode: "bearer",
+	},
+	"/token/mcp": {
+		routeGroup: "token_mcp",
+		transport: "mcp",
+		apiSurface: "mcp",
+		authMode: "token",
+	},
+	"/token/sse": {
+		routeGroup: "token_sse",
+		transport: "sse",
+		apiSurface: "mcp",
+		authMode: "token",
+	},
+} as const satisfies Record<string, RequestMetricContext>;
+
+const API_ROUTE_CONTEXT: RequestMetricContext = {
+	routeGroup: "api",
+	transport: "http",
+	apiSurface: "api",
+	authMode: "oauth",
+};
+
+const UNKNOWN_ROUTE_CONTEXT: RequestMetricContext = {
+	routeGroup: "unknown",
+	transport: "http",
+	apiSurface: "unknown",
+	authMode: "unknown",
+};
+
+function getExplicitRouteContext(
+	pathname: string,
+): RequestMetricContext | undefined {
+	return EXPLICIT_ROUTE_CONTEXTS[
+		pathname as keyof typeof EXPLICIT_ROUTE_CONTEXTS
+	];
 }
 
-export function getTransport(pathname: string): Transport {
+function inferTransport(pathname: string): Transport {
 	if (pathname.endsWith("/mcp") || pathname === "/mcp") {
 		return "mcp";
 	}
@@ -50,7 +123,7 @@ export function getTransport(pathname: string): Transport {
 	return "http";
 }
 
-export function getApiSurface(pathname: string): ApiSurface {
+function inferApiSurface(pathname: string): ApiSurface {
 	if (pathname.startsWith("/openai/")) {
 		return "openai_mcp";
 	}
@@ -65,18 +138,20 @@ export function getApiSurface(pathname: string): ApiSurface {
 	) {
 		return "mcp";
 	}
+	if (pathname === "/") {
+		return "static";
+	}
 	if (
-		pathname === "/" ||
 		pathname === "/authorize" ||
 		pathname === "/callback" ||
 		pathname === "/store-token"
 	) {
-		return pathname === "/" ? "static" : "oauth";
+		return "oauth";
 	}
 	return "unknown";
 }
 
-export function getAuthMode(pathname: string): AuthMode {
+function inferAuthMode(pathname: string): AuthMode {
 	if (pathname.startsWith("/bearer/")) {
 		return "bearer";
 	}
@@ -102,6 +177,42 @@ export function getAuthMode(pathname: string): AuthMode {
 	return "unknown";
 }
 
+export function resolvePathMetricContext(
+	pathname: string,
+): RequestMetricContext {
+	const explicitContext = getExplicitRouteContext(pathname);
+	if (explicitContext) {
+		return explicitContext;
+	}
+
+	if (pathname.startsWith("/api")) {
+		return API_ROUTE_CONTEXT;
+	}
+
+	return {
+		...UNKNOWN_ROUTE_CONTEXT,
+		transport: inferTransport(pathname),
+		apiSurface: inferApiSurface(pathname),
+		authMode: inferAuthMode(pathname),
+	};
+}
+
+export function getRouteGroup(pathname: string): RouteGroup {
+	return resolvePathMetricContext(pathname).routeGroup;
+}
+
+export function getTransport(pathname: string): Transport {
+	return resolvePathMetricContext(pathname).transport;
+}
+
+export function getApiSurface(pathname: string): ApiSurface {
+	return resolvePathMetricContext(pathname).apiSurface;
+}
+
+export function getAuthMode(pathname: string): AuthMode {
+	return resolvePathMetricContext(pathname).authMode;
+}
+
 export function getStatusClass(status: number): StatusClass {
 	if (status >= 100 && status < 200) {
 		return "1xx";
@@ -123,11 +234,5 @@ export function getStatusClass(status: number): StatusClass {
 
 export function resolveRequestMetricContext(request: Request) {
 	const pathname = new URL(request.url).pathname;
-
-	return {
-		routeGroup: getRouteGroup(pathname),
-		transport: getTransport(pathname),
-		apiSurface: getApiSurface(pathname),
-		authMode: getAuthMode(pathname),
-	};
+	return resolvePathMetricContext(pathname);
 }

--- a/src/metrics/runtime/metric-types.ts
+++ b/src/metrics/runtime/metric-types.ts
@@ -102,6 +102,8 @@ export const APPROVED_METRIC_LABEL_KEYS = [
 ] as const;
 
 export const FORBIDDEN_METRIC_LABEL_KEYS = [
+	// These are repo-known high-cardinality or sensitive fields that must never
+	// be promoted into metric labels, even if someone tries to pass them.
 	"instanceUrl",
 	"userGUID",
 	"userName",

--- a/src/metrics/runtime/metric-types.ts
+++ b/src/metrics/runtime/metric-types.ts
@@ -1,0 +1,189 @@
+export const HISTOGRAM_BUCKETS_MS = [
+	25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000,
+] as const;
+
+export const METRIC_NAMES = {
+	httpRequestsTotal: "ts_mcp_http_requests_total",
+	httpRequestDurationMs: "ts_mcp_http_request_duration_ms",
+	httpInflightRequests: "ts_mcp_http_inflight_requests",
+	sessionsStartedTotal: "ts_mcp_sessions_started_total",
+	toolCallsTotal: "ts_mcp_tool_calls_total",
+	toolDurationMs: "ts_mcp_tool_duration_ms",
+	resourceReadsTotal: "ts_mcp_resource_reads_total",
+	oauthAuthorizeRequestsTotal: "ts_mcp_oauth_authorize_requests_total",
+	oauthAuthorizeSubmitTotal: "ts_mcp_oauth_authorize_submit_total",
+	oauthCallbackTotal: "ts_mcp_oauth_callback_total",
+	oauthStoreTokenTotal: "ts_mcp_oauth_store_token_total",
+	bearerAuthRequestsTotal: "ts_mcp_bearer_auth_requests_total",
+	upstreamCallsTotal: "ts_mcp_upstream_calls_total",
+	upstreamDurationMs: "ts_mcp_upstream_duration_ms",
+	upstreamStreamsStartedTotal: "ts_mcp_upstream_streams_started_total",
+	upstreamStreamMessagesTotal: "ts_mcp_upstream_stream_messages_total",
+	analysisSessionsCreatedTotal: "ts_mcp_analysis_sessions_created_total",
+	analysisMessagesSentTotal: "ts_mcp_analysis_messages_sent_total",
+	analysisUpdatesPolledTotal: "ts_mcp_analysis_updates_polled_total",
+	analysisPollWaitMs: "ts_mcp_analysis_poll_wait_ms",
+	analysisFirstBufferedUpdateMs: "ts_mcp_analysis_first_buffered_update_ms",
+	analysisFirstPollDelayMs: "ts_mcp_analysis_first_poll_delay_ms",
+	analysisFirstNonEmptyResponseMs:
+		"ts_mcp_analysis_first_non_empty_response_ms",
+	analysisSessionsNeverPolledTotal:
+		"ts_mcp_analysis_sessions_never_polled_total",
+	streamStorageErrorsTotal: "ts_mcp_stream_storage_errors_total",
+	dashboardsCreatedTotal: "ts_mcp_dashboards_created_total",
+	dashboardTilesCount: "ts_mcp_dashboard_tiles_count",
+} as const;
+
+export type MetricName = (typeof METRIC_NAMES)[keyof typeof METRIC_NAMES];
+export type MetricKind = "counter" | "histogram" | "gauge";
+
+const COUNTER_METRIC_NAMES = new Set<MetricName>([
+	METRIC_NAMES.httpRequestsTotal,
+	METRIC_NAMES.sessionsStartedTotal,
+	METRIC_NAMES.toolCallsTotal,
+	METRIC_NAMES.resourceReadsTotal,
+	METRIC_NAMES.oauthAuthorizeRequestsTotal,
+	METRIC_NAMES.oauthAuthorizeSubmitTotal,
+	METRIC_NAMES.oauthCallbackTotal,
+	METRIC_NAMES.oauthStoreTokenTotal,
+	METRIC_NAMES.bearerAuthRequestsTotal,
+	METRIC_NAMES.upstreamCallsTotal,
+	METRIC_NAMES.upstreamStreamsStartedTotal,
+	METRIC_NAMES.upstreamStreamMessagesTotal,
+	METRIC_NAMES.analysisSessionsCreatedTotal,
+	METRIC_NAMES.analysisMessagesSentTotal,
+	METRIC_NAMES.analysisUpdatesPolledTotal,
+	METRIC_NAMES.analysisSessionsNeverPolledTotal,
+	METRIC_NAMES.streamStorageErrorsTotal,
+	METRIC_NAMES.dashboardsCreatedTotal,
+]);
+
+const HISTOGRAM_METRIC_NAMES = new Set<MetricName>([
+	METRIC_NAMES.httpRequestDurationMs,
+	METRIC_NAMES.toolDurationMs,
+	METRIC_NAMES.upstreamDurationMs,
+	METRIC_NAMES.analysisPollWaitMs,
+	METRIC_NAMES.analysisFirstBufferedUpdateMs,
+	METRIC_NAMES.analysisFirstPollDelayMs,
+	METRIC_NAMES.analysisFirstNonEmptyResponseMs,
+	METRIC_NAMES.dashboardTilesCount,
+]);
+
+const GAUGE_METRIC_NAMES = new Set<MetricName>([
+	METRIC_NAMES.httpInflightRequests,
+]);
+
+export function getMetricKind(name: MetricName): MetricKind {
+	if (COUNTER_METRIC_NAMES.has(name)) {
+		return "counter";
+	}
+	if (HISTOGRAM_METRIC_NAMES.has(name)) {
+		return "histogram";
+	}
+	if (GAUGE_METRIC_NAMES.has(name)) {
+		return "gauge";
+	}
+	throw new Error(`Unknown metric kind for metric: ${name}`);
+}
+
+export const APPROVED_METRIC_LABEL_KEYS = [
+	"route_group",
+	"transport",
+	"auth_mode",
+	"api_surface",
+	"api_version",
+	"outcome",
+	"status_class",
+	"tool_name",
+	"upstream_operation",
+	"message_type",
+	"is_done",
+	"operation",
+] as const;
+
+export const FORBIDDEN_METRIC_LABEL_KEYS = [
+	"instanceUrl",
+	"userGUID",
+	"userName",
+	"clientId",
+	"datasourceId",
+	"conversationId",
+	"question",
+	"query",
+	"redirectUrl",
+	"frameUrl",
+	"authorization",
+	"x-ts-host",
+] as const;
+
+const APPROVED_METRIC_LABEL_KEYS_SET = new Set<string>(
+	APPROVED_METRIC_LABEL_KEYS,
+);
+const FORBIDDEN_METRIC_LABEL_KEYS_SET = new Set<string>(
+	FORBIDDEN_METRIC_LABEL_KEYS,
+);
+
+export type MetricLabelKey = (typeof APPROVED_METRIC_LABEL_KEYS)[number];
+export type MetricLabelValue = string | number | boolean;
+export type MetricLabels = Partial<Record<MetricLabelKey, string>>;
+export type MetricLabelInput = Partial<Record<MetricLabelKey, MetricLabelValue>> &
+	Record<string, MetricLabelValue | null | undefined>;
+
+export type MetricOutcome =
+	| "success"
+	| "error"
+	| "client_error"
+	| "upstream_error"
+	| "validation_error";
+
+export type RouteGroup =
+	| "root"
+	| "authorize"
+	| "callback"
+	| "store_token"
+	| "mcp"
+	| "sse"
+	| "openai_mcp"
+	| "openai_sse"
+	| "api"
+	| "bearer_mcp"
+	| "bearer_sse"
+	| "token_mcp"
+	| "token_sse"
+	| "unknown";
+
+export type Transport = "mcp" | "sse" | "http" | "unknown";
+export type AuthMode = "oauth" | "bearer" | "token" | "none" | "unknown";
+export type ApiSurface = "mcp" | "openai_mcp" | "api" | "oauth" | "static" | "unknown";
+export type StatusClass = "1xx" | "2xx" | "3xx" | "4xx" | "5xx" | "unknown";
+
+function warnOnInvalidMetricLabel(key: string, reason: string) {
+	console.warn(`[metrics] Dropping label "${key}": ${reason}`);
+}
+
+export function normalizeMetricLabels(
+	labels?: MetricLabelInput,
+): MetricLabels {
+	if (!labels) {
+		return {};
+	}
+
+	const normalized: MetricLabels = {};
+	for (const key of Object.keys(labels).sort()) {
+		const rawValue = labels[key];
+		if (rawValue === undefined || rawValue === null || rawValue === "") {
+			continue;
+		}
+		if (FORBIDDEN_METRIC_LABEL_KEYS_SET.has(key)) {
+			warnOnInvalidMetricLabel(key, "forbidden by cardinality guardrail");
+			continue;
+		}
+		if (!APPROVED_METRIC_LABEL_KEYS_SET.has(key)) {
+			warnOnInvalidMetricLabel(key, "not in approved label set");
+			continue;
+		}
+		normalized[key as MetricLabelKey] = String(rawValue);
+	}
+
+	return normalized;
+}

--- a/src/metrics/runtime/metric-types.ts
+++ b/src/metrics/runtime/metric-types.ts
@@ -97,6 +97,7 @@ export const APPROVED_METRIC_LABEL_KEYS = [
 	"tool_name",
 	"upstream_operation",
 	"message_type",
+	"is_thinking",
 	"is_done",
 	"operation",
 ] as const;
@@ -128,7 +129,9 @@ const FORBIDDEN_METRIC_LABEL_KEYS_SET = new Set<string>(
 export type MetricLabelKey = (typeof APPROVED_METRIC_LABEL_KEYS)[number];
 export type MetricLabelValue = string | number | boolean;
 export type MetricLabels = Partial<Record<MetricLabelKey, string>>;
-export type MetricLabelInput = Partial<Record<MetricLabelKey, MetricLabelValue>> &
+export type MetricLabelInput = Partial<
+	Record<MetricLabelKey, MetricLabelValue>
+> &
 	Record<string, MetricLabelValue | null | undefined>;
 
 export type MetricOutcome =
@@ -140,13 +143,18 @@ export type MetricOutcome =
 
 export type RouteGroup =
 	| "root"
+	| "hello"
 	| "authorize"
 	| "callback"
 	| "store_token"
+	| "oauth_token"
+	| "register"
 	| "mcp"
 	| "sse"
 	| "openai_mcp"
 	| "openai_sse"
+	| "openai_apps_challenge"
+	| "openapi_spec"
 	| "api"
 	| "bearer_mcp"
 	| "bearer_sse"
@@ -156,16 +164,20 @@ export type RouteGroup =
 
 export type Transport = "mcp" | "sse" | "http" | "unknown";
 export type AuthMode = "oauth" | "bearer" | "token" | "none" | "unknown";
-export type ApiSurface = "mcp" | "openai_mcp" | "api" | "oauth" | "static" | "unknown";
+export type ApiSurface =
+	| "mcp"
+	| "openai_mcp"
+	| "api"
+	| "oauth"
+	| "static"
+	| "unknown";
 export type StatusClass = "1xx" | "2xx" | "3xx" | "4xx" | "5xx" | "unknown";
 
 function warnOnInvalidMetricLabel(key: string, reason: string) {
 	console.warn(`[metrics] Dropping label "${key}": ${reason}`);
 }
 
-export function normalizeMetricLabels(
-	labels?: MetricLabelInput,
-): MetricLabels {
+export function normalizeMetricLabels(labels?: MetricLabelInput): MetricLabels {
 	if (!labels) {
 		return {};
 	}

--- a/src/metrics/runtime/metrics-recorder.ts
+++ b/src/metrics/runtime/metrics-recorder.ts
@@ -1,0 +1,111 @@
+import {
+	getMetricKind,
+	normalizeMetricLabels,
+	type MetricKind,
+	type MetricLabelInput,
+	type MetricName,
+} from "./metric-types";
+import type {
+	MetricObservation,
+	MetricResourceAttributes,
+	MetricsSink,
+} from "./metrics-sink";
+
+type MetricsRecorderOptions = {
+	sink: MetricsSink;
+	resourceAttributes?: MetricResourceAttributes;
+	now?: () => number;
+};
+
+export interface MetricsRecorder {
+	count(name: MetricName, value?: number, labels?: MetricLabelInput): void;
+	histogram(name: MetricName, value: number, labels?: MetricLabelInput): void;
+	gauge(name: MetricName, value: number, labels?: MetricLabelInput): void;
+	flush(ctx?: Pick<ExecutionContext, "waitUntil">): Promise<void>;
+	snapshot(): readonly MetricObservation[];
+}
+
+export class RequestMetricsRecorder implements MetricsRecorder {
+	private readonly observations: MetricObservation[] = [];
+	private flushPromise?: Promise<void>;
+	private flushed = false;
+
+	constructor(private readonly options: MetricsRecorderOptions) {}
+
+	count(name: MetricName, value = 1, labels?: MetricLabelInput): void {
+		this.record("counter", name, value, labels);
+	}
+
+	histogram(name: MetricName, value: number, labels?: MetricLabelInput): void {
+		this.record("histogram", name, value, labels);
+	}
+
+	gauge(name: MetricName, value: number, labels?: MetricLabelInput): void {
+		this.record("gauge", name, value, labels);
+	}
+
+	snapshot(): readonly MetricObservation[] {
+		return [...this.observations];
+	}
+
+	async flush(ctx?: Pick<ExecutionContext, "waitUntil">): Promise<void> {
+		if (!this.flushPromise) {
+			this.flushPromise = this.flushInternal();
+		}
+
+		if (ctx) {
+			ctx.waitUntil(this.flushPromise);
+		}
+
+		return this.flushPromise;
+	}
+
+	private record(
+		expectedKind: MetricKind,
+		name: MetricName,
+		value: number,
+		labels?: MetricLabelInput,
+	): void {
+		if (this.flushed) {
+			console.warn(`[metrics] Ignoring metric recorded after flush: ${name}`);
+			return;
+		}
+		if (!Number.isFinite(value)) {
+			console.warn(`[metrics] Ignoring non-finite metric value for ${name}`);
+			return;
+		}
+
+		const actualKind = getMetricKind(name);
+		if (actualKind !== expectedKind) {
+			console.warn(
+				`[metrics] Ignoring ${expectedKind} write for ${name}; metric is defined as ${actualKind}`,
+			);
+			return;
+		}
+
+		this.observations.push({
+			kind: actualKind,
+			name,
+			value,
+			labels: normalizeMetricLabels(labels),
+			timestampMs: this.options.now?.() ?? Date.now(),
+		});
+	}
+
+	private async flushInternal(): Promise<void> {
+		try {
+			if (this.observations.length === 0) {
+				return;
+			}
+
+			await this.options.sink.flush({
+				observations: this.snapshot(),
+				resourceAttributes: { ...this.options.resourceAttributes },
+			});
+		} catch (error) {
+			console.error("[metrics] Flush failed", error);
+		} finally {
+			this.flushed = true;
+		}
+	}
+}

--- a/src/metrics/runtime/metrics-recorder.ts
+++ b/src/metrics/runtime/metrics-recorder.ts
@@ -93,19 +93,20 @@ export class RequestMetricsRecorder implements MetricsRecorder {
 	}
 
 	private async flushInternal(): Promise<void> {
+		this.flushed = true;
+		const observations = this.snapshot();
+
 		try {
-			if (this.observations.length === 0) {
+			if (observations.length === 0) {
 				return;
 			}
 
 			await this.options.sink.flush({
-				observations: this.snapshot(),
+				observations,
 				resourceAttributes: { ...this.options.resourceAttributes },
 			});
 		} catch (error) {
 			console.error("[metrics] Flush failed", error);
-		} finally {
-			this.flushed = true;
 		}
 	}
 }

--- a/src/metrics/runtime/metrics-sink.ts
+++ b/src/metrics/runtime/metrics-sink.ts
@@ -1,0 +1,30 @@
+import type { MetricKind, MetricLabels, MetricName } from "./metric-types";
+
+export type MetricObservation = {
+	kind: MetricKind;
+	name: MetricName;
+	value: number;
+	labels: MetricLabels;
+	timestampMs: number;
+};
+
+export type MetricResourceAttributes = Partial<
+	Record<
+		| "service.name"
+		| "service.namespace"
+		| "service.version"
+		| "deployment.environment"
+		| "cloud.provider"
+		| "cloud.platform",
+		string
+	>
+>;
+
+export type MetricsFlushPayload = {
+	observations: readonly MetricObservation[];
+	resourceAttributes: MetricResourceAttributes;
+};
+
+export interface MetricsSink {
+	flush(payload: MetricsFlushPayload): Promise<void>;
+}

--- a/src/metrics/runtime/noop-sink.ts
+++ b/src/metrics/runtime/noop-sink.ts
@@ -1,0 +1,5 @@
+import type { MetricsFlushPayload, MetricsSink } from "./metrics-sink";
+
+export class NoopMetricsSink implements MetricsSink {
+	async flush(_payload: MetricsFlushPayload): Promise<void> {}
+}

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -1,0 +1,65 @@
+import { RequestMetricsRecorder, type MetricsRecorder } from "./metrics-recorder";
+import {
+	createConfiguredMetricsSink,
+	resolveMetricsRuntimeConfig,
+	type ConfiguredMetricsSinks,
+	type MetricsEnvLike,
+} from "./runtime-config";
+
+const METRICS_RECORDER_SYMBOL = Symbol.for(
+	"thoughtspot.mcp.metrics.requestRecorder",
+);
+
+type MetricsExecutionContext = ExecutionContext & {
+	[METRICS_RECORDER_SYMBOL]?: MetricsRecorder;
+};
+
+export function setMetricsRecorderOnExecutionContext(
+	ctx: ExecutionContext,
+	recorder: MetricsRecorder,
+): MetricsRecorder {
+	(ctx as MetricsExecutionContext)[METRICS_RECORDER_SYMBOL] = recorder;
+	return recorder;
+}
+
+export function getMetricsRecorderFromExecutionContext(
+	ctx: ExecutionContext,
+): MetricsRecorder | undefined {
+	return (ctx as MetricsExecutionContext)[METRICS_RECORDER_SYMBOL];
+}
+
+export function clearMetricsRecorderFromExecutionContext(
+	ctx: ExecutionContext,
+): void {
+	delete (ctx as MetricsExecutionContext)[METRICS_RECORDER_SYMBOL];
+}
+
+export function createRequestMetricsRecorder(
+	env?: MetricsEnvLike,
+	sinks: ConfiguredMetricsSinks = {},
+): RequestMetricsRecorder {
+	const config = resolveMetricsRuntimeConfig(env);
+	const sink = createConfiguredMetricsSink(config, sinks);
+
+	return new RequestMetricsRecorder({
+		sink,
+		resourceAttributes: config.resourceAttributes,
+	});
+}
+
+export async function withRequestMetrics<T>(
+	env: MetricsEnvLike | undefined,
+	ctx: ExecutionContext,
+	handler: (recorder: MetricsRecorder) => Promise<T>,
+	sinks: ConfiguredMetricsSinks = {},
+): Promise<T> {
+	const recorder = createRequestMetricsRecorder(env, sinks);
+	setMetricsRecorderOnExecutionContext(ctx, recorder);
+
+	try {
+		return await handler(recorder);
+	} finally {
+		await recorder.flush(ctx);
+		clearMetricsRecorderFromExecutionContext(ctx);
+	}
+}

--- a/src/metrics/runtime/runtime-config.ts
+++ b/src/metrics/runtime/runtime-config.ts
@@ -1,0 +1,146 @@
+import { CompositeMetricsSink } from "./composite-sink";
+import { NoopMetricsSink } from "./noop-sink";
+import type { MetricResourceAttributes, MetricsSink } from "./metrics-sink";
+
+export type MetricsSinkMode = "none" | "analytics_engine" | "grafana" | "both";
+export type MetricsDeploymentEnvironment = "production" | "local";
+export type MetricsEnvLike = Partial<Record<string, unknown>>;
+
+export type MetricsRuntimeConfig = {
+	sinkMode: MetricsSinkMode;
+	deploymentEnvironment: MetricsDeploymentEnvironment;
+	resourceAttributes: MetricResourceAttributes;
+};
+
+export type ConfiguredMetricsSinks = {
+	analyticsEngineSink?: MetricsSink;
+	grafanaSink?: MetricsSink;
+};
+
+function getProcessEnvValue(name: string): string | undefined {
+	if (typeof process === "undefined") {
+		return undefined;
+	}
+	return process.env?.[name];
+}
+
+function readConfigValue(
+	env: MetricsEnvLike | undefined,
+	...keys: string[]
+): string | undefined {
+	for (const key of keys) {
+		const envValue = env?.[key];
+		if (typeof envValue === "string" && envValue.length > 0) {
+			return envValue;
+		}
+
+		const processEnvValue = getProcessEnvValue(key);
+		if (processEnvValue && processEnvValue.length > 0) {
+			return processEnvValue;
+		}
+	}
+
+	return undefined;
+}
+
+export function resolveMetricsSinkMode(rawValue?: string): MetricsSinkMode {
+	switch (rawValue?.trim().toLowerCase()) {
+		case "none":
+			return "none";
+		case "analytics-engine":
+		case "analytics_engine":
+		case "analytics":
+			return "analytics_engine";
+		case "grafana":
+			return "grafana";
+		case "both":
+		case undefined:
+			return "both";
+		default:
+			console.warn(
+				`[metrics] Unknown METRICS_SINK_MODE "${rawValue}", defaulting to "both"`,
+			);
+			return "both";
+	}
+}
+
+export function resolveMetricsDeploymentEnvironment(
+	rawValue?: string,
+): MetricsDeploymentEnvironment {
+	switch (rawValue?.trim().toLowerCase()) {
+		case "local":
+			return "local";
+		case "production":
+		case undefined:
+			return "production";
+		default:
+			console.warn(
+				`[metrics] Unknown metrics environment "${rawValue}", defaulting to "production"`,
+			);
+			return "production";
+	}
+}
+
+export function resolveMetricResourceAttributes(
+	deploymentEnvironment: MetricsDeploymentEnvironment,
+	serviceVersion?: string,
+): MetricResourceAttributes {
+	const resourceAttributes: MetricResourceAttributes = {
+		"service.name": "thoughtspot-mcp-server",
+		"service.namespace": "thoughtspot",
+		"deployment.environment": deploymentEnvironment,
+		"cloud.provider": "cloudflare",
+		"cloud.platform": "cloudflare_workers",
+	};
+
+	if (serviceVersion) {
+		resourceAttributes["service.version"] = serviceVersion;
+	}
+
+	return resourceAttributes;
+}
+
+export function resolveMetricsRuntimeConfig(
+	env?: MetricsEnvLike,
+): MetricsRuntimeConfig {
+	const sinkMode = resolveMetricsSinkMode(
+		readConfigValue(env, "METRICS_SINK_MODE"),
+	);
+	const deploymentEnvironment = resolveMetricsDeploymentEnvironment(
+		readConfigValue(
+			env,
+			"METRICS_DEPLOYMENT_ENVIRONMENT",
+			"DEPLOYMENT_ENVIRONMENT",
+		),
+	);
+	const serviceVersion = readConfigValue(env, "SERVICE_VERSION", "npm_package_version");
+
+	return {
+		sinkMode,
+		deploymentEnvironment,
+		resourceAttributes: resolveMetricResourceAttributes(
+			deploymentEnvironment,
+			serviceVersion,
+		),
+	};
+}
+
+export function createConfiguredMetricsSink(
+	config: Pick<MetricsRuntimeConfig, "sinkMode">,
+	sinks: ConfiguredMetricsSinks = {},
+): MetricsSink {
+	switch (config.sinkMode) {
+		case "none":
+			return new NoopMetricsSink();
+		case "analytics_engine":
+			return sinks.analyticsEngineSink ?? new NoopMetricsSink();
+		case "grafana":
+			return sinks.grafanaSink ?? new NoopMetricsSink();
+		case "both":
+		default:
+			return new CompositeMetricsSink([
+				sinks.analyticsEngineSink ?? new NoopMetricsSink(),
+				sinks.grafanaSink ?? new NoopMetricsSink(),
+			]);
+	}
+}

--- a/src/metrics/runtime/runtime-config.ts
+++ b/src/metrics/runtime/runtime-config.ts
@@ -136,7 +136,6 @@ export function createConfiguredMetricsSink(
 			return sinks.analyticsEngineSink ?? new NoopMetricsSink();
 		case "grafana":
 			return sinks.grafanaSink ?? new NoopMetricsSink();
-		case "both":
 		default:
 			return new CompositeMetricsSink([
 				sinks.analyticsEngineSink ?? new NoopMetricsSink(),

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -21,6 +21,7 @@ export const PUBLIC_ROUTES = {
 export const PUBLIC_ROUTE_PREFIXES = {
 	api: "/api",
 	bearer: "/bearer",
+	openapiSpec: PUBLIC_ROUTES.openapiSpec,
 	token: "/token",
 } as const;
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,45 @@
+export const PUBLIC_ROUTES = {
+	root: "/",
+	hello: "/hello",
+	authorize: "/authorize",
+	callback: "/callback",
+	storeToken: "/store-token",
+	oauthToken: "/token",
+	register: "/register",
+	mcp: "/mcp",
+	sse: "/sse",
+	openaiMcp: "/openai/mcp",
+	openaiSse: "/openai/sse",
+	bearerMcp: "/bearer/mcp",
+	bearerSse: "/bearer/sse",
+	tokenMcp: "/token/mcp",
+	tokenSse: "/token/sse",
+	openaiAppsChallenge: "/.well-known/openai-apps-challenge",
+	openapiSpec: "/openapi-spec",
+} as const;
+
+export const PUBLIC_ROUTE_PREFIXES = {
+	api: "/api",
+	bearer: "/bearer",
+	token: "/token",
+} as const;
+
+export const EXACT_PUBLIC_ROUTES_REQUIRING_METRICS = [
+	PUBLIC_ROUTES.root,
+	PUBLIC_ROUTES.hello,
+	PUBLIC_ROUTES.authorize,
+	PUBLIC_ROUTES.callback,
+	PUBLIC_ROUTES.storeToken,
+	PUBLIC_ROUTES.oauthToken,
+	PUBLIC_ROUTES.register,
+	PUBLIC_ROUTES.mcp,
+	PUBLIC_ROUTES.sse,
+	PUBLIC_ROUTES.openaiMcp,
+	PUBLIC_ROUTES.openaiSse,
+	PUBLIC_ROUTES.bearerMcp,
+	PUBLIC_ROUTES.bearerSse,
+	PUBLIC_ROUTES.tokenMcp,
+	PUBLIC_ROUTES.tokenSse,
+	PUBLIC_ROUTES.openaiAppsChallenge,
+	PUBLIC_ROUTES.openapiSpec,
+] as const;

--- a/test/metrics/runtime/metric-context.spec.ts
+++ b/test/metrics/runtime/metric-context.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+	getApiSurface,
+	getAuthMode,
+	getRouteGroup,
+	getStatusClass,
+	getTransport,
+	resolveRequestMetricContext,
+} from "../../../src/metrics/runtime/metric-context";
+
+describe("metric-context", () => {
+	it("maps known request paths to route groups", () => {
+		expect(getRouteGroup("/")).toBe("root");
+		expect(getRouteGroup("/authorize")).toBe("authorize");
+		expect(getRouteGroup("/callback")).toBe("callback");
+		expect(getRouteGroup("/store-token")).toBe("store_token");
+		expect(getRouteGroup("/mcp")).toBe("mcp");
+		expect(getRouteGroup("/sse")).toBe("sse");
+		expect(getRouteGroup("/openai/mcp")).toBe("openai_mcp");
+		expect(getRouteGroup("/openai/sse")).toBe("openai_sse");
+		expect(getRouteGroup("/bearer/mcp")).toBe("bearer_mcp");
+		expect(getRouteGroup("/bearer/sse")).toBe("bearer_sse");
+		expect(getRouteGroup("/token/mcp")).toBe("token_mcp");
+		expect(getRouteGroup("/token/sse")).toBe("token_sse");
+		expect(getRouteGroup("/api/resources/datasources")).toBe("api");
+		expect(getRouteGroup("/not-a-route")).toBe("unknown");
+	});
+
+	it("derives transport from the request path", () => {
+		expect(getTransport("/mcp")).toBe("mcp");
+		expect(getTransport("/bearer/mcp")).toBe("mcp");
+		expect(getTransport("/openai/sse")).toBe("sse");
+		expect(getTransport("/authorize")).toBe("http");
+	});
+
+	it("derives API surface from the request path", () => {
+		expect(getApiSurface("/openai/mcp")).toBe("openai_mcp");
+		expect(getApiSurface("/api/resources/datasources")).toBe("api");
+		expect(getApiSurface("/mcp")).toBe("mcp");
+		expect(getApiSurface("/bearer/sse")).toBe("mcp");
+		expect(getApiSurface("/token/mcp")).toBe("mcp");
+		expect(getApiSurface("/")).toBe("static");
+		expect(getApiSurface("/authorize")).toBe("oauth");
+		expect(getApiSurface("/callback")).toBe("oauth");
+		expect(getApiSurface("/store-token")).toBe("oauth");
+		expect(getApiSurface("/mystery")).toBe("unknown");
+	});
+
+	it("derives auth mode from the request path", () => {
+		expect(getAuthMode("/bearer/mcp")).toBe("bearer");
+		expect(getAuthMode("/token/sse")).toBe("token");
+		expect(getAuthMode("/mcp")).toBe("oauth");
+		expect(getAuthMode("/openai/mcp")).toBe("oauth");
+		expect(getAuthMode("/api/resources/datasources")).toBe("oauth");
+		expect(getAuthMode("/")).toBe("none");
+		expect(getAuthMode("/authorize")).toBe("none");
+		expect(getAuthMode("/callback")).toBe("none");
+		expect(getAuthMode("/store-token")).toBe("none");
+		expect(getAuthMode("/unknown")).toBe("unknown");
+	});
+
+	it("maps response status codes into status classes", () => {
+		expect(getStatusClass(101)).toBe("1xx");
+		expect(getStatusClass(204)).toBe("2xx");
+		expect(getStatusClass(302)).toBe("3xx");
+		expect(getStatusClass(404)).toBe("4xx");
+		expect(getStatusClass(503)).toBe("5xx");
+		expect(getStatusClass(99)).toBe("unknown");
+		expect(getStatusClass(600)).toBe("unknown");
+	});
+
+	it("resolves the full request metric context from a Request", () => {
+		const request = new Request(
+			"https://example.com/bearer/mcp?api-version=2026-04-23",
+		);
+
+		expect(resolveRequestMetricContext(request)).toEqual({
+			routeGroup: "bearer_mcp",
+			transport: "mcp",
+			apiSurface: "mcp",
+			authMode: "bearer",
+		});
+	});
+});

--- a/test/metrics/runtime/metric-context.spec.ts
+++ b/test/metrics/runtime/metric-context.spec.ts
@@ -9,8 +9,20 @@ import {
 	resolvePathMetricContext,
 	resolveRequestMetricContext,
 } from "../../../src/metrics/runtime/metric-context";
+import {
+	EXACT_PUBLIC_ROUTES_REQUIRING_METRICS,
+	PUBLIC_ROUTES,
+	PUBLIC_ROUTE_PREFIXES,
+} from "../../../src/routes";
 
 describe("metric-context", () => {
+	it("requires exact public routes to have explicit metric context entries", () => {
+		for (const pathname of EXACT_PUBLIC_ROUTES_REQUIRING_METRICS) {
+			expect(EXPLICIT_ROUTE_CONTEXTS).toHaveProperty(pathname);
+			expect(resolvePathMetricContext(pathname).routeGroup).not.toBe("unknown");
+		}
+	});
+
 	it("maps explicit request paths through the shared route context table", () => {
 		for (const [pathname, context] of Object.entries(EXPLICIT_ROUTE_CONTEXTS)) {
 			expect(resolvePathMetricContext(pathname)).toEqual(context);
@@ -22,37 +34,43 @@ describe("metric-context", () => {
 	});
 
 	it("maps known grouped request paths to route groups", () => {
-		expect(getRouteGroup("/api/resources/datasources")).toBe("api");
+		expect(
+			getRouteGroup(`${PUBLIC_ROUTE_PREFIXES.api}/resources/datasources`),
+		).toBe("api");
 		expect(getRouteGroup("/not-a-route")).toBe("unknown");
 	});
 
 	it("derives transport from fallback request paths", () => {
 		expect(getTransport("/future/mcp")).toBe("mcp");
 		expect(getTransport("/future/sse")).toBe("sse");
-		expect(getTransport("/authorize")).toBe("http");
+		expect(getTransport(PUBLIC_ROUTES.authorize)).toBe("http");
 	});
 
 	it("derives API surface from fallback request paths", () => {
 		expect(getApiSurface("/openai/future-endpoint")).toBe("openai_mcp");
-		expect(getApiSurface("/api/resources/datasources")).toBe("api");
+		expect(
+			getApiSurface(`${PUBLIC_ROUTE_PREFIXES.api}/resources/datasources`),
+		).toBe("api");
 		expect(getApiSurface("/bearer/future-endpoint")).toBe("mcp");
 		expect(getApiSurface("/token/future-endpoint")).toBe("mcp");
-		expect(getApiSurface("/")).toBe("static");
-		expect(getApiSurface("/authorize")).toBe("oauth");
-		expect(getApiSurface("/callback")).toBe("oauth");
-		expect(getApiSurface("/store-token")).toBe("oauth");
+		expect(getApiSurface(PUBLIC_ROUTES.root)).toBe("static");
+		expect(getApiSurface(PUBLIC_ROUTES.authorize)).toBe("oauth");
+		expect(getApiSurface(PUBLIC_ROUTES.callback)).toBe("oauth");
+		expect(getApiSurface(PUBLIC_ROUTES.storeToken)).toBe("oauth");
 		expect(getApiSurface("/mystery")).toBe("unknown");
 	});
 
 	it("derives auth mode from fallback request paths", () => {
 		expect(getAuthMode("/bearer/future-endpoint")).toBe("bearer");
 		expect(getAuthMode("/token/future-endpoint")).toBe("token");
-		expect(getAuthMode("/openai/mcp")).toBe("oauth");
-		expect(getAuthMode("/api/resources/datasources")).toBe("oauth");
-		expect(getAuthMode("/")).toBe("none");
-		expect(getAuthMode("/authorize")).toBe("none");
-		expect(getAuthMode("/callback")).toBe("none");
-		expect(getAuthMode("/store-token")).toBe("none");
+		expect(getAuthMode(PUBLIC_ROUTES.openaiMcp)).toBe("oauth");
+		expect(
+			getAuthMode(`${PUBLIC_ROUTE_PREFIXES.api}/resources/datasources`),
+		).toBe("oauth");
+		expect(getAuthMode(PUBLIC_ROUTES.root)).toBe("none");
+		expect(getAuthMode(PUBLIC_ROUTES.authorize)).toBe("none");
+		expect(getAuthMode(PUBLIC_ROUTES.callback)).toBe("none");
+		expect(getAuthMode(PUBLIC_ROUTES.storeToken)).toBe("none");
 		expect(getAuthMode("/unknown")).toBe("unknown");
 	});
 
@@ -68,7 +86,7 @@ describe("metric-context", () => {
 
 	it("resolves the full request metric context from a Request", () => {
 		const request = new Request(
-			"https://example.com/bearer/mcp?api-version=2026-04-23",
+			`https://example.com${PUBLIC_ROUTES.bearerMcp}?api-version=2026-04-23`,
 		);
 
 		expect(resolveRequestMetricContext(request)).toEqual({

--- a/test/metrics/runtime/metric-context.spec.ts
+++ b/test/metrics/runtime/metric-context.spec.ts
@@ -1,44 +1,42 @@
 import { describe, expect, it } from "vitest";
 import {
+	EXPLICIT_ROUTE_CONTEXTS,
 	getApiSurface,
 	getAuthMode,
 	getRouteGroup,
 	getStatusClass,
 	getTransport,
+	resolvePathMetricContext,
 	resolveRequestMetricContext,
 } from "../../../src/metrics/runtime/metric-context";
 
 describe("metric-context", () => {
-	it("maps known request paths to route groups", () => {
-		expect(getRouteGroup("/")).toBe("root");
-		expect(getRouteGroup("/authorize")).toBe("authorize");
-		expect(getRouteGroup("/callback")).toBe("callback");
-		expect(getRouteGroup("/store-token")).toBe("store_token");
-		expect(getRouteGroup("/mcp")).toBe("mcp");
-		expect(getRouteGroup("/sse")).toBe("sse");
-		expect(getRouteGroup("/openai/mcp")).toBe("openai_mcp");
-		expect(getRouteGroup("/openai/sse")).toBe("openai_sse");
-		expect(getRouteGroup("/bearer/mcp")).toBe("bearer_mcp");
-		expect(getRouteGroup("/bearer/sse")).toBe("bearer_sse");
-		expect(getRouteGroup("/token/mcp")).toBe("token_mcp");
-		expect(getRouteGroup("/token/sse")).toBe("token_sse");
+	it("maps explicit request paths through the shared route context table", () => {
+		for (const [pathname, context] of Object.entries(EXPLICIT_ROUTE_CONTEXTS)) {
+			expect(resolvePathMetricContext(pathname)).toEqual(context);
+			expect(getRouteGroup(pathname)).toBe(context.routeGroup);
+			expect(getTransport(pathname)).toBe(context.transport);
+			expect(getApiSurface(pathname)).toBe(context.apiSurface);
+			expect(getAuthMode(pathname)).toBe(context.authMode);
+		}
+	});
+
+	it("maps known grouped request paths to route groups", () => {
 		expect(getRouteGroup("/api/resources/datasources")).toBe("api");
 		expect(getRouteGroup("/not-a-route")).toBe("unknown");
 	});
 
-	it("derives transport from the request path", () => {
-		expect(getTransport("/mcp")).toBe("mcp");
-		expect(getTransport("/bearer/mcp")).toBe("mcp");
-		expect(getTransport("/openai/sse")).toBe("sse");
+	it("derives transport from fallback request paths", () => {
+		expect(getTransport("/future/mcp")).toBe("mcp");
+		expect(getTransport("/future/sse")).toBe("sse");
 		expect(getTransport("/authorize")).toBe("http");
 	});
 
-	it("derives API surface from the request path", () => {
-		expect(getApiSurface("/openai/mcp")).toBe("openai_mcp");
+	it("derives API surface from fallback request paths", () => {
+		expect(getApiSurface("/openai/future-endpoint")).toBe("openai_mcp");
 		expect(getApiSurface("/api/resources/datasources")).toBe("api");
-		expect(getApiSurface("/mcp")).toBe("mcp");
-		expect(getApiSurface("/bearer/sse")).toBe("mcp");
-		expect(getApiSurface("/token/mcp")).toBe("mcp");
+		expect(getApiSurface("/bearer/future-endpoint")).toBe("mcp");
+		expect(getApiSurface("/token/future-endpoint")).toBe("mcp");
 		expect(getApiSurface("/")).toBe("static");
 		expect(getApiSurface("/authorize")).toBe("oauth");
 		expect(getApiSurface("/callback")).toBe("oauth");
@@ -46,10 +44,9 @@ describe("metric-context", () => {
 		expect(getApiSurface("/mystery")).toBe("unknown");
 	});
 
-	it("derives auth mode from the request path", () => {
-		expect(getAuthMode("/bearer/mcp")).toBe("bearer");
-		expect(getAuthMode("/token/sse")).toBe("token");
-		expect(getAuthMode("/mcp")).toBe("oauth");
+	it("derives auth mode from fallback request paths", () => {
+		expect(getAuthMode("/bearer/future-endpoint")).toBe("bearer");
+		expect(getAuthMode("/token/future-endpoint")).toBe("token");
 		expect(getAuthMode("/openai/mcp")).toBe("oauth");
 		expect(getAuthMode("/api/resources/datasources")).toBe("oauth");
 		expect(getAuthMode("/")).toBe("none");

--- a/test/metrics/runtime/metric-context.spec.ts
+++ b/test/metrics/runtime/metric-context.spec.ts
@@ -37,6 +37,9 @@ describe("metric-context", () => {
 		expect(
 			getRouteGroup(`${PUBLIC_ROUTE_PREFIXES.api}/resources/datasources`),
 		).toBe("api");
+		expect(
+			getRouteGroup(`${PUBLIC_ROUTE_PREFIXES.openapiSpec}/tools/ping`),
+		).toBe("openapi_spec");
 		expect(getRouteGroup("/not-a-route")).toBe("unknown");
 	});
 
@@ -51,6 +54,9 @@ describe("metric-context", () => {
 		expect(
 			getApiSurface(`${PUBLIC_ROUTE_PREFIXES.api}/resources/datasources`),
 		).toBe("api");
+		expect(
+			getApiSurface(`${PUBLIC_ROUTE_PREFIXES.openapiSpec}/tools/ping`),
+		).toBe("static");
 		expect(getApiSurface("/bearer/future-endpoint")).toBe("mcp");
 		expect(getApiSurface("/token/future-endpoint")).toBe("mcp");
 		expect(getApiSurface(PUBLIC_ROUTES.root)).toBe("static");
@@ -67,6 +73,9 @@ describe("metric-context", () => {
 		expect(
 			getAuthMode(`${PUBLIC_ROUTE_PREFIXES.api}/resources/datasources`),
 		).toBe("oauth");
+		expect(getAuthMode(`${PUBLIC_ROUTE_PREFIXES.openapiSpec}/tools/ping`)).toBe(
+			"none",
+		);
 		expect(getAuthMode(PUBLIC_ROUTES.root)).toBe("none");
 		expect(getAuthMode(PUBLIC_ROUTES.authorize)).toBe("none");
 		expect(getAuthMode(PUBLIC_ROUTES.callback)).toBe("none");

--- a/test/metrics/runtime/metric-types.spec.ts
+++ b/test/metrics/runtime/metric-types.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	METRIC_NAMES,
+	getMetricKind,
+	normalizeMetricLabels,
+} from "../../../src/metrics/runtime/metric-types";
+
+describe("metric-types", () => {
+	it("returns the configured metric kind for known metrics", () => {
+		expect(getMetricKind(METRIC_NAMES.httpRequestsTotal)).toBe("counter");
+		expect(getMetricKind(METRIC_NAMES.httpRequestDurationMs)).toBe("histogram");
+		expect(getMetricKind(METRIC_NAMES.httpInflightRequests)).toBe("gauge");
+	});
+
+	it("normalizes labels and drops forbidden or unknown keys", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+		const labels = normalizeMetricLabels({
+			route_group: "mcp",
+			outcome: "success",
+			instanceUrl: "https://tenant.thoughtspot.cloud",
+			unexpected_key: "value",
+			tool_name: undefined,
+		});
+
+		expect(labels).toEqual({
+			outcome: "success",
+			route_group: "mcp",
+		});
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+});

--- a/test/metrics/runtime/metric-types.spec.ts
+++ b/test/metrics/runtime/metric-types.spec.ts
@@ -13,17 +13,21 @@ describe("metric-types", () => {
 	});
 
 	it("normalizes labels and drops forbidden or unknown keys", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const warnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => undefined);
 
 		const labels = normalizeMetricLabels({
 			route_group: "mcp",
 			outcome: "success",
+			is_thinking: true,
 			instanceUrl: "https://tenant.thoughtspot.cloud",
 			unexpected_key: "value",
 			tool_name: undefined,
 		});
 
 		expect(labels).toEqual({
+			is_thinking: "true",
 			outcome: "success",
 			route_group: "mcp",
 		});

--- a/test/metrics/runtime/metrics-recorder.spec.ts
+++ b/test/metrics/runtime/metrics-recorder.spec.ts
@@ -100,6 +100,42 @@ describe("RequestMetricsRecorder", () => {
 		expect(errorSpy).toHaveBeenCalled();
 	});
 
+	it("rejects new metrics once a flush has started", async () => {
+		let resolveFlush!: () => void;
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const flushSpy = vi.fn().mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveFlush = resolve;
+				}),
+		);
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: flushSpy },
+		});
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		const flushPromise = recorder.flush();
+		recorder.histogram(METRIC_NAMES.httpRequestDurationMs, 25);
+
+		expect(recorder.snapshot()).toHaveLength(1);
+		expect(warnSpy).toHaveBeenCalledWith(
+			`[metrics] Ignoring metric recorded after flush: ${METRIC_NAMES.httpRequestDurationMs}`,
+		);
+
+		resolveFlush();
+		await flushPromise;
+
+		expect(flushSpy).toHaveBeenCalledWith({
+			observations: [
+				expect.objectContaining({
+					name: METRIC_NAMES.httpRequestsTotal,
+					kind: "counter",
+				}),
+			],
+			resourceAttributes: {},
+		});
+	});
+
 	it("ignores metrics recorded after the recorder has been flushed", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 		const flushSpy = vi.fn().mockResolvedValue(undefined);

--- a/test/metrics/runtime/metrics-recorder.spec.ts
+++ b/test/metrics/runtime/metrics-recorder.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
+import { RequestMetricsRecorder } from "../../../src/metrics/runtime/metrics-recorder";
+
+describe("RequestMetricsRecorder", () => {
+	it("records normalized observations and flushes them once", async () => {
+		const flushSpy = vi.fn().mockResolvedValue(undefined);
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: flushSpy },
+			resourceAttributes: { "service.name": "thoughtspot-mcp-server" },
+			now: () => 123,
+		});
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+			route_group: "mcp",
+			instanceUrl: "forbidden",
+		});
+		recorder.histogram(METRIC_NAMES.httpRequestDurationMs, 50, {
+			outcome: "success",
+		});
+		recorder.gauge(METRIC_NAMES.httpInflightRequests, 2, {
+			transport: "mcp",
+		});
+
+		expect(recorder.snapshot()).toEqual([
+			{
+				kind: "counter",
+				name: METRIC_NAMES.httpRequestsTotal,
+				value: 1,
+				labels: { route_group: "mcp" },
+				timestampMs: 123,
+			},
+			{
+				kind: "histogram",
+				name: METRIC_NAMES.httpRequestDurationMs,
+				value: 50,
+				labels: { outcome: "success" },
+				timestampMs: 123,
+			},
+			{
+				kind: "gauge",
+				name: METRIC_NAMES.httpInflightRequests,
+				value: 2,
+				labels: { transport: "mcp" },
+				timestampMs: 123,
+			},
+		]);
+
+		await recorder.flush();
+		await recorder.flush();
+
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(flushSpy).toHaveBeenCalledTimes(1);
+		expect(flushSpy).toHaveBeenCalledWith({
+			observations: recorder.snapshot(),
+			resourceAttributes: { "service.name": "thoughtspot-mcp-server" },
+		});
+	});
+
+	it("schedules the flush with waitUntil when an execution context is provided", async () => {
+		const flushSpy = vi.fn().mockResolvedValue(undefined);
+		const waitUntil = vi.fn();
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: flushSpy },
+		});
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		const flushPromise = recorder.flush({ waitUntil } as ExecutionContext);
+
+		expect(waitUntil).toHaveBeenCalledTimes(1);
+		expect(waitUntil).toHaveBeenCalledWith(flushPromise);
+		await flushPromise;
+		expect(flushSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not emit observations for the wrong metric kind", () => {
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: vi.fn().mockResolvedValue(undefined) },
+		});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+		recorder.histogram(METRIC_NAMES.httpRequestsTotal, 10);
+
+		expect(recorder.snapshot()).toEqual([]);
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it("swallows sink flush failures", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const recorder = new RequestMetricsRecorder({
+			sink: {
+				flush: vi.fn().mockRejectedValue(new Error("flush failed")),
+			},
+		});
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+
+		await expect(recorder.flush()).resolves.toBeUndefined();
+		expect(errorSpy).toHaveBeenCalled();
+	});
+
+	it("ignores metrics recorded after the recorder has been flushed", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const flushSpy = vi.fn().mockResolvedValue(undefined);
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: flushSpy },
+		});
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		await recorder.flush();
+		recorder.count(METRIC_NAMES.httpRequestsTotal, 5);
+
+		expect(flushSpy).toHaveBeenCalledTimes(1);
+		expect(recorder.snapshot()).toHaveLength(1);
+		expect(warnSpy).toHaveBeenCalledWith(
+			`[metrics] Ignoring metric recorded after flush: ${METRIC_NAMES.httpRequestsTotal}`,
+		);
+	});
+
+	it("ignores non-finite metric values", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: vi.fn().mockResolvedValue(undefined) },
+		});
+
+		recorder.histogram(METRIC_NAMES.httpRequestDurationMs, Number.NaN);
+		recorder.gauge(METRIC_NAMES.httpInflightRequests, Number.POSITIVE_INFINITY);
+
+		expect(recorder.snapshot()).toEqual([]);
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not flush empty observations but still closes the recorder", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const flushSpy = vi.fn().mockResolvedValue(undefined);
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: flushSpy },
+		});
+
+		await recorder.flush();
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+
+		expect(flushSpy).not.toHaveBeenCalled();
+		expect(recorder.snapshot()).toEqual([]);
+		expect(warnSpy).toHaveBeenCalledWith(
+			`[metrics] Ignoring metric recorded after flush: ${METRIC_NAMES.httpRequestsTotal}`,
+		);
+	});
+});

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
+import {
+	clearMetricsRecorderFromExecutionContext,
+	createRequestMetricsRecorder,
+	getMetricsRecorderFromExecutionContext,
+	setMetricsRecorderOnExecutionContext,
+	withRequestMetrics,
+} from "../../../src/metrics/runtime/request-metrics";
+
+describe("withRequestMetrics", () => {
+	it("exposes a request-scoped recorder during handler execution and clears it afterwards", async () => {
+		const waitUntil = vi.fn();
+		const analyticsEngineSink = { flush: vi.fn().mockResolvedValue(undefined) };
+		const ctx = { waitUntil } as ExecutionContext;
+
+		await withRequestMetrics(
+			{ METRICS_SINK_MODE: "analytics_engine" },
+			ctx,
+			async (recorder) => {
+				expect(getMetricsRecorderFromExecutionContext(ctx)).toBe(recorder);
+				recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+					route_group: "mcp",
+				});
+			},
+			{ analyticsEngineSink },
+		);
+
+		expect(getMetricsRecorderFromExecutionContext(ctx)).toBeUndefined();
+		expect(waitUntil).toHaveBeenCalledTimes(1);
+		expect(analyticsEngineSink.flush).toHaveBeenCalledTimes(1);
+	});
+
+	it("flushes and clears the request-scoped recorder when the handler throws", async () => {
+		const waitUntil = vi.fn();
+		const analyticsEngineSink = { flush: vi.fn().mockResolvedValue(undefined) };
+		const ctx = { waitUntil } as ExecutionContext;
+
+		await expect(
+			withRequestMetrics(
+				{ METRICS_SINK_MODE: "analytics_engine" },
+				ctx,
+				async (recorder) => {
+					recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+						route_group: "mcp",
+					});
+					throw new Error("boom");
+				},
+				{ analyticsEngineSink },
+			),
+		).rejects.toThrow("boom");
+
+		expect(getMetricsRecorderFromExecutionContext(ctx)).toBeUndefined();
+		expect(waitUntil).toHaveBeenCalledTimes(1);
+		expect(analyticsEngineSink.flush).toHaveBeenCalledTimes(1);
+	});
+
+	it("creates a recorder with resolved resource attributes", async () => {
+		const grafanaSink = { flush: vi.fn().mockResolvedValue(undefined) };
+		const recorder = createRequestMetricsRecorder(
+			{
+				METRICS_SINK_MODE: "grafana",
+				METRICS_DEPLOYMENT_ENVIRONMENT: "local",
+				SERVICE_VERSION: "1.2.3",
+			},
+			{ grafanaSink },
+		);
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		await recorder.flush();
+
+		expect(grafanaSink.flush).toHaveBeenCalledWith(
+			expect.objectContaining({
+				resourceAttributes: expect.objectContaining({
+					"deployment.environment": "local",
+					"service.version": "1.2.3",
+				}),
+			}),
+		);
+	});
+
+	it("supports setting and clearing the recorder on the execution context", () => {
+		const ctx = {} as ExecutionContext;
+		const recorder = createRequestMetricsRecorder();
+
+		expect(setMetricsRecorderOnExecutionContext(ctx, recorder)).toBe(recorder);
+		expect(getMetricsRecorderFromExecutionContext(ctx)).toBe(recorder);
+
+		clearMetricsRecorderFromExecutionContext(ctx);
+
+		expect(getMetricsRecorderFromExecutionContext(ctx)).toBeUndefined();
+	});
+});

--- a/test/metrics/runtime/runtime-config.spec.ts
+++ b/test/metrics/runtime/runtime-config.spec.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CompositeMetricsSink } from "../../../src/metrics/runtime/composite-sink";
+import { NoopMetricsSink } from "../../../src/metrics/runtime/noop-sink";
+import {
+	createConfiguredMetricsSink,
+	resolveMetricResourceAttributes,
+	resolveMetricsDeploymentEnvironment,
+	resolveMetricsRuntimeConfig,
+	resolveMetricsSinkMode,
+} from "../../../src/metrics/runtime/runtime-config";
+
+describe("runtime-config", () => {
+	const baseEnv = { ...process.env };
+
+	afterEach(() => {
+		vi.stubGlobal("process", { env: { ...baseEnv } });
+		vi.restoreAllMocks();
+	});
+
+	it("defaults to both sinks and production attributes", () => {
+		const config = resolveMetricsRuntimeConfig();
+
+		expect(config.sinkMode).toBe("both");
+		expect(config.deploymentEnvironment).toBe("production");
+		expect(config.resourceAttributes["service.name"]).toBe(
+			"thoughtspot-mcp-server",
+		);
+		expect(config.resourceAttributes["deployment.environment"]).toBe(
+			"production",
+		);
+	});
+
+	it("parses supported sink mode aliases", () => {
+		expect(resolveMetricsSinkMode("analytics-engine")).toBe("analytics_engine");
+		expect(resolveMetricsSinkMode("analytics")).toBe("analytics_engine");
+		expect(resolveMetricsSinkMode("grafana")).toBe("grafana");
+		expect(resolveMetricsSinkMode("none")).toBe("none");
+		expect(resolveMetricsSinkMode(" both ")).toBe("both");
+	});
+
+	it("warns and defaults for unknown sink mode and deployment environment", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+		expect(resolveMetricsSinkMode("mystery")).toBe("both");
+		expect(resolveMetricsDeploymentEnvironment("qa")).toBe("production");
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("resolves runtime config from explicit env values", () => {
+		const config = resolveMetricsRuntimeConfig({
+			METRICS_SINK_MODE: "analytics",
+			METRICS_DEPLOYMENT_ENVIRONMENT: "local",
+			SERVICE_VERSION: "1.2.3",
+		});
+
+		expect(config.sinkMode).toBe("analytics_engine");
+		expect(config.deploymentEnvironment).toBe("local");
+		expect(config.resourceAttributes).toMatchObject({
+			"deployment.environment": "local",
+			"service.version": "1.2.3",
+		});
+	});
+
+	it("falls back to alternate env key names", () => {
+		const config = resolveMetricsRuntimeConfig({
+			METRICS_SINK_MODE: "grafana",
+			DEPLOYMENT_ENVIRONMENT: "local",
+			npm_package_version: "9.9.9",
+		});
+
+		expect(config.sinkMode).toBe("grafana");
+		expect(config.deploymentEnvironment).toBe("local");
+		expect(config.resourceAttributes["service.version"]).toBe("9.9.9");
+	});
+
+	it("includes service.version only when provided", () => {
+		expect(resolveMetricResourceAttributes("production")).not.toHaveProperty(
+			"service.version",
+		);
+		expect(
+			resolveMetricResourceAttributes("local", "2026.04.23")["service.version"],
+		).toBe("2026.04.23");
+	});
+
+	it("creates noop sinks for none and missing single-sink modes", async () => {
+		const noneSink = createConfiguredMetricsSink({ sinkMode: "none" });
+		const analyticsSink = createConfiguredMetricsSink({
+			sinkMode: "analytics_engine",
+		});
+		const grafanaSink = createConfiguredMetricsSink({ sinkMode: "grafana" });
+
+		expect(noneSink).toBeInstanceOf(NoopMetricsSink);
+		expect(analyticsSink).toBeInstanceOf(NoopMetricsSink);
+		expect(grafanaSink).toBeInstanceOf(NoopMetricsSink);
+		await expect(
+			noneSink.flush({ observations: [], resourceAttributes: {} }),
+		).resolves.toBeUndefined();
+	});
+
+	it("returns the provided single sink when configured", () => {
+		const analyticsEngineSink = { flush: vi.fn() };
+		const grafanaSink = { flush: vi.fn() };
+
+		expect(
+			createConfiguredMetricsSink(
+				{ sinkMode: "analytics_engine" },
+				{ analyticsEngineSink },
+			),
+		).toBe(analyticsEngineSink);
+		expect(
+			createConfiguredMetricsSink({ sinkMode: "grafana" }, { grafanaSink }),
+		).toBe(grafanaSink);
+	});
+
+	it("creates a composite sink for both mode and tolerates missing sinks", async () => {
+		const analyticsEngineSink = { flush: vi.fn() };
+		const sink = createConfiguredMetricsSink(
+			{ sinkMode: "both" },
+			{ analyticsEngineSink },
+		);
+
+		await expect(
+			sink.flush({ observations: [], resourceAttributes: {} }),
+		).resolves.toBeUndefined();
+
+		expect(sink).toBeInstanceOf(CompositeMetricsSink);
+		expect(analyticsEngineSink.flush).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/metrics/runtime/sinks.spec.ts
+++ b/test/metrics/runtime/sinks.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { CompositeMetricsSink } from "../../../src/metrics/runtime/composite-sink";
+import { NoopMetricsSink } from "../../../src/metrics/runtime/noop-sink";
+
+describe("runtime sinks", () => {
+	it("flushes every sink in the composite", async () => {
+		const payload = { observations: [], resourceAttributes: {} };
+		const firstSink = { flush: vi.fn().mockResolvedValue(undefined) };
+		const secondSink = { flush: vi.fn().mockResolvedValue(undefined) };
+		const sink = new CompositeMetricsSink([firstSink, secondSink]);
+
+		await expect(sink.flush(payload)).resolves.toBeUndefined();
+
+		expect(firstSink.flush).toHaveBeenCalledWith(payload);
+		expect(secondSink.flush).toHaveBeenCalledWith(payload);
+	});
+
+	it("logs rejected sinks but still resolves the composite flush", async () => {
+		const payload = { observations: [], resourceAttributes: {} };
+		const failure = new Error("grafana unavailable");
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const sink = new CompositeMetricsSink([
+			{ flush: vi.fn().mockRejectedValue(failure) },
+			{ flush: vi.fn().mockResolvedValue(undefined) },
+		]);
+
+		await expect(sink.flush(payload)).resolves.toBeUndefined();
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			"[metrics] Sink at index 0 failed during flush",
+			failure,
+		);
+	});
+
+	it("treats the noop sink as a successful no-op", async () => {
+		const sink = new NoopMetricsSink();
+
+		await expect(
+			sink.flush({ observations: [], resourceAttributes: {} }),
+		).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Introduce the request-scoped metrics runtime core for the Worker and add focused tests so the new runtime metrics files do not regress repo coverage.

## What Changed

- add metric definitions, label normalization, and runtime config for sink selection
- add the request-scoped recorder, sink interfaces, composite/noop sinks, and context helpers
- wrap the Worker fetch entrypoint so every request gets a recorder and non-blocking flush behavior
- add targeted tests for metric context, sink behavior, recorder branches, runtime config, and request-scoped recorder helpers

## Notes

- this PR only adds the runtime core, request wrapper plumbing, and tests
- external Analytics Engine and Grafana emission lands in follow-up PRs