### PR TITLE
Add pre-commit lint hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# thoughtspot-mcp-server-hook
+
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+cd "$REPO_ROOT"
+
+echo "Running staged Biome lint checks..."
+npm run lint:staged --silent

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,5 +7,6 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "$REPO_ROOT"
 
-echo "Running staged Biome lint checks..."
-npm run lint:staged --silent
+echo "Running staged Biome checks..."
+npm run check:staged --silent
+git update-index --again

--- a/package.json
+++ b/package.json
@@ -15,12 +15,15 @@
     "deploy": "wrangler deploy",
     "format": "biome format --write",
     "lint": "biome lint",
+    "lint:staged": "biome lint --staged --no-errors-on-unmatched",
     "lint:fix": "biome lint --write",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "bin": "node --import tsx ./src/stdio.ts",
-    "run:deploy": "tsx deploy/index.ts"
+    "run:deploy": "tsx deploy/index.ts",
+    "hooks:install": "node ./scripts/install-git-hooks.mjs",
+    "prepare": "node ./scripts/install-git-hooks.mjs"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "deploy": "wrangler deploy",
     "format": "biome format --write",
     "lint": "biome lint",
+    "check:staged": "biome check --write --staged --no-errors-on-unmatched",
     "lint:staged": "biome lint --staged --no-errors-on-unmatched",
     "lint:fix": "biome lint --write",
     "test": "vitest run",

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -1,0 +1,51 @@
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HOOK_MARKER = "# thoughtspot-mcp-server-hook";
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const hookSourcePath = join(repoRoot, ".githooks", "pre-commit");
+
+function getHooksDirectory() {
+	const result = spawnSync("git", ["rev-parse", "--git-path", "hooks"], {
+		cwd: repoRoot,
+		encoding: "utf8",
+	});
+
+	if (result.status !== 0) {
+		console.warn("[hooks] Skipping install because this is not a git checkout.");
+		return null;
+	}
+
+	return resolve(repoRoot, result.stdout.trim());
+}
+
+function isRepoManagedHook(hookPath) {
+	if (!existsSync(hookPath)) {
+		return true;
+	}
+
+	return readFileSync(hookPath, "utf8").includes(HOOK_MARKER);
+}
+
+const hooksDirectory = getHooksDirectory();
+
+if (!hooksDirectory || !existsSync(hookSourcePath)) {
+	process.exit(0);
+}
+
+const hookTargetPath = join(hooksDirectory, "pre-commit");
+
+if (!isRepoManagedHook(hookTargetPath)) {
+	console.warn(
+		`[hooks] Skipping install because ${hookTargetPath} is already managed locally.`,
+	);
+	process.exit(0);
+}
+
+mkdirSync(hooksDirectory, { recursive: true });
+copyFileSync(hookSourcePath, hookTargetPath);
+chmodSync(hookTargetPath, 0o755);
+
+console.log(`[hooks] Installed pre-commit hook at ${hookTargetPath}`);

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 const HOOK_MARKER = "# thoughtspot-mcp-server-hook";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const hookSourcePath = join(repoRoot, ".githooks", "pre-commit");
+const hookSourcePath = resolve(repoRoot, ".githooks", "pre-commit");
 
 function getHooksDirectory() {
 	const result = spawnSync("git", ["rev-parse", "--git-path", "hooks"], {
@@ -22,11 +22,23 @@ function getHooksDirectory() {
 }
 
 function isRepoManagedHook(hookPath) {
-	if (!existsSync(hookPath)) {
-		return true;
-	}
+	try {
+		if (!existsSync(hookPath)) {
+			return true;
+		}
 
-	return readFileSync(hookPath, "utf8").includes(HOOK_MARKER);
+		return readFileSync(hookPath, "utf8").includes(HOOK_MARKER);
+	} catch {
+		console.warn(
+			`[hooks] Skipping install because ${hookPath} could not be inspected safely.`,
+		);
+		return false;
+	}
+}
+
+if (process.env.CI) {
+	console.log("[hooks] Skipping install in CI.");
+	process.exit(0);
 }
 
 const hooksDirectory = getHooksDirectory();
@@ -35,7 +47,12 @@ if (!hooksDirectory || !existsSync(hookSourcePath)) {
 	process.exit(0);
 }
 
-const hookTargetPath = join(hooksDirectory, "pre-commit");
+const hookTargetPath = resolve(hooksDirectory, "pre-commit");
+
+if (hookSourcePath === hookTargetPath) {
+	console.log("[hooks] Skipping install because git already uses the shared hook path.");
+	process.exit(0);
+}
 
 if (!isRepoManagedHook(hookTargetPath)) {
 	console.warn(


### PR DESCRIPTION
## Summary

Add a repo-managed pre-commit hook that runs Biome lint checks on staged files before commits.

## What Changed

- add a `lint:staged` script that runs Biome against staged files only
- add a tracked `.githooks/pre-commit` template for local commits
- add a small installer and wire it into `prepare` so the hook is installed on `npm ci` and `npm install`
- avoid overwriting unrelated local pre-commit hooks by requiring the repo marker before reinstalling