### PR TITLE
Add conversation storage server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ import { MCPServer } from "./servers/mcp-server";
 import { apiServer } from "./servers/api-server";
 import { withBearerHandler } from "./bearer";
 import { OpenAIDeepResearchMCPServer } from "./servers/openai-mcp-server";
+import { ConversationStorageServer } from "./servers/conversation-storage-server";
+
+export { ConversationStorageServer };
 
 // OTEL configuration function
 const config: ResolveConfigFn = (env: Env, _trigger) => {
@@ -63,6 +66,21 @@ function createMCPRouter(
 	};
 }
 
+const conversationStorageHandler = {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+		// Path format: /storage/<conversation-id>[/<operation>]
+		const parts = url.pathname.split("/");
+		const conversationId = parts[2];
+		if (!conversationId) {
+			return new Response("Missing conversation ID", { status: 400 });
+		}
+		const id = env.CONVERSATION_STORAGE_OBJECT.idFromName(conversationId);
+		const stub = env.CONVERSATION_STORAGE_OBJECT.get(id);
+		return stub.fetch(request);
+	},
+};
+
 // Create the OAuth provider instance
 const oauthProvider = new OAuthProvider({
 	apiHandlers: {
@@ -75,6 +93,7 @@ const oauthProvider = new OAuthProvider({
 			binding: "OPENAI_DEEP_RESEARCH_MCP_OBJECT",
 		}) as any, // TODO: Remove 'any'
 		"/api": apiServer as any, // TODO: Remove 'any'
+		"/storage": conversationStorageHandler as any, // TODO: Remove 'any'
 	},
 	defaultHandler: withBearerHandler(handler, ThoughtSpotMCP) as any, // TODO: Remove 'any'
 	authorizeEndpoint: "/authorize",

--- a/src/servers/conversation-storage-server.ts
+++ b/src/servers/conversation-storage-server.ts
@@ -1,0 +1,129 @@
+import type { Message, StreamingMessagesState } from "../thoughtspot/types";
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+const STATE_KEY = "streaming-messages-state";
+const BOOKMARK_KEY = "streaming-messages-bookmark";
+
+/**
+ * A Durable Object that stores streaming conversation messages and exposes them over HTTP.
+ *
+ * Each instance corresponds to a single conversation. This means we don't need to use the
+ * conversationId internally, instead it is used to route to a unique instance per conversation.
+ * The parent DurableObject routes requests here via /storage/<conversation-id>, and this DO
+ * handles the following sub-routes:
+ *
+ *   POST  /storage/<conversation-id>/initialize —> initializeConversation
+ *   POST  /storage/<conversation-id>/append     —> appendMessagesAndRestartTtl
+ *   GET   /storage/<conversation-id>/messages   —> getNewMessagesAndUpdateBookmark
+ */
+export class ConversationStorageServer {
+	constructor(
+		private state: DurableObjectState,
+		private env: Env,
+	) {}
+
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		// Strip the /storage/<conversation-id> prefix; remaining path is the operation
+		// e.g. /storage/abc123/initialize -> /initialize
+		const parts = url.pathname.split("/");
+		// parts: ["", "storage", "<conversationId>", "<operation>"]
+		const operation = parts[3] ?? "";
+
+		try {
+			switch (`${request.method} /${operation}`) {
+				case "POST /initialize": {
+					await this.initializeConversation();
+					return Response.json({ ok: true });
+				}
+
+				case "POST /append": {
+					const body = (await request.json()) as StreamingMessagesState;
+					await this.appendMessagesAndRestartTtl(body.messages, body.isDone);
+					return Response.json({ ok: true });
+				}
+
+				case "GET /messages": {
+					const state = await this.getNewMessagesAndUpdateBookmark();
+					return Response.json(state);
+				}
+
+				default:
+					return new Response("Not Found", { status: 404 });
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.error("Error handling conversation storage request:", message);
+			return Response.json({ error: "Something went wrong" }, { status: 500 });
+		}
+	}
+
+	/*
+	 * Initialize the conversation. This can be a brand new conversation, or it can be priming an
+	 * existing conversation which is already marked done for a followup message.
+	 */
+	private async initializeConversation(): Promise<void> {
+		const existing =
+			await this.state.storage.get<StreamingMessagesState>(STATE_KEY);
+		if (existing && !existing.isDone) {
+			throw new Error("Conversation already exists and is not marked done");
+		}
+
+		await this.setStateAndRestartTtl({ messages: [], isDone: false });
+		await this.state.storage.put<number>(BOOKMARK_KEY, 0);
+	}
+
+	private async appendMessagesAndRestartTtl(
+		newMessages: Message[],
+		isDone = false,
+	): Promise<void> {
+		const oldState =
+			await this.state.storage.get<StreamingMessagesState>(STATE_KEY);
+		if (!oldState) {
+			throw new Error("Conversation not found");
+		}
+		if (oldState.isDone) {
+			throw new Error("Cannot append messages to a conversation marked done");
+		}
+
+		await this.setStateAndRestartTtl({
+			messages: [...oldState.messages, ...newMessages],
+			isDone,
+		});
+	}
+
+	private async getNewMessagesAndUpdateBookmark(): Promise<StreamingMessagesState> {
+		const bookmark = (await this.state.storage.get<number>(BOOKMARK_KEY)) ?? 0;
+
+		const conversationState =
+			await this.state.storage.get<StreamingMessagesState>(STATE_KEY);
+		if (!conversationState) {
+			throw new Error("Conversation not found");
+		}
+
+		await this.state.storage.put<number>(
+			BOOKMARK_KEY,
+			conversationState.messages.length,
+		);
+
+		return {
+			messages: conversationState.messages.slice(bookmark),
+			isDone: conversationState.isDone,
+		};
+	}
+
+	private async setStateAndRestartTtl(
+		newState: StreamingMessagesState,
+	): Promise<void> {
+		// Cancel any existing alarm and schedule a fresh one
+		await this.state.storage.deleteAlarm();
+		await this.state.storage.setAlarm(Date.now() + DEFAULT_TTL_MS);
+
+		await this.state.storage.put<StreamingMessagesState>(STATE_KEY, newState);
+	}
+
+	async alarm(): Promise<void> {
+		await this.state.storage.delete([STATE_KEY, BOOKMARK_KEY]);
+	}
+}

--- a/test/servers/conversation-storage-server.spec.ts
+++ b/test/servers/conversation-storage-server.spec.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ConversationStorageServer } from "../../src/servers/conversation-storage-server";
+import type {
+	Message,
+	StreamingMessagesState,
+} from "../../src/thoughtspot/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockStorage() {
+	const store = new Map<string, unknown>();
+	let alarm: number | null = null;
+
+	return {
+		store,
+		get alarm() {
+			return alarm;
+		},
+		storage: {
+			get: vi.fn(async <T>(key: string): Promise<T | undefined> => {
+				return store.get(key) as T | undefined;
+			}),
+			put: vi.fn(async (key: string, value: unknown): Promise<void> => {
+				store.set(key, value);
+			}),
+			delete: vi.fn(async (keys: string[]): Promise<void> => {
+				for (const key of keys) {
+					store.delete(key);
+				}
+			}),
+			setAlarm: vi.fn(async (scheduledTime: number): Promise<void> => {
+				alarm = scheduledTime;
+			}),
+			deleteAlarm: vi.fn(async (): Promise<void> => {
+				alarm = null;
+			}),
+		},
+	};
+}
+
+function createServer(mock: ReturnType<typeof createMockStorage>) {
+	const state = { storage: mock.storage } as unknown as DurableObjectState;
+	return new ConversationStorageServer(state, {} as Env);
+}
+
+function makeRequest(
+	method: string,
+	operation: string,
+	body?: unknown,
+): Request {
+	const url = `https://example.com/storage/conv-1/${operation}`;
+	return new Request(url, {
+		method,
+		headers: body ? { "Content-Type": "application/json" } : {},
+		body: body ? JSON.stringify(body) : undefined,
+	});
+}
+
+// Sample messages
+const textMessage: Message = { type: "text", text: "Hello" };
+const chunkMessage: Message = { type: "text_chunk", text: " world" };
+const answerMessage: Message = {
+	type: "answer",
+	answer_id: "ans-1",
+	answer_title: "My Answer",
+	answer_query: "SELECT 1",
+	iframe_url: "https://example.com/answer/1",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ConversationStorageServer", () => {
+	let mock: ReturnType<typeof createMockStorage>;
+	let server: ConversationStorageServer;
+
+	beforeEach(() => {
+		mock = createMockStorage();
+		server = createServer(mock);
+	});
+
+	// -------------------------------------------------------------------------
+	// Routing
+	// -------------------------------------------------------------------------
+
+	describe("routing", () => {
+		it("returns 404 for an unknown route", async () => {
+			const res = await server.fetch(makeRequest("GET", "unknown"));
+			expect(res.status).toBe(404);
+		});
+
+		it("returns 404 for a valid operation with the wrong HTTP method", async () => {
+			const res = await server.fetch(makeRequest("GET", "initialize"));
+			expect(res.status).toBe(404);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// POST /initialize
+	// -------------------------------------------------------------------------
+
+	describe("POST /initialize", () => {
+		it("responds with { ok: true } on success", async () => {
+			const res = await server.fetch(makeRequest("POST", "initialize"));
+			expect(res.status).toBe(200);
+			expect(await res.json()).toEqual({ ok: true });
+		});
+
+		it("stores empty messages and isDone=false", async () => {
+			await server.fetch(makeRequest("POST", "initialize"));
+
+			const state = mock.store.get(
+				"streaming-messages-state",
+			) as StreamingMessagesState;
+			expect(state).toMatchObject({ messages: [], isDone: false });
+		});
+
+		it("sets bookmark to 0", async () => {
+			await server.fetch(makeRequest("POST", "initialize"));
+
+			expect(mock.store.get("streaming-messages-bookmark")).toBe(0);
+		});
+
+		it("schedules a TTL alarm", async () => {
+			const before = Date.now();
+			await server.fetch(makeRequest("POST", "initialize"));
+
+			expect(mock.storage.setAlarm).toHaveBeenCalledOnce();
+			const scheduledTime = mock.storage.setAlarm.mock.calls[0][0] as number;
+			expect(scheduledTime).toBeGreaterThanOrEqual(before + 30 * 60 * 1000);
+		});
+
+		it("returns 500 when conversation already exists and is not done", async () => {
+			await server.fetch(makeRequest("POST", "initialize"));
+			// Second init while not done should fail
+			const res = await server.fetch(makeRequest("POST", "initialize"));
+			expect(res.status).toBe(500);
+		});
+
+		it("allows re-initialization after the conversation is marked done", async () => {
+			await server.fetch(makeRequest("POST", "initialize"));
+			await server.fetch(
+				makeRequest("POST", "append", {
+					messages: [textMessage],
+					isDone: true,
+				}),
+			);
+
+			const res = await server.fetch(makeRequest("POST", "initialize"));
+			expect(res.status).toBe(200);
+
+			const state = mock.store.get(
+				"streaming-messages-state",
+			) as StreamingMessagesState;
+			expect(state).toMatchObject({ messages: [], isDone: false });
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// POST /append
+	// -------------------------------------------------------------------------
+
+	describe("POST /append", () => {
+		beforeEach(async () => {
+			await server.fetch(makeRequest("POST", "initialize"));
+			vi.clearAllMocks();
+		});
+
+		it("responds with { ok: true } on success", async () => {
+			const res = await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+			expect(res.status).toBe(200);
+			expect(await res.json()).toEqual({ ok: true });
+		});
+
+		it("appends messages to storage", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+
+			const state = mock.store.get(
+				"streaming-messages-state",
+			) as StreamingMessagesState;
+			expect(state.messages).toEqual([textMessage]);
+		});
+
+		it("accumulates messages across multiple calls", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+			await server.fetch(
+				makeRequest("POST", "append", {
+					messages: [chunkMessage, answerMessage],
+				}),
+			);
+
+			const state = mock.store.get(
+				"streaming-messages-state",
+			) as StreamingMessagesState;
+			expect(state.messages).toEqual([
+				textMessage,
+				chunkMessage,
+				answerMessage,
+			]);
+		});
+
+		it("marks the conversation done when isDone is true", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", {
+					messages: [textMessage],
+					isDone: true,
+				}),
+			);
+
+			const state = mock.store.get(
+				"streaming-messages-state",
+			) as StreamingMessagesState;
+			expect(state.isDone).toBe(true);
+		});
+
+		it("restarts the TTL alarm on each call", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+
+			expect(mock.storage.deleteAlarm).toHaveBeenCalledOnce();
+			expect(mock.storage.setAlarm).toHaveBeenCalledOnce();
+		});
+
+		it("returns 500 when the conversation does not exist", async () => {
+			// Wipe the state so the conversation is gone
+			mock.store.clear();
+
+			const res = await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+			expect(res.status).toBe(500);
+		});
+
+		it("returns 500 when the conversation is already marked done", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [], isDone: true }),
+			);
+
+			const res = await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+			expect(res.status).toBe(500);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// GET /messages
+	// -------------------------------------------------------------------------
+
+	describe("GET /messages", () => {
+		beforeEach(async () => {
+			await server.fetch(makeRequest("POST", "initialize"));
+		});
+
+		it("returns empty messages and isDone=false on a fresh conversation", async () => {
+			const res = await server.fetch(makeRequest("GET", "messages"));
+			expect(res.status).toBe(200);
+			expect(await res.json()).toEqual({ messages: [], isDone: false });
+		});
+
+		it("returns all messages appended since the last call", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", {
+					messages: [textMessage, chunkMessage],
+				}),
+			);
+
+			const res = await server.fetch(makeRequest("GET", "messages"));
+			const body = (await res.json()) as StreamingMessagesState;
+			expect(body.messages).toEqual([textMessage, chunkMessage]);
+		});
+
+		it("advances the bookmark so subsequent calls only return new messages", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+			// First poll — consumes textMessage
+			await server.fetch(makeRequest("GET", "messages"));
+
+			// Append another message
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [chunkMessage] }),
+			);
+
+			// Second poll — should only see chunkMessage
+			const res = await server.fetch(makeRequest("GET", "messages"));
+			const body = (await res.json()) as StreamingMessagesState;
+			expect(body.messages).toEqual([chunkMessage]);
+		});
+
+		it("returns empty messages when polled again with no new messages", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+			await server.fetch(makeRequest("GET", "messages")); // advances bookmark
+
+			const res = await server.fetch(makeRequest("GET", "messages"));
+			const body = (await res.json()) as StreamingMessagesState;
+			expect(body.messages).toHaveLength(0);
+		});
+
+		it("reflects isDone=true when the conversation has been completed", async () => {
+			await server.fetch(
+				makeRequest("POST", "append", {
+					messages: [textMessage],
+					isDone: true,
+				}),
+			);
+
+			const res = await server.fetch(makeRequest("GET", "messages"));
+			const body = (await res.json()) as StreamingMessagesState;
+			expect(body.isDone).toBe(true);
+		});
+
+		it("returns 500 when the conversation does not exist", async () => {
+			mock.store.clear();
+
+			const res = await server.fetch(makeRequest("GET", "messages"));
+			expect(res.status).toBe(500);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// alarm()
+	// -------------------------------------------------------------------------
+
+	describe("alarm()", () => {
+		beforeEach(async () => {
+			await server.fetch(makeRequest("POST", "initialize"));
+			await server.fetch(
+				makeRequest("POST", "append", { messages: [textMessage] }),
+			);
+		});
+
+		it("deletes the conversation state and bookmark", async () => {
+			await server.alarm();
+
+			expect(mock.store.has("streaming-messages-state")).toBe(false);
+			expect(mock.store.has("streaming-messages-bookmark")).toBe(false);
+		});
+
+		it("causes subsequent append to return 500", async () => {
+			await server.alarm();
+
+			const res = await server.fetch(
+				makeRequest("POST", "append", { messages: [chunkMessage] }),
+			);
+			expect(res.status).toBe(500);
+		});
+
+		it("causes subsequent GET /messages to return 500", async () => {
+			await server.alarm();
+
+			const res = await server.fetch(makeRequest("GET", "messages"));
+			expect(res.status).toBe(500);
+		});
+
+		it("allows re-initialization after the alarm fires", async () => {
+			await server.alarm();
+
+			const res = await server.fetch(makeRequest("POST", "initialize"));
+			expect(res.status).toBe(200);
+		});
+	});
+});

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -10,6 +10,7 @@ declare namespace Cloudflare {
 		OAUTH_KV: KVNamespace;
 		MCP_OBJECT: DurableObjectNamespace<import("./src/index").ThoughtSpotMCP>;
 		OPENAI_DEEP_RESEARCH_MCP_OBJECT: DurableObjectNamespace<import("./src/index").ThoughtSpotOpenAIDeepResearchMCP>;
+		CONVERSATION_STORAGE_OBJECT: DurableObjectNamespace<import("./src/index").ConversationStorageServer>;
 		ANALYTICS: AnalyticsEngineDataset;
 		ASSETS: Fetcher;
 	}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,6 +20,10 @@
 			{
 				"class_name": "ThoughtSpotOpenAIDeepResearchMCP",
 				"name": "OPENAI_DEEP_RESEARCH_MCP_OBJECT"
+			},
+			{
+				"class_name": "ConversationStorageServer",
+				"name": "CONVERSATION_STORAGE_OBJECT"
 			}
 		]
 	},
@@ -34,6 +38,12 @@
 			"tag": "v3",
 			"new_sqlite_classes": [
 				"ThoughtSpotOpenAIDeepResearchMCP"
+			]
+		},
+		{
+			"tag": "v4",
+			"new_classes": [
+				"ConversationStorageServer"
 			]
 		}
 	],


### PR DESCRIPTION
- Add new DO for conversation storage, and serve it on a new /storage/conversation-id route
- Add test coverage
- This DO is not yet used, we will switch to this in a future PR