### PR TITLE
Add is_thinking flag to analytical session updates

### DIFF
--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -138,6 +138,11 @@ export const ConversationUpdateSchema = z.object({
 		.describe(
 			"The type of update: `text` or `text_chunk` for a natural language message from the Analytics Agent, or `answer` for a data visualization with query results. Determines which other fields are populated.",
 		),
+	is_thinking: z
+		.boolean()
+		.describe(
+			"Whether this update is part of the Analytics Agent's thinking process. Use this to separate thinking updates from final result updates. You can use the thinking updates to show intermediate status or progress updates to the user.",
+		),
 	text: z
 		.string()
 		.optional()

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -73,12 +73,14 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 							if (item.type === "text") {
 								nTextMessagesParsed++;
 								newMessages.push({
+									is_thinking: item.metadata?.type === "thinking",
 									type: "text",
 									text: item.content,
 								});
 							} else if (item.type === "text-chunk") {
 								nTextMessagesParsed++;
 								newMessages.push({
+									is_thinking: item.metadata?.type === "thinking",
 									type: "text_chunk",
 									text: item.content,
 								});
@@ -86,6 +88,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								nAnswerMessagesParsed++;
 								const iframeUrl = `${instanceUrl}/?tsmcp=true#/embed/conv-assist-answer?sessionId=${item.metadata?.session_id}&genNo=${item.metadata?.gen_no}&acSessionId=${item.metadata?.transaction_id}&acGenNo=${item.metadata?.generation_number}`;
 								newMessages.push({
+									is_thinking: item.metadata?.type === "thinking",
 									type: "answer",
 									answer_id: JSON.stringify({
 										session_id: item.metadata?.session_id,
@@ -113,6 +116,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 									message: item,
 								});
 								newMessages.push({
+									is_thinking: false,
 									type: "text",
 									text: item.display_message || "Something went wrong",
 								});

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -30,12 +30,16 @@ export interface SessionInfo {
 	enableSpotterDataSourceDiscovery?: boolean;
 }
 
-export interface TextMessage {
+export interface BaseMessage {
+	is_thinking: boolean;
+}
+
+export interface TextMessage extends BaseMessage {
 	type: "text" | "text_chunk";
 	text: string;
 }
 
-export interface AnswerMessage {
+export interface AnswerMessage extends BaseMessage {
 	type: "answer";
 	answer_id: string;
 	answer_title: string;

--- a/test/handlers.spec.ts
+++ b/test/handlers.spec.ts
@@ -105,13 +105,11 @@ describe("Handlers", () => {
 
 			// Mock the OAUTH_PROVIDER to return valid client info
 			const mockOAuthProvider = {
-				parseAuthRequest: vi
-					.fn()
-					.mockResolvedValue({
-						clientId: "test-client",
-						codeChallenge: "test-code-challenge",
-						codeChallengeMethod: "S256",
-					}),
+				parseAuthRequest: vi.fn().mockResolvedValue({
+					clientId: "test-client",
+					codeChallenge: "test-code-challenge",
+					codeChallengeMethod: "S256",
+				}),
 				lookupClient: vi.fn().mockResolvedValue({
 					clientId: "test-client",
 					clientName: "Test Client",

--- a/test/streaming-message-storage-with-ttl/streaming-message-storage-with-ttl.spec.ts
+++ b/test/streaming-message-storage-with-ttl/streaming-message-storage-with-ttl.spec.ts
@@ -29,9 +29,18 @@ function createMockStorage() {
 }
 
 // Sample messages used across tests
-const textMessage: Message = { type: "text", text: "Hello" };
-const chunkMessage: Message = { type: "text_chunk", text: " world" };
+const textMessage: Message = {
+	is_thinking: false,
+	type: "text",
+	text: "Hello",
+};
+const chunkMessage: Message = {
+	is_thinking: false,
+	type: "text_chunk",
+	text: " world",
+};
 const answerMessage: Message = {
+	is_thinking: false,
 	type: "answer",
 	answer_id: "ans-1",
 	answer_title: "My Answer",

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -62,7 +62,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 	it("parses a text event and stores a text message", async () => {
 		const storage = makeMockStorage();
-		const line = `data: ${JSON.stringify([{ type: "text", content: "Hello world" }])}\n`;
+		const line = `data: ${JSON.stringify([{ type: "text", content: "Hello world", metadata: {} }])}\n`;
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -73,7 +73,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
-			{ type: "text", text: "Hello world" },
+			{ is_thinking: false, type: "text", text: "Hello world" },
 		]);
 		// Final done call
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
@@ -83,9 +83,9 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 	});
 
-	it("parses a text-chunk event and stores a text_chunk message", async () => {
+	it("sets is_thinking=true on a text event when metadata.type is 'thinking'", async () => {
 		const storage = makeMockStorage();
-		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "chunk content" }])}\n`;
+		const line = `data: ${JSON.stringify([{ type: "text", content: "Reasoning...", metadata: { type: "thinking" } }])}\n`;
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -96,7 +96,41 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
-			{ type: "text_chunk", text: "chunk content" },
+			{ is_thinking: true, type: "text", text: "Reasoning..." },
+		]);
+	});
+
+	it("parses a text-chunk event and stores a text_chunk message", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "chunk content", metadata: {} }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage as any,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			{ is_thinking: false, type: "text_chunk", text: "chunk content" },
+		]);
+	});
+
+	it("sets is_thinking=true on a text-chunk event when metadata.type is 'thinking'", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "thinking chunk", metadata: { type: "thinking" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage as any,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			{ is_thinking: true, type: "text_chunk", text: "thinking chunk" },
 		]);
 	});
 
@@ -123,10 +157,45 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const expectedIframeUrl = `${INSTANCE_URL}/?tsmcp=true#/embed/conv-assist-answer?sessionId=sess-1&genNo=42&acSessionId=txn-1&acGenNo=7`;
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
 			{
+				is_thinking: false,
 				type: "answer",
 				answer_id: JSON.stringify({ session_id: "sess-1", gen_no: 42 }),
 				answer_title: "My Answer",
 				answer_query: "show sales",
+				iframe_url: expectedIframeUrl,
+			},
+		]);
+	});
+
+	it("sets is_thinking=true on an answer event when metadata.type is 'thinking'", async () => {
+		const storage = makeMockStorage();
+		const metadata = {
+			type: "thinking",
+			session_id: "sess-2",
+			gen_no: 1,
+			transaction_id: "txn-2",
+			generation_number: 2,
+			title: "Thinking Answer",
+			sage_query: "show revenue",
+		};
+		const line = `data: ${JSON.stringify([{ type: "answer", metadata }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage as any,
+			INSTANCE_URL,
+		);
+
+		const expectedIframeUrl = `${INSTANCE_URL}/?tsmcp=true#/embed/conv-assist-answer?sessionId=sess-2&genNo=1&acSessionId=txn-2&acGenNo=2`;
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			{
+				is_thinking: true,
+				type: "answer",
+				answer_id: JSON.stringify({ session_id: "sess-2", gen_no: 1 }),
+				answer_title: "Thinking Answer",
+				answer_query: "show revenue",
 				iframe_url: expectedIframeUrl,
 			},
 		]);
@@ -145,7 +214,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
-			{ type: "text", text: "Something went wrong" },
+			{ is_thinking: false, type: "text", text: "Something went wrong" },
 		]);
 	});
 
@@ -162,7 +231,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
-			{ type: "text", text: "Something went wrong" },
+			{ is_thinking: false, type: "text", text: "Something went wrong" },
 		]);
 	});
 
@@ -198,7 +267,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 	it("ignores blank lines and heartbeat lines", async () => {
 		const storage = makeMockStorage();
 		// Blank line and heartbeat, then a real message
-		const chunk = `\n: heartbeat\ndata: ${JSON.stringify([{ type: "text", content: "hi" }])}\n`;
+		const chunk = `\n: heartbeat\ndata: ${JSON.stringify([{ type: "text", content: "hi", metadata: {} }])}\n`;
 		const reader = makeReader([chunk]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -209,7 +278,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
-			{ type: "text", text: "hi" },
+			{ is_thinking: false, type: "text", text: "hi" },
 		]);
 	});
 
@@ -273,7 +342,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 	it("handles multiple chunks and assembles partial lines across reads correctly", async () => {
 		const storage = makeMockStorage();
 		// Split the data line across two chunks
-		const fullLine = `data: ${JSON.stringify([{ type: "text", content: "split message" }])}`;
+		const fullLine = `data: ${JSON.stringify([{ type: "text", content: "split message", metadata: {} }])}`;
 		const part1 = fullLine.slice(0, 20);
 		const part2 = `${fullLine.slice(20)}\n`;
 		const reader = makeReader([part1, part2]);
@@ -286,14 +355,14 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
-			{ type: "text", text: "split message" },
+			{ is_thinking: false, type: "text", text: "split message" },
 		]);
 	});
 
 	it("processes multiple messages from multiple chunks and stores them in order", async () => {
 		const storage = makeMockStorage();
-		const chunk1 = `data: ${JSON.stringify([{ type: "text", content: "first" }])}\n`;
-		const chunk2 = `data: ${JSON.stringify([{ type: "text-chunk", content: "second" }])}\n`;
+		const chunk1 = `data: ${JSON.stringify([{ type: "text", content: "first", metadata: {} }])}\n`;
+		const chunk2 = `data: ${JSON.stringify([{ type: "text-chunk", content: "second", metadata: {} }])}\n`;
 		const reader = makeReader([chunk1, chunk2]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -306,12 +375,12 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenNthCalledWith(
 			1,
 			CONV_ID,
-			[{ type: "text", text: "first" }],
+			[{ is_thinking: false, type: "text", text: "first" }],
 		);
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenNthCalledWith(
 			2,
 			CONV_ID,
-			[{ type: "text_chunk", text: "second" }],
+			[{ is_thinking: false, type: "text_chunk", text: "second" }],
 		);
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenNthCalledWith(
 			3,
@@ -324,8 +393,8 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 	it("processes multiple events in the same line as a batch", async () => {
 		const storage = makeMockStorage();
 		const items = [
-			{ type: "text", content: "one" },
-			{ type: "text-chunk", content: "two" },
+			{ type: "text", content: "one", metadata: {} },
+			{ type: "text-chunk", content: "two", metadata: {} },
 		];
 		const chunk = `data: ${JSON.stringify(items)}\n`;
 		const reader = makeReader([chunk]);
@@ -338,8 +407,8 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
-			{ type: "text", text: "one" },
-			{ type: "text_chunk", text: "two" },
+			{ is_thinking: false, type: "text", text: "one" },
+			{ is_thinking: false, type: "text_chunk", text: "two" },
 		]);
 	});
 });

--- a/test/thoughtspot/thoughtspot-client-nanoid-integration.spec.ts
+++ b/test/thoughtspot/thoughtspot-client-nanoid-integration.spec.ts
@@ -165,9 +165,7 @@ describe("sendAgentConversationMessageStreaming — nano ID integration", () => 
 		const body = JSON.parse(options.body);
 
 		// Endpoint construction
-		expect(url).toBe(
-			`${INSTANCE_URL}/conversation/v2/${conversationId}/query`,
-		);
+		expect(url).toBe(`${INSTANCE_URL}/conversation/v2/${conversationId}/query`);
 
 		// The id must be present, valid length, and from the correct alphabet
 		expect(body.id).toHaveLength(NANO_ID_SIZE);


### PR DESCRIPTION
- Each message will have a new is_thinking flag, indicating whether the message is part of Spotter's thinking process or final results
- Add test coverage
- Fix some minor biome formatter violations