### PR TITLE
Use new Storage Server for streaming message storage

### DIFF
--- a/src/cloudflare-utils.ts
+++ b/src/cloudflare-utils.ts
@@ -18,7 +18,10 @@ export function instrumentedMCPServer<T extends BaseMCPServer>(
 			this.scheduleTimer.bind(this),
 			this.cancelTimer.bind(this),
 		);
-		server = new MCPServer(this as Context, this.streamingMessageStorage);
+		server = new MCPServer(
+			this as unknown as Context,
+			this.streamingMessageStorage,
+		);
 
 		// Argument of type 'typeof ThoughtSpotMCPWrapper' is not assignable to parameter of type 'DOClass'.
 		// Cannot assign a 'protected' constructor type to a 'public' constructor type.

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,21 +66,6 @@ function createMCPRouter(
 	};
 }
 
-const conversationStorageHandler = {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		const url = new URL(request.url);
-		// Path format: /storage/<conversation-id>[/<operation>]
-		const parts = url.pathname.split("/");
-		const conversationId = parts[2];
-		if (!conversationId) {
-			return new Response("Missing conversation ID", { status: 400 });
-		}
-		const id = env.CONVERSATION_STORAGE_OBJECT.idFromName(conversationId);
-		const stub = env.CONVERSATION_STORAGE_OBJECT.get(id);
-		return stub.fetch(request);
-	},
-};
-
 // Create the OAuth provider instance
 const oauthProvider = new OAuthProvider({
 	apiHandlers: {
@@ -93,7 +78,6 @@ const oauthProvider = new OAuthProvider({
 			binding: "OPENAI_DEEP_RESEARCH_MCP_OBJECT",
 		}) as any, // TODO: Remove 'any'
 		"/api": apiServer as any, // TODO: Remove 'any'
-		"/storage": conversationStorageHandler as any, // TODO: Remove 'any'
 	},
 	defaultHandler: withBearerHandler(handler, ThoughtSpotMCP) as any, // TODO: Remove 'any'
 	authorizeEndpoint: "/authorize",

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -8,13 +8,14 @@ import {
 	type ListToolsResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { z } from "zod";
-import { context, type Span, SpanStatusCode } from "@opentelemetry/api";
+import { type Span, SpanStatusCode } from "@opentelemetry/api";
 import { getActiveSpan, withSpan } from "../metrics/tracing/tracing-utils";
 import { Trackers, type Tracker, TrackEvent } from "../metrics";
 import type { Props } from "../utils";
 import { MixpanelTracker } from "../metrics/mixpanel/mixpanel";
 import { getThoughtSpotClient } from "../thoughtspot/thoughtspot-client";
 import { ThoughtSpotService } from "../thoughtspot/thoughtspot-service";
+import { StorageServiceClient } from "../storage-service/storage-service";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -39,6 +40,7 @@ export type ToolResponse = SuccessResponse | ErrorResponse;
 
 export interface Context {
 	props: Props;
+	env: Env;
 }
 
 export abstract class BaseMCPServer extends Server {
@@ -170,6 +172,13 @@ export abstract class BaseMCPServer extends Server {
 			],
 			structuredContent,
 		};
+	}
+
+	protected getStorageService(): StorageServiceClient {
+		return new StorageServiceClient(
+			this.ctx.env
+				.CONVERSATION_STORAGE_OBJECT as unknown as DurableObjectNamespace,
+		);
 	}
 
 	protected getThoughtSpotService() {

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -317,11 +317,14 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			has_additional_context: !!additional_context,
 		});
 
+		const storageService = this.getStorageService();
 		try {
-			await this.streamingMessageStorage.initializeConversation(
-				analytical_session_id,
-			);
+			await storageService.initializeConversation(analytical_session_id);
 		} catch (error) {
+			console.error(
+				"Error initializing conversation in storage service:",
+				error,
+			);
 			return this.createErrorResponse(
 				"The analytical session has an ongoing response to the previous message. Please continue to call `get_session_updates` until `is_done` is true before sending a followup message.",
 				`Error sending message to conversation ${analytical_session_id}: ${error}`,
@@ -331,7 +334,7 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		await this.getThoughtSpotService().sendAgentConversationMessageStreaming(
 			analytical_session_id,
 			message,
-			this.streamingMessageStorage,
+			storageService.appendMessages.bind(storageService),
 			additional_context,
 		);
 
@@ -356,6 +359,7 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		//    returning too quickly, which leads to too many get updates tool calls.
 		// 4. If there are no updates after waiting for 10 seconds, return an empty response. We
 		//    want to avoid waiting indefinitely in case of errors or unexpected problems.
+		const storageService = this.getStorageService();
 		const messagesState: StreamingMessagesState = {
 			messages: [],
 			isDone: false,
@@ -363,10 +367,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		let i = 0;
 		for (; i < 20; i++) {
 			// Get latest updates
-			const newMessagesState =
-				await this.streamingMessageStorage.getNewMessagesAndUpdateBookmark(
-					analytical_session_id,
-				);
+			const newMessagesState = await storageService.getNewMessages(
+				analytical_session_id,
+			);
 			messagesState.messages.push(...newMessagesState.messages);
 			messagesState.isDone = newMessagesState.isDone;
 

--- a/src/storage-service/storage-service.ts
+++ b/src/storage-service/storage-service.ts
@@ -3,27 +3,30 @@ import type { Message, StreamingMessagesState } from "../thoughtspot/types";
 /**
  * Client for the ConversationStorageServer Durable Object.
  *
- * Provides typed methods for each HTTP endpoint exposed by the server:
+ * Communicates directly with the DO via its stub (bypassing the OAuth layer), mapping to the
+ * following HTTP endpoints exposed by the server:
  *   POST  /storage/<conversationId>/initialize —> initializeConversation
  *   POST  /storage/<conversationId>/append     —> appendMessagesAndRestartTtl
  *   GET   /storage/<conversationId>/messages   —> getNewMessagesAndUpdateBookmark
  */
 export class StorageServiceClient {
-	constructor(
-		private readonly baseUrl: string,
-		private readonly authToken: string,
-	) {}
+	constructor(private readonly namespace: DurableObjectNamespace) {}
 
 	private headers(): HeadersInit {
 		return {
 			"Content-Type": "application/json",
 			Accept: "application/json",
-			Authorization: `Bearer ${this.authToken}`,
 		};
 	}
 
+	private stubFor(conversationId: string): DurableObjectStub {
+		const id = this.namespace.idFromName(conversationId);
+		return this.namespace.get(id);
+	}
+
+	// DO stubs ignore the hostname; we use a placeholder so the path is parsed correctly.
 	private url(conversationId: string, operation: string): string {
-		return `${this.baseUrl}/storage/${encodeURIComponent(conversationId)}/${operation}`;
+		return `https://internal/storage/${encodeURIComponent(conversationId)}/${operation}`;
 	}
 
 	/**
@@ -32,10 +35,10 @@ export class StorageServiceClient {
 	 * to prime it for a follow-up message.
 	 */
 	async initializeConversation(conversationId: string): Promise<void> {
-		const response = await fetch(this.url(conversationId, "initialize"), {
-			method: "POST",
-			headers: this.headers(),
-		});
+		const response = await this.stubFor(conversationId).fetch(
+			this.url(conversationId, "initialize"),
+			{ method: "POST", headers: this.headers() },
+		);
 
 		if (!response.ok) {
 			const body = await response.text();
@@ -56,11 +59,10 @@ export class StorageServiceClient {
 	): Promise<void> {
 		const body: StreamingMessagesState = { messages, isDone };
 
-		const response = await fetch(this.url(conversationId, "append"), {
-			method: "POST",
-			headers: this.headers(),
-			body: JSON.stringify(body),
-		});
+		const response = await this.stubFor(conversationId).fetch(
+			this.url(conversationId, "append"),
+			{ method: "POST", headers: this.headers(), body: JSON.stringify(body) },
+		);
 
 		if (!response.ok) {
 			const text = await response.text();
@@ -78,10 +80,10 @@ export class StorageServiceClient {
 	async getNewMessages(
 		conversationId: string,
 	): Promise<StreamingMessagesState> {
-		const response = await fetch(this.url(conversationId, "messages"), {
-			method: "GET",
-			headers: this.headers(),
-		});
+		const response = await this.stubFor(conversationId).fetch(
+			this.url(conversationId, "messages"),
+			{ method: "GET", headers: this.headers() },
+		);
 
 		if (!response.ok) {
 			const text = await response.text();

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -1,5 +1,4 @@
 import type { Message } from "./thoughtspot/types";
-import type { StreamingMessagesStorageWithTtl } from "./streaming-message-storage-with-ttl/streaming-message-storage-with-ttl";
 import { withSpan } from "./metrics/tracing/tracing-utils";
 import { type Span, SpanStatusCode } from "@opentelemetry/api";
 
@@ -11,7 +10,11 @@ import { type Span, SpanStatusCode } from "@opentelemetry/api";
 export const processSendAgentConversationMessageStreamingResponse = async (
 	conversationId: string,
 	streamingResponseReader: ReadableStreamDefaultReader,
-	streamingMessageStorage: StreamingMessagesStorageWithTtl,
+	appendStoredMessages: (
+		conversationId: string,
+		messages: Message[],
+		isDone?: boolean,
+	) => Promise<void>,
 	instanceUrl: string,
 ) => {
 	return await withSpan(
@@ -33,11 +36,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 
 					// If stream is marked done, mark the conversation as done and exit
 					if (done) {
-						await streamingMessageStorage.appendMessagesAndRestartTtl(
-							conversationId,
-							[],
-							true,
-						);
+						await appendStoredMessages(conversationId, [], true);
 						break;
 					}
 
@@ -129,10 +128,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 
 					// If we parsed any new messages, store them in the storage
 					if (newMessages.length > 0) {
-						await streamingMessageStorage.appendMessagesAndRestartTtl(
-							conversationId,
-							newMessages,
-						);
+						await appendStoredMessages(conversationId, newMessages);
 					}
 				}
 			} catch (error) {

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -11,7 +11,6 @@ import type {
 	Message,
 	Answer,
 } from "./types";
-import type { StreamingMessagesStorageWithTtl } from "../streaming-message-storage-with-ttl/streaming-message-storage-with-ttl";
 import { processSendAgentConversationMessageStreamingResponse } from "../streaming-utils";
 
 /**
@@ -281,7 +280,11 @@ export class ThoughtSpotService {
 	async sendAgentConversationMessageStreaming(
 		conversationId: string,
 		message: string,
-		streamingMessageStorage: StreamingMessagesStorageWithTtl,
+		appendStoredMessages: (
+			conversationId: string,
+			messages: Message[],
+			isDone?: boolean,
+		) => Promise<void>,
 		additionalContext?: string | undefined,
 	): Promise<void> {
 		const span = trace.getSpan(context.active());
@@ -315,7 +318,7 @@ export class ThoughtSpotService {
 			processSendAgentConversationMessageStreamingResponse(
 				conversationId,
 				reader,
-				streamingMessageStorage,
+				appendStoredMessages,
 				(this.client as any).instanceUrl,
 			);
 

--- a/test/storage-service/storage-service.spec.ts
+++ b/test/storage-service/storage-service.spec.ts
@@ -9,8 +9,6 @@ import type {
 // Helpers
 // ---------------------------------------------------------------------------
 
-const BASE_URL = "https://example.com";
-const AUTH_TOKEN = "test-token";
 const CONVERSATION_ID = "conv-abc123";
 
 const textMessage: Message = { type: "text", text: "Hello" };
@@ -23,32 +21,37 @@ const answerMessage: Message = {
 	iframe_url: "https://example.com/answer/1",
 };
 
-function mockFetchOk(body: unknown = { ok: true }): void {
-	vi.stubGlobal(
-		"fetch",
-		vi.fn().mockResolvedValue(
-			new Response(JSON.stringify(body), {
-				status: 200,
+// Captured request from the stub's last fetch call
+let lastStubRequest: Request | undefined;
+
+function makeNamespaceMock(
+	responseBody: unknown = { ok: true },
+	status = 200,
+): DurableObjectNamespace {
+	lastStubRequest = undefined;
+	const stub = {
+		fetch: vi.fn(async (input: RequestInfo, init?: RequestInit) => {
+			lastStubRequest = new Request(input, init);
+			const body =
+				typeof responseBody === "string"
+					? responseBody
+					: JSON.stringify(responseBody);
+			return new Response(body, {
+				status,
 				headers: { "Content-Type": "application/json" },
-			}),
-		),
-	);
+			});
+		}),
+	} as unknown as DurableObjectStub;
+
+	return {
+		idFromName: vi.fn(() => ({ toString: () => "stub-id" }) as DurableObjectId),
+		get: vi.fn(() => stub),
+	} as unknown as DurableObjectNamespace;
 }
 
-function mockFetchError(status: number, body: string): void {
-	vi.stubGlobal(
-		"fetch",
-		vi.fn().mockResolvedValue(new Response(body, { status })),
-	);
-}
-
-function lastFetchCall(): { url: string; init: RequestInit } {
-	const mockFn = vi.mocked(fetch);
-	const [url, init] = mockFn.mock.calls[mockFn.mock.calls.length - 1] as [
-		string,
-		RequestInit,
-	];
-	return { url, init };
+function lastRequest(): Request {
+	if (!lastStubRequest) throw new Error("No stub request recorded");
+	return lastStubRequest;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,11 +60,12 @@ function lastFetchCall(): { url: string; init: RequestInit } {
 
 describe("StorageServiceClient", () => {
 	let client: StorageServiceClient;
+	let namespaceMock: DurableObjectNamespace;
 
 	beforeEach(() => {
 		vi.restoreAllMocks();
-		vi.unstubAllGlobals();
-		client = new StorageServiceClient(BASE_URL, AUTH_TOKEN);
+		namespaceMock = makeNamespaceMock();
+		client = new StorageServiceClient(namespaceMock);
 	});
 
 	// -------------------------------------------------------------------------
@@ -70,46 +74,33 @@ describe("StorageServiceClient", () => {
 
 	describe("initializeConversation", () => {
 		it("sends POST to /storage/<id>/initialize", async () => {
-			mockFetchOk();
-
 			await client.initializeConversation(CONVERSATION_ID);
 
-			const { url, init } = lastFetchCall();
-			expect(url).toBe(`${BASE_URL}/storage/${CONVERSATION_ID}/initialize`);
-			expect(init.method).toBe("POST");
-		});
-
-		it("sends the Authorization header", async () => {
-			mockFetchOk();
-
-			await client.initializeConversation(CONVERSATION_ID);
-
-			const { init } = lastFetchCall();
-			expect((init.headers as Record<string, string>).Authorization).toBe(
-				`Bearer ${AUTH_TOKEN}`,
+			const req = lastRequest();
+			expect(req.url).toBe(
+				`https://internal/storage/${CONVERSATION_ID}/initialize`,
 			);
+			expect(req.method).toBe("POST");
 		});
 
 		it("URL-encodes the conversation ID", async () => {
-			mockFetchOk();
-
 			await client.initializeConversation("conv with spaces/and-slash");
 
-			const { url } = lastFetchCall();
-			expect(url).toBe(
-				`${BASE_URL}/storage/conv%20with%20spaces%2Fand-slash/initialize`,
+			const req = lastRequest();
+			expect(req.url).toBe(
+				"https://internal/storage/conv%20with%20spaces%2Fand-slash/initialize",
 			);
 		});
 
 		it("resolves without error on a 200 response", async () => {
-			mockFetchOk();
 			await expect(
 				client.initializeConversation(CONVERSATION_ID),
 			).resolves.toBeUndefined();
 		});
 
 		it("throws when the server returns a non-ok status", async () => {
-			mockFetchError(500, "Something went wrong");
+			namespaceMock = makeNamespaceMock("Something went wrong", 500);
+			client = new StorageServiceClient(namespaceMock);
 
 			await expect(
 				client.initializeConversation(CONVERSATION_ID),
@@ -117,7 +108,11 @@ describe("StorageServiceClient", () => {
 		});
 
 		it("includes the error body in the thrown error message", async () => {
-			mockFetchError(400, "Conversation already exists and is not marked done");
+			namespaceMock = makeNamespaceMock(
+				"Conversation already exists and is not marked done",
+				400,
+			);
+			client = new StorageServiceClient(namespaceMock);
 
 			await expect(
 				client.initializeConversation(CONVERSATION_ID),
@@ -131,67 +126,47 @@ describe("StorageServiceClient", () => {
 
 	describe("appendMessages", () => {
 		it("sends POST to /storage/<id>/append", async () => {
-			mockFetchOk();
-
 			await client.appendMessages(CONVERSATION_ID, [textMessage]);
 
-			const { url, init } = lastFetchCall();
-			expect(url).toBe(`${BASE_URL}/storage/${CONVERSATION_ID}/append`);
-			expect(init.method).toBe("POST");
+			const req = lastRequest();
+			expect(req.url).toBe(
+				`https://internal/storage/${CONVERSATION_ID}/append`,
+			);
+			expect(req.method).toBe("POST");
 		});
 
 		it("sends messages and isDone=false in the request body by default", async () => {
-			mockFetchOk();
-
 			await client.appendMessages(CONVERSATION_ID, [textMessage, chunkMessage]);
 
-			const { init } = lastFetchCall();
-			const body = JSON.parse(init.body as string) as StreamingMessagesState;
+			const body = (await lastRequest().json()) as StreamingMessagesState;
 			expect(body.messages).toEqual([textMessage, chunkMessage]);
 			expect(body.isDone).toBe(false);
 		});
 
 		it("sends isDone=true when specified", async () => {
-			mockFetchOk();
-
 			await client.appendMessages(CONVERSATION_ID, [answerMessage], true);
 
-			const { init } = lastFetchCall();
-			const body = JSON.parse(init.body as string) as StreamingMessagesState;
+			const body = (await lastRequest().json()) as StreamingMessagesState;
 			expect(body.isDone).toBe(true);
 		});
 
-		it("sends the Authorization header", async () => {
-			mockFetchOk();
-
-			await client.appendMessages(CONVERSATION_ID, []);
-
-			const { init } = lastFetchCall();
-			expect((init.headers as Record<string, string>).Authorization).toBe(
-				`Bearer ${AUTH_TOKEN}`,
-			);
-		});
-
 		it("sends Content-Type: application/json", async () => {
-			mockFetchOk();
-
 			await client.appendMessages(CONVERSATION_ID, []);
 
-			const { init } = lastFetchCall();
-			expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+			expect(lastRequest().headers.get("Content-Type")).toBe(
 				"application/json",
 			);
 		});
 
 		it("resolves without error on a 200 response", async () => {
-			mockFetchOk();
 			await expect(
 				client.appendMessages(CONVERSATION_ID, [textMessage]),
 			).resolves.toBeUndefined();
 		});
 
 		it("throws when the server returns a non-ok status", async () => {
-			mockFetchError(500, "Conversation not found");
+			namespaceMock = makeNamespaceMock("Conversation not found", 500);
+			client = new StorageServiceClient(namespaceMock);
 
 			await expect(
 				client.appendMessages(CONVERSATION_ID, [textMessage]),
@@ -199,10 +174,11 @@ describe("StorageServiceClient", () => {
 		});
 
 		it("includes the error body in the thrown error message", async () => {
-			mockFetchError(
-				400,
+			namespaceMock = makeNamespaceMock(
 				"Cannot append messages to a conversation marked done",
+				400,
 			);
+			client = new StorageServiceClient(namespaceMock);
 
 			await expect(
 				client.appendMessages(CONVERSATION_ID, [textMessage]),
@@ -216,28 +192,16 @@ describe("StorageServiceClient", () => {
 
 	describe("getNewMessages", () => {
 		it("sends GET to /storage/<id>/messages", async () => {
-			const state: StreamingMessagesState = {
-				messages: [textMessage],
-				isDone: false,
-			};
-			mockFetchOk(state);
+			namespaceMock = makeNamespaceMock({ messages: [textMessage], isDone: false });
+			client = new StorageServiceClient(namespaceMock);
 
 			await client.getNewMessages(CONVERSATION_ID);
 
-			const { url, init } = lastFetchCall();
-			expect(url).toBe(`${BASE_URL}/storage/${CONVERSATION_ID}/messages`);
-			expect(init.method).toBe("GET");
-		});
-
-		it("sends the Authorization header", async () => {
-			mockFetchOk({ messages: [], isDone: false });
-
-			await client.getNewMessages(CONVERSATION_ID);
-
-			const { init } = lastFetchCall();
-			expect((init.headers as Record<string, string>).Authorization).toBe(
-				`Bearer ${AUTH_TOKEN}`,
+			const req = lastRequest();
+			expect(req.url).toBe(
+				`https://internal/storage/${CONVERSATION_ID}/messages`,
 			);
+			expect(req.method).toBe("GET");
 		});
 
 		it("returns the parsed StreamingMessagesState", async () => {
@@ -245,7 +209,8 @@ describe("StorageServiceClient", () => {
 				messages: [textMessage, answerMessage],
 				isDone: true,
 			};
-			mockFetchOk(state);
+			namespaceMock = makeNamespaceMock(state);
+			client = new StorageServiceClient(namespaceMock);
 
 			const result = await client.getNewMessages(CONVERSATION_ID);
 
@@ -253,7 +218,8 @@ describe("StorageServiceClient", () => {
 		});
 
 		it("returns an empty messages array when there are no new messages", async () => {
-			mockFetchOk({ messages: [], isDone: false });
+			namespaceMock = makeNamespaceMock({ messages: [], isDone: false });
+			client = new StorageServiceClient(namespaceMock);
 
 			const result = await client.getNewMessages(CONVERSATION_ID);
 
@@ -262,7 +228,8 @@ describe("StorageServiceClient", () => {
 		});
 
 		it("throws when the server returns a non-ok status", async () => {
-			mockFetchError(404, "Conversation not found");
+			namespaceMock = makeNamespaceMock("Conversation not found", 404);
+			client = new StorageServiceClient(namespaceMock);
 
 			await expect(client.getNewMessages(CONVERSATION_ID)).rejects.toThrow(
 				"Failed to get messages (404)",
@@ -270,7 +237,8 @@ describe("StorageServiceClient", () => {
 		});
 
 		it("includes the error body in the thrown error message", async () => {
-			mockFetchError(500, "Internal error");
+			namespaceMock = makeNamespaceMock("Internal error", 500);
+			client = new StorageServiceClient(namespaceMock);
 
 			await expect(client.getNewMessages(CONVERSATION_ID)).rejects.toThrow(
 				"Internal error",

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -19,8 +19,10 @@ function makeReader(chunks: string[]): ReadableStreamDefaultReader {
 
 // Mock storage
 function makeMockStorage() {
+	const fn = vi.fn(async () => {});
 	return {
-		appendMessagesAndRestartTtl: vi.fn(async () => {}),
+		appendMessages: fn,
+		appendMessagesAndRestartTtl: fn,
 	};
 }
 
@@ -48,7 +50,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -68,7 +70,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -91,7 +93,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -108,7 +110,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -125,7 +127,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -150,7 +152,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -184,7 +186,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -209,7 +211,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -226,7 +228,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -251,7 +253,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -273,7 +275,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -290,7 +292,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -310,7 +312,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -328,7 +330,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -350,7 +352,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -368,7 +370,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 
@@ -402,7 +404,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		await processSendAgentConversationMessageStreamingResponse(
 			CONV_ID,
 			reader,
-			storage as any,
+			storage.appendMessages,
 			INSTANCE_URL,
 		);
 


### PR DESCRIPTION
- Remove /storage public route and use internal binding to access Storage Server (no longer need to expose the endpoint publicly)
- Wire up Storage Client to use the new Storage Server in place of existing storage class
- Update tests