### PR TITLE
SCAL-308278 Add Analytics Engine metrics sink

### DIFF
--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -1,0 +1,197 @@
+import {
+	METRIC_NAMES,
+	type MetricLabels,
+	type MetricName,
+} from "./metric-types";
+import type {
+	MetricObservation,
+	MetricResourceAttributes,
+	MetricsFlushPayload,
+	MetricsSink,
+} from "./metrics-sink";
+
+export type AnalyticsEngineDataPointLike = {
+	indexes?: ((ArrayBuffer | string) | null)[];
+	blobs?: ((ArrayBuffer | string) | null)[];
+	doubles?: number[];
+};
+
+export type AnalyticsEngineDatasetLike = {
+	writeDataPoint(event?: AnalyticsEngineDataPointLike): void;
+};
+
+export const ANALYTICS_ENGINE_SCHEMA_VERSION = "mcp_metrics_v1";
+
+export const ANALYTICS_ENGINE_INDEX_FIELDS = [
+	"schema_version",
+	"event_family",
+	"metric_name",
+	"tenant_id",
+	"user_id",
+] as const;
+
+export const ANALYTICS_ENGINE_BLOB_FIELDS = [
+	"metric_kind",
+	"route_group",
+	"transport",
+	"auth_mode",
+	"api_surface",
+	"api_version",
+	"outcome",
+	"status_class",
+	"tool_name",
+	"upstream_operation",
+	"message_type",
+	"is_thinking",
+	"is_done",
+	"operation",
+	"deployment_environment",
+	"service_name",
+	"service_namespace",
+	"service_version",
+] as const;
+
+export const ANALYTICS_ENGINE_DOUBLE_FIELDS = [
+	"metric_value",
+	"timestamp_ms",
+] as const;
+
+type AnalyticsEngineIdentity = {
+	tenantId?: string;
+	userId?: string;
+};
+
+type AnalyticsEngineMetricFamily =
+	| "analysis"
+	| "auth"
+	| "dashboard"
+	| "http"
+	| "resource"
+	| "stream_storage"
+	| "tool"
+	| "upstream";
+
+function nullableString(value: string | undefined): string | null {
+	return value && value.length > 0 ? value : null;
+}
+
+function getLabel(
+	labels: MetricLabels,
+	key: keyof MetricLabels,
+): string | null {
+	return nullableString(labels[key]);
+}
+
+function getResourceAttribute(
+	resourceAttributes: MetricResourceAttributes,
+	key: keyof MetricResourceAttributes,
+): string | null {
+	return nullableString(resourceAttributes[key]);
+}
+
+export function getAnalyticsEngineMetricFamily(
+	name: MetricName,
+): AnalyticsEngineMetricFamily {
+	switch (name) {
+		case METRIC_NAMES.httpRequestsTotal:
+		case METRIC_NAMES.httpRequestDurationMs:
+		case METRIC_NAMES.httpInflightRequests:
+			return "http";
+		case METRIC_NAMES.toolCallsTotal:
+		case METRIC_NAMES.toolDurationMs:
+			return "tool";
+		case METRIC_NAMES.resourceReadsTotal:
+			return "resource";
+		case METRIC_NAMES.oauthAuthorizeRequestsTotal:
+		case METRIC_NAMES.oauthAuthorizeSubmitTotal:
+		case METRIC_NAMES.oauthCallbackTotal:
+		case METRIC_NAMES.oauthStoreTokenTotal:
+		case METRIC_NAMES.bearerAuthRequestsTotal:
+			return "auth";
+		case METRIC_NAMES.upstreamCallsTotal:
+		case METRIC_NAMES.upstreamDurationMs:
+		case METRIC_NAMES.upstreamStreamsStartedTotal:
+		case METRIC_NAMES.upstreamStreamMessagesTotal:
+			return "upstream";
+		case METRIC_NAMES.analysisSessionsCreatedTotal:
+		case METRIC_NAMES.analysisMessagesSentTotal:
+		case METRIC_NAMES.analysisUpdatesPolledTotal:
+		case METRIC_NAMES.analysisPollWaitMs:
+		case METRIC_NAMES.analysisFirstBufferedUpdateMs:
+		case METRIC_NAMES.analysisFirstPollDelayMs:
+		case METRIC_NAMES.analysisFirstNonEmptyResponseMs:
+		case METRIC_NAMES.analysisSessionsNeverPolledTotal:
+			return "analysis";
+		case METRIC_NAMES.streamStorageErrorsTotal:
+			return "stream_storage";
+		case METRIC_NAMES.dashboardsCreatedTotal:
+		case METRIC_NAMES.dashboardTilesCount:
+			return "dashboard";
+	}
+}
+
+export function toAnalyticsEngineDataPoint(
+	observation: MetricObservation,
+	resourceAttributes: MetricResourceAttributes,
+	identity: AnalyticsEngineIdentity = {},
+): AnalyticsEngineDataPointLike {
+	return {
+		indexes: [
+			ANALYTICS_ENGINE_SCHEMA_VERSION,
+			getAnalyticsEngineMetricFamily(observation.name),
+			observation.name,
+			nullableString(identity.tenantId),
+			nullableString(identity.userId),
+		],
+		blobs: [
+			observation.kind,
+			getLabel(observation.labels, "route_group"),
+			getLabel(observation.labels, "transport"),
+			getLabel(observation.labels, "auth_mode"),
+			getLabel(observation.labels, "api_surface"),
+			getLabel(observation.labels, "api_version"),
+			getLabel(observation.labels, "outcome"),
+			getLabel(observation.labels, "status_class"),
+			getLabel(observation.labels, "tool_name"),
+			getLabel(observation.labels, "upstream_operation"),
+			getLabel(observation.labels, "message_type"),
+			getLabel(observation.labels, "is_thinking"),
+			getLabel(observation.labels, "is_done"),
+			getLabel(observation.labels, "operation"),
+			getResourceAttribute(resourceAttributes, "deployment.environment"),
+			getResourceAttribute(resourceAttributes, "service.name"),
+			getResourceAttribute(resourceAttributes, "service.namespace"),
+			getResourceAttribute(resourceAttributes, "service.version"),
+		],
+		doubles: [observation.value, observation.timestampMs],
+	};
+}
+
+export class AnalyticsEngineMetricsSink implements MetricsSink {
+	constructor(private readonly dataset: AnalyticsEngineDatasetLike) {}
+
+	async flush(payload: MetricsFlushPayload): Promise<void> {
+		for (const observation of payload.observations) {
+			this.dataset.writeDataPoint(
+				toAnalyticsEngineDataPoint(observation, payload.resourceAttributes),
+			);
+		}
+	}
+}
+
+export function createAnalyticsEngineMetricsSink(
+	dataset: unknown,
+): AnalyticsEngineMetricsSink | undefined {
+	if (
+		typeof dataset === "object" &&
+		dataset !== null &&
+		"writeDataPoint" in dataset &&
+		typeof dataset.writeDataPoint === "function"
+	) {
+		return new AnalyticsEngineMetricsSink(
+			dataset as AnalyticsEngineDatasetLike,
+		);
+	}
+
+	return undefined;
+}

--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -17,7 +17,7 @@ export type AnalyticsEngineDataPointLike = {
 };
 
 export type AnalyticsEngineDatasetLike = {
-	writeDataPoint(event?: AnalyticsEngineDataPointLike): void;
+	writeDataPoint(event?: AnalyticsEngineDataPointLike): Promise<void> | void;
 };
 
 export const ANALYTICS_ENGINE_SCHEMA_VERSION = "mcp_metrics_v1";
@@ -179,9 +179,16 @@ export class AnalyticsEngineMetricsSink implements MetricsSink {
 
 	async flush(payload: MetricsFlushPayload): Promise<void> {
 		for (const observation of payload.observations) {
-			this.dataset.writeDataPoint(
-				toAnalyticsEngineDataPoint(observation, payload.resourceAttributes),
-			);
+			try {
+				await this.dataset.writeDataPoint(
+					toAnalyticsEngineDataPoint(observation, payload.resourceAttributes),
+				);
+			} catch (error) {
+				console.warn(
+					`[metrics] Failed to write Analytics Engine data point for ${observation.name}`,
+					error,
+				);
+			}
 		}
 	}
 }

--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -102,6 +102,7 @@ export function getAnalyticsEngineMetricFamily(
 			return "tool";
 		case METRIC_NAMES.resourceReadsTotal:
 			return "resource";
+		case METRIC_NAMES.sessionsStartedTotal:
 		case METRIC_NAMES.oauthAuthorizeRequestsTotal:
 		case METRIC_NAMES.oauthAuthorizeSubmitTotal:
 		case METRIC_NAMES.oauthCallbackTotal:
@@ -127,6 +128,12 @@ export function getAnalyticsEngineMetricFamily(
 		case METRIC_NAMES.dashboardsCreatedTotal:
 		case METRIC_NAMES.dashboardTilesCount:
 			return "dashboard";
+		default: {
+			const _exhaustiveCheck: never = name;
+			throw new Error(
+				`Unhandled Analytics Engine metric family: ${_exhaustiveCheck}`,
+			);
+		}
 	}
 }
 

--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -17,7 +17,7 @@ export type AnalyticsEngineDataPointLike = {
 };
 
 export type AnalyticsEngineDatasetLike = {
-	writeDataPoint(event?: AnalyticsEngineDataPointLike): Promise<void> | void;
+	writeDataPoint(event?: AnalyticsEngineDataPointLike): void;
 };
 
 export const ANALYTICS_ENGINE_SCHEMA_VERSION = "mcp_metrics_v1";
@@ -178,24 +178,22 @@ export class AnalyticsEngineMetricsSink implements MetricsSink {
 	constructor(private readonly dataset: AnalyticsEngineDatasetLike) {}
 
 	async flush(payload: MetricsFlushPayload): Promise<void> {
-		await Promise.all(
-			payload.observations.map(async (observation) => {
-				try {
-					await this.dataset.writeDataPoint(
-						toAnalyticsEngineDataPoint(
-							observation,
-							payload.resourceAttributes,
-							payload.eventIdentity,
-						),
-					);
-				} catch (error) {
-					console.warn(
-						`[metrics] Failed to write Analytics Engine data point for ${observation.name}`,
-						error,
-					);
-				}
-			}),
-		);
+		for (const observation of payload.observations) {
+			try {
+				this.dataset.writeDataPoint(
+					toAnalyticsEngineDataPoint(
+						observation,
+						payload.resourceAttributes,
+						payload.eventIdentity,
+					),
+				);
+			} catch (error) {
+				console.warn(
+					`[metrics] Failed to write Analytics Engine data point for ${observation.name}`,
+					error,
+				);
+			}
+		}
 	}
 }
 

--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -182,7 +182,11 @@ export class AnalyticsEngineMetricsSink implements MetricsSink {
 			payload.observations.map(async (observation) => {
 				try {
 					await this.dataset.writeDataPoint(
-						toAnalyticsEngineDataPoint(observation, payload.resourceAttributes),
+						toAnalyticsEngineDataPoint(
+							observation,
+							payload.resourceAttributes,
+							payload.eventIdentity,
+						),
 					);
 				} catch (error) {
 					console.warn(

--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -1,4 +1,5 @@
 import {
+	APPROVED_METRIC_LABEL_KEYS,
 	METRIC_NAMES,
 	type MetricLabels,
 	type MetricName,
@@ -30,25 +31,22 @@ export const ANALYTICS_ENGINE_INDEX_FIELDS = [
 	"user_id",
 ] as const;
 
+export const ANALYTICS_ENGINE_LABEL_FIELDS = APPROVED_METRIC_LABEL_KEYS;
+
+export const ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS = [
+	["deployment_environment", "deployment.environment"],
+	["service_name", "service.name"],
+	["service_namespace", "service.namespace"],
+	["service_version", "service.version"],
+] as const satisfies readonly (readonly [
+	string,
+	keyof MetricResourceAttributes,
+])[];
+
 export const ANALYTICS_ENGINE_BLOB_FIELDS = [
 	"metric_kind",
-	"route_group",
-	"transport",
-	"auth_mode",
-	"api_surface",
-	"api_version",
-	"outcome",
-	"status_class",
-	"tool_name",
-	"upstream_operation",
-	"message_type",
-	"is_thinking",
-	"is_done",
-	"operation",
-	"deployment_environment",
-	"service_name",
-	"service_namespace",
-	"service_version",
+	...ANALYTICS_ENGINE_LABEL_FIELDS,
+	...ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS.map(([field]) => field),
 ] as const;
 
 export const ANALYTICS_ENGINE_DOUBLE_FIELDS = [
@@ -152,23 +150,12 @@ export function toAnalyticsEngineDataPoint(
 		],
 		blobs: [
 			observation.kind,
-			getLabel(observation.labels, "route_group"),
-			getLabel(observation.labels, "transport"),
-			getLabel(observation.labels, "auth_mode"),
-			getLabel(observation.labels, "api_surface"),
-			getLabel(observation.labels, "api_version"),
-			getLabel(observation.labels, "outcome"),
-			getLabel(observation.labels, "status_class"),
-			getLabel(observation.labels, "tool_name"),
-			getLabel(observation.labels, "upstream_operation"),
-			getLabel(observation.labels, "message_type"),
-			getLabel(observation.labels, "is_thinking"),
-			getLabel(observation.labels, "is_done"),
-			getLabel(observation.labels, "operation"),
-			getResourceAttribute(resourceAttributes, "deployment.environment"),
-			getResourceAttribute(resourceAttributes, "service.name"),
-			getResourceAttribute(resourceAttributes, "service.namespace"),
-			getResourceAttribute(resourceAttributes, "service.version"),
+			...ANALYTICS_ENGINE_LABEL_FIELDS.map((key) =>
+				getLabel(observation.labels, key),
+			),
+			...ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS.map(([, key]) =>
+				getResourceAttribute(resourceAttributes, key),
+			),
 		],
 		doubles: [observation.value, observation.timestampMs],
 	};
@@ -197,18 +184,22 @@ export class AnalyticsEngineMetricsSink implements MetricsSink {
 	}
 }
 
-export function createAnalyticsEngineMetricsSink(
+function isAnalyticsEngineDatasetLike(
 	dataset: unknown,
-): AnalyticsEngineMetricsSink | undefined {
-	if (
+): dataset is AnalyticsEngineDatasetLike {
+	return (
 		typeof dataset === "object" &&
 		dataset !== null &&
 		"writeDataPoint" in dataset &&
 		typeof dataset.writeDataPoint === "function"
-	) {
-		return new AnalyticsEngineMetricsSink(
-			dataset as AnalyticsEngineDatasetLike,
-		);
+	);
+}
+
+export function createAnalyticsEngineMetricsSink(
+	dataset: unknown,
+): AnalyticsEngineMetricsSink | undefined {
+	if (isAnalyticsEngineDatasetLike(dataset)) {
+		return new AnalyticsEngineMetricsSink(dataset);
 	}
 
 	return undefined;

--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -178,18 +178,20 @@ export class AnalyticsEngineMetricsSink implements MetricsSink {
 	constructor(private readonly dataset: AnalyticsEngineDatasetLike) {}
 
 	async flush(payload: MetricsFlushPayload): Promise<void> {
-		for (const observation of payload.observations) {
-			try {
-				await this.dataset.writeDataPoint(
-					toAnalyticsEngineDataPoint(observation, payload.resourceAttributes),
-				);
-			} catch (error) {
-				console.warn(
-					`[metrics] Failed to write Analytics Engine data point for ${observation.name}`,
-					error,
-				);
-			}
-		}
+		await Promise.all(
+			payload.observations.map(async (observation) => {
+				try {
+					await this.dataset.writeDataPoint(
+						toAnalyticsEngineDataPoint(observation, payload.resourceAttributes),
+					);
+				} catch (error) {
+					console.warn(
+						`[metrics] Failed to write Analytics Engine data point for ${observation.name}`,
+						error,
+					);
+				}
+			}),
+		);
 	}
 }
 

--- a/src/metrics/runtime/metrics-sink.ts
+++ b/src/metrics/runtime/metrics-sink.ts
@@ -20,9 +20,15 @@ export type MetricResourceAttributes = Partial<
 	>
 >;
 
+export type MetricEventIdentity = {
+	tenantId?: string;
+	userId?: string;
+};
+
 export type MetricsFlushPayload = {
 	observations: readonly MetricObservation[];
 	resourceAttributes: MetricResourceAttributes;
+	eventIdentity?: MetricEventIdentity;
 };
 
 export interface MetricsSink {

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -1,4 +1,5 @@
 import { createGrafanaOtlpMetricsSink } from "./grafana-otlp-sink";
+import { createAnalyticsEngineMetricsSink } from "./analytics-engine-sink";
 import {
 	type MetricsRecorder,
 	NOOP_METRICS_RECORDER,
@@ -27,6 +28,18 @@ export function setMetricsRecorderOnExecutionContext(
 ): MetricsRecorder {
 	(ctx as MetricsExecutionContext)[METRICS_RECORDER_SYMBOL] = recorder;
 	return recorder;
+}
+
+function createDefaultConfiguredMetricsSinks(
+	env: MetricsEnvLike | undefined,
+	sinks: ConfiguredMetricsSinks,
+): ConfiguredMetricsSinks {
+	return {
+		analyticsEngineSink:
+			sinks.analyticsEngineSink ??
+			createAnalyticsEngineMetricsSink(env?.ANALYTICS),
+		grafanaSink: sinks.grafanaSink ?? getCachedGrafanaSink(env),
+	};
 }
 
 export function getMetricsRecorderFromExecutionContext(
@@ -58,16 +71,6 @@ function getCachedGrafanaSink(
 		GRAFANA_SINK_CACHE.set(env, sink);
 	}
 	return sink;
-}
-
-function createDefaultConfiguredMetricsSinks(
-	env: MetricsEnvLike | undefined,
-	sinks: ConfiguredMetricsSinks,
-): ConfiguredMetricsSinks {
-	return {
-		analyticsEngineSink: sinks.analyticsEngineSink,
-		grafanaSink: sinks.grafanaSink ?? getCachedGrafanaSink(env),
-	};
 }
 
 export function createRequestMetricsRecorder(

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -1,12 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	ANALYTICS_ENGINE_BLOB_FIELDS,
+	ANALYTICS_ENGINE_DOUBLE_FIELDS,
+	ANALYTICS_ENGINE_INDEX_FIELDS,
+	ANALYTICS_ENGINE_LABEL_FIELDS,
+	ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS,
 	ANALYTICS_ENGINE_SCHEMA_VERSION,
 	AnalyticsEngineMetricsSink,
 	createAnalyticsEngineMetricsSink,
 	getAnalyticsEngineMetricFamily,
 	toAnalyticsEngineDataPoint,
 } from "../../../src/metrics/runtime/analytics-engine-sink";
-import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
+import {
+	APPROVED_METRIC_LABEL_KEYS,
+	METRIC_NAMES,
+} from "../../../src/metrics/runtime/metric-types";
 import type { MetricObservation } from "../../../src/metrics/runtime/metrics-sink";
 
 describe("AnalyticsEngineMetricsSink", () => {
@@ -85,6 +93,35 @@ describe("AnalyticsEngineMetricsSink", () => {
 		expect(
 			getAnalyticsEngineMetricFamily(METRIC_NAMES.sessionsStartedTotal),
 		).toBe("auth");
+	});
+
+	it("keeps the Analytics Engine schema aligned with approved labels and resource attributes", () => {
+		expect(ANALYTICS_ENGINE_LABEL_FIELDS).toEqual(APPROVED_METRIC_LABEL_KEYS);
+		expect(ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS).toEqual([
+			["deployment_environment", "deployment.environment"],
+			["service_name", "service.name"],
+			["service_namespace", "service.namespace"],
+			["service_version", "service.version"],
+		]);
+		expect(ANALYTICS_ENGINE_INDEX_FIELDS).toEqual([
+			"schema_version",
+			"event_family",
+			"metric_name",
+			"tenant_id",
+			"user_id",
+		]);
+		expect(ANALYTICS_ENGINE_BLOB_FIELDS).toEqual([
+			"metric_kind",
+			...APPROVED_METRIC_LABEL_KEYS,
+			"deployment_environment",
+			"service_name",
+			"service_namespace",
+			"service_version",
+		]);
+		expect(ANALYTICS_ENGINE_DOUBLE_FIELDS).toEqual([
+			"metric_value",
+			"timestamp_ms",
+		]);
 	});
 
 	it("writes one data point per observation", async () => {
@@ -172,5 +209,8 @@ describe("AnalyticsEngineMetricsSink", () => {
 		).toBeInstanceOf(AnalyticsEngineMetricsSink);
 		expect(createAnalyticsEngineMetricsSink(undefined)).toBeUndefined();
 		expect(createAnalyticsEngineMetricsSink({})).toBeUndefined();
+		expect(
+			createAnalyticsEngineMetricsSink({ writeDataPoint: "not-a-function" }),
+		).toBeUndefined();
 	});
 });

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -146,10 +146,11 @@ describe("AnalyticsEngineMetricsSink", () => {
 			name: METRIC_NAMES.httpRequestsTotal,
 		} satisfies MetricObservation;
 		const dataset = {
-			writeDataPoint: vi
-				.fn()
-				.mockRejectedValueOnce(new Error("write failed"))
-				.mockResolvedValueOnce(undefined),
+			writeDataPoint: vi.fn((dataPoint) => {
+				if (dataPoint?.indexes?.[2] === METRIC_NAMES.toolCallsTotal) {
+					throw new Error("write failed");
+				}
+			}),
 		};
 		const sink = new AnalyticsEngineMetricsSink(dataset);
 

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -113,6 +113,32 @@ describe("AnalyticsEngineMetricsSink", () => {
 		);
 	});
 
+	it("maps request-scoped event identity into Analytics Engine indexes", async () => {
+		const dataset = { writeDataPoint: vi.fn() };
+		const sink = new AnalyticsEngineMetricsSink(dataset);
+
+		await sink.flush({
+			observations: [observation],
+			resourceAttributes: {},
+			eventIdentity: {
+				tenantId: "tenant-123",
+				userId: "user-456",
+			},
+		});
+
+		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
+			expect.objectContaining({
+				indexes: [
+					ANALYTICS_ENGINE_SCHEMA_VERSION,
+					"tool",
+					METRIC_NAMES.toolCallsTotal,
+					"tenant-123",
+					"user-456",
+				],
+			}),
+		);
+	});
+
 	it("continues writing remaining data points when one write fails", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const secondObservation = {

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	ANALYTICS_ENGINE_SCHEMA_VERSION,
+	AnalyticsEngineMetricsSink,
+	createAnalyticsEngineMetricsSink,
+	getAnalyticsEngineMetricFamily,
+	toAnalyticsEngineDataPoint,
+} from "../../../src/metrics/runtime/analytics-engine-sink";
+import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
+import type { MetricObservation } from "../../../src/metrics/runtime/metrics-sink";
+
+describe("AnalyticsEngineMetricsSink", () => {
+	const observation = {
+		kind: "counter",
+		name: METRIC_NAMES.toolCallsTotal,
+		value: 2,
+		labels: {
+			tool_name: "create_liveboard",
+			outcome: "success",
+			route_group: "mcp",
+			transport: "mcp",
+			api_surface: "mcp",
+			auth_mode: "oauth",
+		},
+		timestampMs: 1_714_000_000_000,
+	} satisfies MetricObservation;
+
+	it("maps metric observations into the Analytics Engine schema", () => {
+		const dataPoint = toAnalyticsEngineDataPoint(observation, {
+			"deployment.environment": "production",
+			"service.name": "thoughtspot-mcp-server",
+			"service.namespace": "thoughtspot",
+			"service.version": "0.5.0",
+		});
+
+		expect(dataPoint.indexes).toEqual([
+			ANALYTICS_ENGINE_SCHEMA_VERSION,
+			"tool",
+			METRIC_NAMES.toolCallsTotal,
+			null,
+			null,
+		]);
+		expect(dataPoint.blobs).toEqual([
+			"counter",
+			"mcp",
+			"mcp",
+			"oauth",
+			"mcp",
+			null,
+			"success",
+			null,
+			"create_liveboard",
+			null,
+			null,
+			null,
+			null,
+			null,
+			"production",
+			"thoughtspot-mcp-server",
+			"thoughtspot",
+			"0.5.0",
+		]);
+		expect(dataPoint.doubles).toEqual([2, 1_714_000_000_000]);
+	});
+
+	it("classifies every metric name into a stable event family", () => {
+		expect(getAnalyticsEngineMetricFamily(METRIC_NAMES.httpRequestsTotal)).toBe(
+			"http",
+		);
+		expect(getAnalyticsEngineMetricFamily(METRIC_NAMES.toolDurationMs)).toBe(
+			"tool",
+		);
+		expect(
+			getAnalyticsEngineMetricFamily(METRIC_NAMES.upstreamCallsTotal),
+		).toBe("upstream");
+		expect(
+			getAnalyticsEngineMetricFamily(
+				METRIC_NAMES.analysisFirstNonEmptyResponseMs,
+			),
+		).toBe("analysis");
+		expect(
+			getAnalyticsEngineMetricFamily(METRIC_NAMES.dashboardTilesCount),
+		).toBe("dashboard");
+	});
+
+	it("writes one data point per observation", async () => {
+		const dataset = { writeDataPoint: vi.fn() };
+		const sink = new AnalyticsEngineMetricsSink(dataset);
+
+		await sink.flush({
+			observations: [observation],
+			resourceAttributes: {
+				"deployment.environment": "local",
+			},
+		});
+
+		expect(dataset.writeDataPoint).toHaveBeenCalledTimes(1);
+		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
+			expect.objectContaining({
+				indexes: [
+					ANALYTICS_ENGINE_SCHEMA_VERSION,
+					"tool",
+					METRIC_NAMES.toolCallsTotal,
+					null,
+					null,
+				],
+				doubles: [2, 1_714_000_000_000],
+			}),
+		);
+	});
+
+	it("only creates a sink when the Analytics Engine binding is present", () => {
+		expect(
+			createAnalyticsEngineMetricsSink({ writeDataPoint: vi.fn() }),
+		).toBeInstanceOf(AnalyticsEngineMetricsSink);
+		expect(createAnalyticsEngineMetricsSink(undefined)).toBeUndefined();
+		expect(createAnalyticsEngineMetricsSink({})).toBeUndefined();
+	});
+});

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -64,23 +64,23 @@ describe("AnalyticsEngineMetricsSink", () => {
 	});
 
 	it("classifies every metric name into a stable event family", () => {
-		expect(getAnalyticsEngineMetricFamily(METRIC_NAMES.httpRequestsTotal)).toBe(
+		const validFamilies = [
+			"analysis",
+			"auth",
+			"dashboard",
 			"http",
-		);
-		expect(getAnalyticsEngineMetricFamily(METRIC_NAMES.toolDurationMs)).toBe(
+			"resource",
+			"stream_storage",
 			"tool",
-		);
+			"upstream",
+		];
+
+		for (const name of Object.values(METRIC_NAMES)) {
+			expect(validFamilies).toContain(getAnalyticsEngineMetricFamily(name));
+		}
 		expect(
-			getAnalyticsEngineMetricFamily(METRIC_NAMES.upstreamCallsTotal),
-		).toBe("upstream");
-		expect(
-			getAnalyticsEngineMetricFamily(
-				METRIC_NAMES.analysisFirstNonEmptyResponseMs,
-			),
-		).toBe("analysis");
-		expect(
-			getAnalyticsEngineMetricFamily(METRIC_NAMES.dashboardTilesCount),
-		).toBe("dashboard");
+			getAnalyticsEngineMetricFamily(METRIC_NAMES.sessionsStartedTotal),
+		).toBe("auth");
 	});
 
 	it("writes one data point per observation", async () => {

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	ANALYTICS_ENGINE_SCHEMA_VERSION,
 	AnalyticsEngineMetricsSink,
@@ -10,6 +10,10 @@ import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
 import type { MetricObservation } from "../../../src/metrics/runtime/metrics-sink";
 
 describe("AnalyticsEngineMetricsSink", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	const observation = {
 		kind: "counter",
 		name: METRIC_NAMES.toolCallsTotal,
@@ -106,6 +110,32 @@ describe("AnalyticsEngineMetricsSink", () => {
 				],
 				doubles: [2, 1_714_000_000_000],
 			}),
+		);
+	});
+
+	it("continues writing remaining data points when one write fails", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const secondObservation = {
+			...observation,
+			name: METRIC_NAMES.httpRequestsTotal,
+		} satisfies MetricObservation;
+		const dataset = {
+			writeDataPoint: vi
+				.fn()
+				.mockRejectedValueOnce(new Error("write failed"))
+				.mockResolvedValueOnce(undefined),
+		};
+		const sink = new AnalyticsEngineMetricsSink(dataset);
+
+		await sink.flush({
+			observations: [observation, secondObservation],
+			resourceAttributes: {},
+		});
+
+		expect(dataset.writeDataPoint).toHaveBeenCalledTimes(2);
+		expect(warnSpy).toHaveBeenCalledWith(
+			`[metrics] Failed to write Analytics Engine data point for ${METRIC_NAMES.toolCallsTotal}`,
+			expect.any(Error),
 		);
 	});
 

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -222,6 +222,26 @@ describe("withRequestMetrics", () => {
 		);
 	});
 
+	it("uses the Analytics Engine binding as the default analytics sink", async () => {
+		const analyticsDataset = { writeDataPoint: vi.fn() };
+		const recorder = createRequestMetricsRecorder({
+			METRICS_SINK_MODE: "analytics_engine",
+			ANALYTICS: analyticsDataset,
+		});
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+			route_group: "mcp",
+		});
+		await recorder.flush();
+
+		expect(analyticsDataset.writeDataPoint).toHaveBeenCalledTimes(1);
+		expect(analyticsDataset.writeDataPoint).toHaveBeenCalledWith(
+			expect.objectContaining({
+				indexes: expect.arrayContaining([METRIC_NAMES.httpRequestsTotal]),
+			}),
+		);
+	});
+
 	it("does not fail the request when waitUntil rejects scheduling", async () => {
 		const errorSpy = vi
 			.spyOn(console, "error")


### PR DESCRIPTION
## Summary

Add the Analytics Engine sink for the metrics runtime so PM and tenant event observations can be written to the existing Cloudflare `ANALYTICS` binding.

## What Changed

- add an Analytics Engine sink that writes one datapoint per metric observation
- define the positional Analytics Engine schema for indexes, blobs, and doubles
- classify metric names into stable event families for PM-oriented querying
- wire request metrics to use `env.ANALYTICS` when the analytics sink is enabled
- keep missing bindings as noop through the existing sink selection path
- cover datapoint mapping, binding detection, and default sink wiring in tests

## Semantics

The schema reserves index positions for tenant and user identity. This PR wires the sink and raw event shape; later instrumentation PRs will populate those identity fields from ThoughtSpot session context where available.