### PR TITLE
SCAL-308279 Add Grafana OTLP metrics sink

### DIFF
--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -110,52 +110,16 @@ function getProcessEnvValue(name: string): string | undefined {
 
 function readConfigValue(
 	env: GrafanaOtlpEnvLike | undefined,
-	...keys: string[]
+	key: string,
 ): string | undefined {
-	for (const key of keys) {
-		const envValue = env?.[key];
-		if (typeof envValue === "string" && envValue.length > 0) {
-			return envValue;
-		}
-
-		const processEnvValue = getProcessEnvValue(key);
-		if (processEnvValue && processEnvValue.length > 0) {
-			return processEnvValue;
-		}
+	const envValue = env?.[key];
+	if (typeof envValue === "string" && envValue.length > 0) {
+		return envValue;
 	}
 
-	return undefined;
-}
-
-function decodeHeaderValue(value: string): string {
-	try {
-		return decodeURIComponent(value);
-	} catch {
-		return value;
-	}
-}
-
-function readOtlpAuthorizationHeader(
-	env: GrafanaOtlpEnvLike | undefined,
-): string | undefined {
-	const rawHeaders = readConfigValue(env, "OTEL_EXPORTER_OTLP_HEADERS");
-	if (!rawHeaders) {
-		return undefined;
-	}
-
-	for (const header of rawHeaders.split(",")) {
-		const separatorIndex = header.indexOf("=");
-		if (separatorIndex === -1) {
-			continue;
-		}
-
-		const key = header.slice(0, separatorIndex).trim().toLowerCase();
-		if (key !== "authorization") {
-			continue;
-		}
-
-		const value = header.slice(separatorIndex + 1).trim();
-		return value ? decodeHeaderValue(value) : undefined;
+	const processEnvValue = getProcessEnvValue(key);
+	if (processEnvValue && processEnvValue.length > 0) {
+		return processEnvValue;
 	}
 
 	return undefined;
@@ -398,36 +362,16 @@ export function toOtlpMetricsPayload(
 export function resolveGrafanaOtlpSinkConfig(
 	env?: GrafanaOtlpEnvLike,
 ): GrafanaOtlpSinkConfig | undefined {
-	const endpoint = readConfigValue(
-		env,
-		"GRAFANA_OTLP_METRICS_ENDPOINT",
-		"GRAFANA_OTLP_ENDPOINT",
-		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
-		"OTEL_EXPORTER_OTLP_ENDPOINT",
-	);
+	const endpoint = readConfigValue(env, "GRAFANA_OTLP_ENDPOINT");
 	if (!endpoint) {
 		return undefined;
 	}
 
 	return {
 		endpoint: normalizeOtlpMetricsEndpoint(endpoint),
-		username: readConfigValue(
-			env,
-			"GRAFANA_OTLP_USERNAME",
-			"GRAFANA_CLOUD_ACCOUNT_ID",
-			"GRAFANA_CLOUD_INSTANCE_ID",
-		),
-		apiToken: readConfigValue(
-			env,
-			"GRAFANA_OTLP_API_TOKEN",
-			"GRAFANA_CLOUD_API_TOKEN",
-		),
-		authHeader:
-			readConfigValue(
-				env,
-				"GRAFANA_OTLP_AUTH_HEADER",
-				"OTEL_EXPORTER_OTLP_AUTH_HEADER",
-			) ?? readOtlpAuthorizationHeader(env),
+		username: readConfigValue(env, "GRAFANA_OTLP_USERNAME"),
+		apiToken: readConfigValue(env, "GRAFANA_OTLP_API_TOKEN"),
+		authHeader: readConfigValue(env, "GRAFANA_OTLP_AUTH_HEADER"),
 	};
 }
 

--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -86,6 +86,14 @@ type GrafanaOtlpMetricsSinkOptions = GrafanaOtlpSinkConfig & {
 	fetchFn?: typeof fetch;
 };
 
+type AggregatedMetricDataPoint = {
+	attributes: OtlpAttribute[];
+	bucketCounts: number[];
+	count: number;
+	timestampMs: number;
+	value: number;
+};
+
 const OTLP_SCOPE_NAME = "thoughtspot.mcp.metrics.runtime";
 const OTLP_AGGREGATION_TEMPORALITY_DELTA = 1;
 const JSON_HEADERS = {
@@ -187,16 +195,16 @@ function toAttributes(
 }
 
 function toTimeUnixNano(timestampMs: number): string {
-	return String(Math.trunc(timestampMs * 1_000_000));
+	return (BigInt(Math.trunc(timestampMs * 1_000)) * 1_000n).toString();
 }
 
-function getHistogramBucketCounts(value: number): string[] {
+function getHistogramBucketCounts(value: number): number[] {
 	const bucketCounts = new Array(HISTOGRAM_BUCKETS_MS.length + 1).fill(
 		0,
 	) as number[];
 	const bucketIndex = HISTOGRAM_BUCKETS_MS.findIndex((bound) => value <= bound);
 	bucketCounts[bucketIndex === -1 ? bucketCounts.length - 1 : bucketIndex] = 1;
-	return bucketCounts.map(String);
+	return bucketCounts;
 }
 
 function groupObservationsByMetric(
@@ -211,33 +219,79 @@ function groupObservationsByMetric(
 	return grouped;
 }
 
-function observationLabelsToAttributes(
-	observation: MetricObservation,
-): OtlpAttribute[] {
-	return toAttributes(observation.labels);
+function getAttributeSetKey(attributes: readonly OtlpAttribute[]): string {
+	return JSON.stringify(attributes);
 }
 
 function toNumberDataPoint(
-	observation: MetricObservation,
+	observation: AggregatedMetricDataPoint,
 ): OtlpNumberDataPoint {
 	return {
-		attributes: observationLabelsToAttributes(observation),
+		attributes: observation.attributes,
 		asDouble: observation.value,
 		timeUnixNano: toTimeUnixNano(observation.timestampMs),
 	};
 }
 
 function toHistogramDataPoint(
-	observation: MetricObservation,
+	observation: AggregatedMetricDataPoint,
 ): OtlpHistogramDataPoint {
 	return {
-		attributes: observationLabelsToAttributes(observation),
-		count: "1",
+		attributes: observation.attributes,
+		count: String(observation.count),
 		sum: observation.value,
-		bucketCounts: getHistogramBucketCounts(observation.value),
+		bucketCounts: observation.bucketCounts.map(String),
 		explicitBounds: HISTOGRAM_BUCKETS_MS,
 		timeUnixNano: toTimeUnixNano(observation.timestampMs),
 	};
+}
+
+function aggregateObservations(
+	kind: MetricKind,
+	observations: readonly MetricObservation[],
+): AggregatedMetricDataPoint[] {
+	const aggregated = new Map<string, AggregatedMetricDataPoint>();
+
+	for (const observation of observations) {
+		const attributes = toAttributes(observation.labels);
+		const attributeSetKey = getAttributeSetKey(attributes);
+		const dataPoint = aggregated.get(attributeSetKey) ?? {
+			attributes,
+			bucketCounts: new Array(HISTOGRAM_BUCKETS_MS.length + 1).fill(
+				0,
+			) as number[],
+			count: 0,
+			timestampMs: observation.timestampMs,
+			value: 0,
+		};
+
+		switch (kind) {
+			case "counter":
+				dataPoint.value += observation.value;
+				dataPoint.count += 1;
+				dataPoint.timestampMs = observation.timestampMs;
+				break;
+			case "gauge":
+				dataPoint.value = observation.value;
+				dataPoint.count = 1;
+				dataPoint.timestampMs = observation.timestampMs;
+				break;
+			case "histogram": {
+				const bucketCounts = getHistogramBucketCounts(observation.value);
+				for (const [index, bucketCount] of bucketCounts.entries()) {
+					dataPoint.bucketCounts[index] += bucketCount;
+				}
+				dataPoint.value += observation.value;
+				dataPoint.count += 1;
+				dataPoint.timestampMs = observation.timestampMs;
+				break;
+			}
+		}
+
+		aggregated.set(attributeSetKey, dataPoint);
+	}
+
+	return [...aggregated.values()];
 }
 
 function toOtlpMetric(
@@ -245,6 +299,8 @@ function toOtlpMetric(
 	kind: MetricKind,
 	observations: readonly MetricObservation[],
 ): OtlpMetric {
+	const dataPoints = aggregateObservations(kind, observations);
+
 	switch (kind) {
 		case "counter":
 			return {
@@ -252,14 +308,14 @@ function toOtlpMetric(
 				sum: {
 					aggregationTemporality: OTLP_AGGREGATION_TEMPORALITY_DELTA,
 					isMonotonic: true,
-					dataPoints: observations.map(toNumberDataPoint),
+					dataPoints: dataPoints.map(toNumberDataPoint),
 				},
 			};
 		case "gauge":
 			return {
 				name,
 				gauge: {
-					dataPoints: observations.map(toNumberDataPoint),
+					dataPoints: dataPoints.map(toNumberDataPoint),
 				},
 			};
 		case "histogram":
@@ -267,7 +323,7 @@ function toOtlpMetric(
 				name,
 				histogram: {
 					aggregationTemporality: OTLP_AGGREGATION_TEMPORALITY_DELTA,
-					dataPoints: observations.map(toHistogramDataPoint),
+					dataPoints: dataPoints.map(toHistogramDataPoint),
 				},
 			};
 	}

--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -210,13 +210,9 @@ function toTimeUnixNano(timestampMs: number): string {
 	).toString();
 }
 
-function getHistogramBucketCounts(value: number): number[] {
-	const bucketCounts = new Array(HISTOGRAM_BUCKETS_MS.length + 1).fill(
-		0,
-	) as number[];
+function getHistogramBucketIndex(value: number): number {
 	const bucketIndex = HISTOGRAM_BUCKETS_MS.findIndex((bound) => value <= bound);
-	bucketCounts[bucketIndex === -1 ? bucketCounts.length - 1 : bucketIndex] = 1;
-	return bucketCounts;
+	return bucketIndex === -1 ? HISTOGRAM_BUCKETS_MS.length : bucketIndex;
 }
 
 function groupObservationsByMetric(
@@ -290,10 +286,8 @@ function aggregateObservations(
 				dataPoint.timestampMs = observation.timestampMs;
 				break;
 			case "histogram": {
-				const bucketCounts = getHistogramBucketCounts(observation.value);
-				for (const [index, bucketCount] of bucketCounts.entries()) {
-					dataPoint.bucketCounts[index] += bucketCount;
-				}
+				const bucketIndex = getHistogramBucketIndex(observation.value);
+				dataPoint.bucketCounts[bucketIndex] += 1;
 				dataPoint.value += observation.value;
 				dataPoint.count += 1;
 				dataPoint.timestampMs = observation.timestampMs;

--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -257,9 +257,10 @@ function aggregateObservations(
 		const attributeSetKey = getAttributeSetKey(attributes);
 		const dataPoint = aggregated.get(attributeSetKey) ?? {
 			attributes,
-			bucketCounts: new Array(HISTOGRAM_BUCKETS_MS.length + 1).fill(
-				0,
-			) as number[],
+			bucketCounts:
+				kind === "histogram"
+					? (new Array(HISTOGRAM_BUCKETS_MS.length + 1).fill(0) as number[])
+					: [],
 			count: 0,
 			timestampMs: observation.timestampMs,
 			value: 0,

--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -96,6 +96,7 @@ type AggregatedMetricDataPoint = {
 
 const OTLP_SCOPE_NAME = "thoughtspot.mcp.metrics.runtime";
 const OTLP_AGGREGATION_TEMPORALITY_DELTA = 1;
+const MAX_EXPORT_ERROR_BODY_LENGTH = 1_000;
 const JSON_HEADERS = {
 	"Content-Type": "application/json",
 };
@@ -161,11 +162,16 @@ function readOtlpAuthorizationHeader(
 }
 
 function encodeBase64(value: string): string {
-	if (typeof btoa === "function") {
-		return btoa(value);
-	}
 	if (typeof Buffer !== "undefined") {
 		return Buffer.from(value, "utf8").toString("base64");
+	}
+	if (typeof TextEncoder !== "undefined" && typeof btoa === "function") {
+		const bytes = new TextEncoder().encode(value);
+		let binary = "";
+		for (const byte of bytes) {
+			binary += String.fromCharCode(byte);
+		}
+		return btoa(binary);
 	}
 	throw new Error("No base64 encoder is available for Grafana OTLP auth");
 }
@@ -195,7 +201,13 @@ function toAttributes(
 }
 
 function toTimeUnixNano(timestampMs: number): string {
-	return (BigInt(Math.trunc(timestampMs * 1_000)) * 1_000n).toString();
+	const integerMs = Math.trunc(timestampMs);
+	const fractionalMs = timestampMs - integerMs;
+	const fractionalMicros = Math.round(fractionalMs * 1_000);
+	return (
+		BigInt(integerMs) * 1_000_000n +
+		BigInt(fractionalMicros) * 1_000n
+	).toString();
 }
 
 function getHistogramBucketCounts(value: number): number[] {
@@ -354,6 +366,14 @@ function buildRequestHeaders(config: GrafanaOtlpSinkConfig): HeadersInit {
 		: JSON_HEADERS;
 }
 
+async function getExportErrorBody(response: Response): Promise<string> {
+	const text = await response.text();
+	if (text.length <= MAX_EXPORT_ERROR_BODY_LENGTH) {
+		return text;
+	}
+	return `${text.slice(0, MAX_EXPORT_ERROR_BODY_LENGTH)}...`;
+}
+
 export function toOtlpMetricsPayload(
 	payload: MetricsFlushPayload,
 ): OtlpMetricsPayload {
@@ -438,7 +458,7 @@ export class GrafanaOtlpMetricsSink implements MetricsSink {
 
 		if (!response.ok) {
 			throw new Error(
-				`Grafana OTLP metrics export failed with status ${response.status}: ${await response.text()}`,
+				`Grafana OTLP metrics export failed with status ${response.status}: ${await getExportErrorBody(response)}`,
 			);
 		}
 	}

--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -176,7 +176,7 @@ function encodeBase64(value: string): string {
 	throw new Error("No base64 encoder is available for Grafana OTLP auth");
 }
 
-function toOtlpValue(value: MetricLabelValue | string): OtlpAttributeValue {
+function toOtlpValue(value: MetricLabelValue): OtlpAttributeValue {
 	if (typeof value === "boolean") {
 		return { boolValue: value };
 	}
@@ -186,8 +186,8 @@ function toOtlpValue(value: MetricLabelValue | string): OtlpAttributeValue {
 	return { stringValue: value };
 }
 
-function toAttributes(
-	attributes: Record<string, MetricLabelValue | string | undefined>,
+function toOtlpAttributes(
+	attributes: Record<string, MetricLabelValue | undefined>,
 ): OtlpAttribute[] {
 	return Object.keys(attributes)
 		.sort()
@@ -202,11 +202,13 @@ function toAttributes(
 
 function toTimeUnixNano(timestampMs: number): string {
 	const integerMs = Math.trunc(timestampMs);
-	const fractionalMs = timestampMs - integerMs;
-	const fractionalMicros = Math.round(fractionalMs * 1_000);
+	const remainderNs = Math.round((timestampMs - integerMs) * 1_000_000);
+	const carryMs = Math.trunc(remainderNs / 1_000_000);
+	const normalizedRemainderNs = remainderNs - carryMs * 1_000_000;
+
 	return (
-		BigInt(integerMs) * 1_000_000n +
-		BigInt(fractionalMicros) * 1_000n
+		(BigInt(integerMs) + BigInt(carryMs)) * 1_000_000n +
+		BigInt(normalizedRemainderNs)
 	).toString();
 }
 
@@ -261,7 +263,7 @@ function aggregateObservations(
 	const aggregated = new Map<string, AggregatedMetricDataPoint>();
 
 	for (const observation of observations) {
-		const attributes = toAttributes(observation.labels);
+		const attributes = toOtlpAttributes(observation.labels);
 		const attributeSetKey = getAttributeSetKey(attributes);
 		const dataPoint = aggregated.get(attributeSetKey) ?? {
 			attributes,
@@ -341,7 +343,7 @@ function normalizeOtlpMetricsEndpoint(endpoint: string): string {
 	return trimmed.endsWith("/v1/metrics") ? trimmed : `${trimmed}/v1/metrics`;
 }
 
-function buildAuthorizationHeader(
+function buildAuthorizationHeaderValue(
 	config: Pick<GrafanaOtlpSinkConfig, "apiToken" | "authHeader" | "username">,
 ): string | undefined {
 	if (config.authHeader) {
@@ -354,7 +356,7 @@ function buildAuthorizationHeader(
 }
 
 function buildRequestHeaders(config: GrafanaOtlpSinkConfig): HeadersInit {
-	const authorization = buildAuthorizationHeader(config);
+	const authorization = buildAuthorizationHeaderValue(config);
 	return authorization
 		? { ...JSON_HEADERS, Authorization: authorization }
 		: JSON_HEADERS;
@@ -365,7 +367,8 @@ async function getExportErrorBody(response: Response): Promise<string> {
 	if (text.length <= MAX_EXPORT_ERROR_BODY_LENGTH) {
 		return text;
 	}
-	return `${text.slice(0, MAX_EXPORT_ERROR_BODY_LENGTH)}...`;
+	const truncatedLength = Math.max(0, MAX_EXPORT_ERROR_BODY_LENGTH - 3);
+	return `${text.slice(0, truncatedLength)}...`;
 }
 
 export function toOtlpMetricsPayload(
@@ -377,7 +380,7 @@ export function toOtlpMetricsPayload(
 		resourceMetrics: [
 			{
 				resource: {
-					attributes: toAttributes(payload.resourceAttributes),
+					attributes: toOtlpAttributes(payload.resourceAttributes),
 				},
 				scopeMetrics: [
 					{

--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -1,0 +1,395 @@
+import {
+	HISTOGRAM_BUCKETS_MS,
+	type MetricKind,
+	type MetricLabelValue,
+	type MetricName,
+} from "./metric-types";
+import type {
+	MetricObservation,
+	MetricResourceAttributes,
+	MetricsFlushPayload,
+	MetricsSink,
+} from "./metrics-sink";
+
+type OtlpStringValue = { stringValue: string };
+type OtlpBoolValue = { boolValue: boolean };
+type OtlpDoubleValue = { doubleValue: number };
+type OtlpAttributeValue = OtlpStringValue | OtlpBoolValue | OtlpDoubleValue;
+
+type OtlpAttribute = {
+	key: string;
+	value: OtlpAttributeValue;
+};
+
+type OtlpNumberDataPoint = {
+	attributes?: OtlpAttribute[];
+	asDouble: number;
+	timeUnixNano: string;
+};
+
+type OtlpHistogramDataPoint = {
+	attributes?: OtlpAttribute[];
+	count: string;
+	sum: number;
+	bucketCounts: string[];
+	explicitBounds: readonly number[];
+	timeUnixNano: string;
+};
+
+type OtlpMetric =
+	| {
+			name: string;
+			sum: {
+				aggregationTemporality: typeof OTLP_AGGREGATION_TEMPORALITY_DELTA;
+				isMonotonic: true;
+				dataPoints: OtlpNumberDataPoint[];
+			};
+	  }
+	| {
+			name: string;
+			gauge: {
+				dataPoints: OtlpNumberDataPoint[];
+			};
+	  }
+	| {
+			name: string;
+			histogram: {
+				aggregationTemporality: typeof OTLP_AGGREGATION_TEMPORALITY_DELTA;
+				dataPoints: OtlpHistogramDataPoint[];
+			};
+	  };
+
+export type OtlpMetricsPayload = {
+	resourceMetrics: Array<{
+		resource: {
+			attributes: OtlpAttribute[];
+		};
+		scopeMetrics: Array<{
+			scope: {
+				name: string;
+			};
+			metrics: OtlpMetric[];
+		}>;
+	}>;
+};
+
+export type GrafanaOtlpEnvLike = Partial<Record<string, unknown>>;
+
+export type GrafanaOtlpSinkConfig = {
+	endpoint: string;
+	username?: string;
+	apiToken?: string;
+	authHeader?: string;
+};
+
+type GrafanaOtlpMetricsSinkOptions = GrafanaOtlpSinkConfig & {
+	fetchFn?: typeof fetch;
+};
+
+const OTLP_SCOPE_NAME = "thoughtspot.mcp.metrics.runtime";
+const OTLP_AGGREGATION_TEMPORALITY_DELTA = 1;
+const JSON_HEADERS = {
+	"Content-Type": "application/json",
+};
+
+function getProcessEnvValue(name: string): string | undefined {
+	if (typeof process === "undefined") {
+		return undefined;
+	}
+	return process.env?.[name];
+}
+
+function readConfigValue(
+	env: GrafanaOtlpEnvLike | undefined,
+	...keys: string[]
+): string | undefined {
+	for (const key of keys) {
+		const envValue = env?.[key];
+		if (typeof envValue === "string" && envValue.length > 0) {
+			return envValue;
+		}
+
+		const processEnvValue = getProcessEnvValue(key);
+		if (processEnvValue && processEnvValue.length > 0) {
+			return processEnvValue;
+		}
+	}
+
+	return undefined;
+}
+
+function decodeHeaderValue(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+function readOtlpAuthorizationHeader(
+	env: GrafanaOtlpEnvLike | undefined,
+): string | undefined {
+	const rawHeaders = readConfigValue(env, "OTEL_EXPORTER_OTLP_HEADERS");
+	if (!rawHeaders) {
+		return undefined;
+	}
+
+	for (const header of rawHeaders.split(",")) {
+		const separatorIndex = header.indexOf("=");
+		if (separatorIndex === -1) {
+			continue;
+		}
+
+		const key = header.slice(0, separatorIndex).trim().toLowerCase();
+		if (key !== "authorization") {
+			continue;
+		}
+
+		const value = header.slice(separatorIndex + 1).trim();
+		return value ? decodeHeaderValue(value) : undefined;
+	}
+
+	return undefined;
+}
+
+function encodeBase64(value: string): string {
+	if (typeof btoa === "function") {
+		return btoa(value);
+	}
+	if (typeof Buffer !== "undefined") {
+		return Buffer.from(value, "utf8").toString("base64");
+	}
+	throw new Error("No base64 encoder is available for Grafana OTLP auth");
+}
+
+function toOtlpValue(value: MetricLabelValue | string): OtlpAttributeValue {
+	if (typeof value === "boolean") {
+		return { boolValue: value };
+	}
+	if (typeof value === "number") {
+		return { doubleValue: value };
+	}
+	return { stringValue: value };
+}
+
+function toAttributes(
+	attributes: Record<string, MetricLabelValue | string | undefined>,
+): OtlpAttribute[] {
+	return Object.keys(attributes)
+		.sort()
+		.flatMap((key) => {
+			const value = attributes[key];
+			if (value === undefined || value === "") {
+				return [];
+			}
+			return [{ key, value: toOtlpValue(value) }];
+		});
+}
+
+function toTimeUnixNano(timestampMs: number): string {
+	return String(Math.trunc(timestampMs * 1_000_000));
+}
+
+function getHistogramBucketCounts(value: number): string[] {
+	const bucketCounts = new Array(HISTOGRAM_BUCKETS_MS.length + 1).fill(
+		0,
+	) as number[];
+	const bucketIndex = HISTOGRAM_BUCKETS_MS.findIndex((bound) => value <= bound);
+	bucketCounts[bucketIndex === -1 ? bucketCounts.length - 1 : bucketIndex] = 1;
+	return bucketCounts.map(String);
+}
+
+function groupObservationsByMetric(
+	observations: readonly MetricObservation[],
+): Map<MetricName, MetricObservation[]> {
+	const grouped = new Map<MetricName, MetricObservation[]>();
+	for (const observation of observations) {
+		const metricObservations = grouped.get(observation.name) ?? [];
+		metricObservations.push(observation);
+		grouped.set(observation.name, metricObservations);
+	}
+	return grouped;
+}
+
+function observationLabelsToAttributes(
+	observation: MetricObservation,
+): OtlpAttribute[] {
+	return toAttributes(observation.labels);
+}
+
+function toNumberDataPoint(
+	observation: MetricObservation,
+): OtlpNumberDataPoint {
+	return {
+		attributes: observationLabelsToAttributes(observation),
+		asDouble: observation.value,
+		timeUnixNano: toTimeUnixNano(observation.timestampMs),
+	};
+}
+
+function toHistogramDataPoint(
+	observation: MetricObservation,
+): OtlpHistogramDataPoint {
+	return {
+		attributes: observationLabelsToAttributes(observation),
+		count: "1",
+		sum: observation.value,
+		bucketCounts: getHistogramBucketCounts(observation.value),
+		explicitBounds: HISTOGRAM_BUCKETS_MS,
+		timeUnixNano: toTimeUnixNano(observation.timestampMs),
+	};
+}
+
+function toOtlpMetric(
+	name: MetricName,
+	kind: MetricKind,
+	observations: readonly MetricObservation[],
+): OtlpMetric {
+	switch (kind) {
+		case "counter":
+			return {
+				name,
+				sum: {
+					aggregationTemporality: OTLP_AGGREGATION_TEMPORALITY_DELTA,
+					isMonotonic: true,
+					dataPoints: observations.map(toNumberDataPoint),
+				},
+			};
+		case "gauge":
+			return {
+				name,
+				gauge: {
+					dataPoints: observations.map(toNumberDataPoint),
+				},
+			};
+		case "histogram":
+			return {
+				name,
+				histogram: {
+					aggregationTemporality: OTLP_AGGREGATION_TEMPORALITY_DELTA,
+					dataPoints: observations.map(toHistogramDataPoint),
+				},
+			};
+	}
+}
+
+function normalizeOtlpMetricsEndpoint(endpoint: string): string {
+	const trimmed = endpoint.trim().replace(/\/+$/, "");
+	return trimmed.endsWith("/v1/metrics") ? trimmed : `${trimmed}/v1/metrics`;
+}
+
+function buildAuthorizationHeader(
+	config: Pick<GrafanaOtlpSinkConfig, "apiToken" | "authHeader" | "username">,
+): string | undefined {
+	if (config.authHeader) {
+		return config.authHeader;
+	}
+	if (config.username && config.apiToken) {
+		return `Basic ${encodeBase64(`${config.username}:${config.apiToken}`)}`;
+	}
+	return undefined;
+}
+
+function buildRequestHeaders(config: GrafanaOtlpSinkConfig): HeadersInit {
+	const authorization = buildAuthorizationHeader(config);
+	return authorization
+		? { ...JSON_HEADERS, Authorization: authorization }
+		: JSON_HEADERS;
+}
+
+export function toOtlpMetricsPayload(
+	payload: MetricsFlushPayload,
+): OtlpMetricsPayload {
+	const grouped = groupObservationsByMetric(payload.observations);
+
+	return {
+		resourceMetrics: [
+			{
+				resource: {
+					attributes: toAttributes(payload.resourceAttributes),
+				},
+				scopeMetrics: [
+					{
+						scope: { name: OTLP_SCOPE_NAME },
+						metrics: [...grouped.entries()].map(([name, observations]) =>
+							toOtlpMetric(name, observations[0].kind, observations),
+						),
+					},
+				],
+			},
+		],
+	};
+}
+
+export function resolveGrafanaOtlpSinkConfig(
+	env?: GrafanaOtlpEnvLike,
+): GrafanaOtlpSinkConfig | undefined {
+	const endpoint = readConfigValue(
+		env,
+		"GRAFANA_OTLP_METRICS_ENDPOINT",
+		"GRAFANA_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+	);
+	if (!endpoint) {
+		return undefined;
+	}
+
+	return {
+		endpoint: normalizeOtlpMetricsEndpoint(endpoint),
+		username: readConfigValue(
+			env,
+			"GRAFANA_OTLP_USERNAME",
+			"GRAFANA_CLOUD_ACCOUNT_ID",
+			"GRAFANA_CLOUD_INSTANCE_ID",
+		),
+		apiToken: readConfigValue(
+			env,
+			"GRAFANA_OTLP_API_TOKEN",
+			"GRAFANA_CLOUD_API_TOKEN",
+		),
+		authHeader:
+			readConfigValue(
+				env,
+				"GRAFANA_OTLP_AUTH_HEADER",
+				"OTEL_EXPORTER_OTLP_AUTH_HEADER",
+			) ?? readOtlpAuthorizationHeader(env),
+	};
+}
+
+export class GrafanaOtlpMetricsSink implements MetricsSink {
+	private readonly endpoint: string;
+	private readonly fetchFn: typeof fetch;
+	private readonly headers: HeadersInit;
+
+	constructor(options: GrafanaOtlpMetricsSinkOptions) {
+		this.endpoint = normalizeOtlpMetricsEndpoint(options.endpoint);
+		this.fetchFn = options.fetchFn ?? fetch;
+		this.headers = buildRequestHeaders(options);
+	}
+
+	async flush(payload: MetricsFlushPayload): Promise<void> {
+		if (payload.observations.length === 0) {
+			return;
+		}
+
+		const response = await this.fetchFn(this.endpoint, {
+			method: "POST",
+			headers: this.headers,
+			body: JSON.stringify(toOtlpMetricsPayload(payload)),
+		});
+
+		if (!response.ok) {
+			throw new Error(
+				`Grafana OTLP metrics export failed with status ${response.status}: ${await response.text()}`,
+			);
+		}
+	}
+}
+
+export function createGrafanaOtlpMetricsSink(
+	env?: GrafanaOtlpEnvLike,
+): GrafanaOtlpMetricsSink | undefined {
+	const config = resolveGrafanaOtlpSinkConfig(env);
+	return config ? new GrafanaOtlpMetricsSink(config) : undefined;
+}

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -4,6 +4,7 @@ import {
 	NOOP_METRICS_RECORDER,
 	RequestMetricsRecorder,
 } from "./metrics-recorder";
+import type { MetricsSink } from "./metrics-sink";
 import {
 	type ConfiguredMetricsSinks,
 	type MetricsEnvLike,
@@ -14,6 +15,7 @@ import {
 const METRICS_RECORDER_SYMBOL = Symbol.for(
 	"thoughtspot.mcp.metrics.requestRecorder",
 );
+const GRAFANA_SINK_CACHE = new WeakMap<object, MetricsSink>();
 
 type MetricsExecutionContext = ExecutionContext & {
 	[METRICS_RECORDER_SYMBOL]?: MetricsRecorder;
@@ -39,13 +41,32 @@ export function clearMetricsRecorderFromExecutionContext(
 	delete (ctx as MetricsExecutionContext)[METRICS_RECORDER_SYMBOL];
 }
 
+function getCachedGrafanaSink(
+	env: MetricsEnvLike | undefined,
+): MetricsSink | undefined {
+	if (!env || typeof env !== "object") {
+		return createGrafanaOtlpMetricsSink(env);
+	}
+
+	const cachedSink = GRAFANA_SINK_CACHE.get(env);
+	if (cachedSink) {
+		return cachedSink;
+	}
+
+	const sink = createGrafanaOtlpMetricsSink(env);
+	if (sink) {
+		GRAFANA_SINK_CACHE.set(env, sink);
+	}
+	return sink;
+}
+
 function createDefaultConfiguredMetricsSinks(
 	env: MetricsEnvLike | undefined,
 	sinks: ConfiguredMetricsSinks,
 ): ConfiguredMetricsSinks {
 	return {
 		analyticsEngineSink: sinks.analyticsEngineSink,
-		grafanaSink: sinks.grafanaSink ?? createGrafanaOtlpMetricsSink(env),
+		grafanaSink: sinks.grafanaSink ?? getCachedGrafanaSink(env),
 	};
 }
 

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -1,3 +1,4 @@
+import { createGrafanaOtlpMetricsSink } from "./grafana-otlp-sink";
 import {
 	type MetricsRecorder,
 	NOOP_METRICS_RECORDER,
@@ -38,13 +39,26 @@ export function clearMetricsRecorderFromExecutionContext(
 	delete (ctx as MetricsExecutionContext)[METRICS_RECORDER_SYMBOL];
 }
 
+function createDefaultConfiguredMetricsSinks(
+	env: MetricsEnvLike | undefined,
+	sinks: ConfiguredMetricsSinks,
+): ConfiguredMetricsSinks {
+	return {
+		analyticsEngineSink: sinks.analyticsEngineSink,
+		grafanaSink: sinks.grafanaSink ?? createGrafanaOtlpMetricsSink(env),
+	};
+}
+
 export function createRequestMetricsRecorder(
 	env?: MetricsEnvLike,
 	sinks: ConfiguredMetricsSinks = {},
 ): MetricsRecorder {
 	try {
 		const config = resolveMetricsRuntimeConfig(env);
-		const sink = createConfiguredMetricsSink(config, sinks);
+		const sink = createConfiguredMetricsSink(
+			config,
+			createDefaultConfiguredMetricsSinks(env, sinks),
+		);
 
 		return new RequestMetricsRecorder({
 			sink,

--- a/test/metrics/runtime/grafana-otlp-sink.spec.ts
+++ b/test/metrics/runtime/grafana-otlp-sink.spec.ts
@@ -111,6 +111,119 @@ describe("GrafanaOtlpMetricsSink", () => {
 		});
 	});
 
+	it("aggregates observations with identical attributes before export", () => {
+		const otlpPayload = toOtlpMetricsPayload({
+			observations: [
+				{
+					kind: "counter",
+					name: METRIC_NAMES.httpRequestsTotal,
+					value: 1,
+					labels: {
+						route_group: "mcp",
+						status_class: "2xx",
+					},
+					timestampMs: 1_714_000_000_100,
+				},
+				{
+					kind: "counter",
+					name: METRIC_NAMES.httpRequestsTotal,
+					value: 2,
+					labels: {
+						status_class: "2xx",
+						route_group: "mcp",
+					},
+					timestampMs: 1_714_000_000_123.456,
+				},
+				{
+					kind: "histogram",
+					name: METRIC_NAMES.httpRequestDurationMs,
+					value: 25,
+					labels: {
+						route_group: "mcp",
+					},
+					timestampMs: 1_714_000_000_200,
+				},
+				{
+					kind: "histogram",
+					name: METRIC_NAMES.httpRequestDurationMs,
+					value: 75,
+					labels: {
+						route_group: "mcp",
+					},
+					timestampMs: 1_714_000_000_201,
+				},
+				{
+					kind: "gauge",
+					name: METRIC_NAMES.httpInflightRequests,
+					value: 1,
+					labels: {
+						route_group: "mcp",
+					},
+					timestampMs: 1_714_000_000_300,
+				},
+				{
+					kind: "gauge",
+					name: METRIC_NAMES.httpInflightRequests,
+					value: 4,
+					labels: {
+						route_group: "mcp",
+					},
+					timestampMs: 1_714_000_000_301,
+				},
+			],
+			resourceAttributes: {},
+		});
+		const [counterMetric, histogramMetric, gaugeMetric] =
+			otlpPayload.resourceMetrics[0].scopeMetrics[0].metrics;
+
+		expect(counterMetric).toMatchObject({
+			sum: {
+				dataPoints: [
+					{
+						asDouble: 3,
+						timeUnixNano: "1714000000123456000",
+					},
+				],
+			},
+		});
+		expect(counterMetric.sum.dataPoints).toHaveLength(1);
+		expect(histogramMetric).toMatchObject({
+			histogram: {
+				dataPoints: [
+					{
+						count: "2",
+						sum: 100,
+						bucketCounts: [
+							"1",
+							"0",
+							"1",
+							"0",
+							"0",
+							"0",
+							"0",
+							"0",
+							"0",
+							"0",
+							"0",
+						],
+					},
+				],
+			},
+		});
+		expect(histogramMetric.histogram.dataPoints).toHaveLength(1);
+		expect(gaugeMetric).toMatchObject({
+			gauge: {
+				dataPoints: [
+					{
+						asDouble: 4,
+						timeUnixNano: "1714000000301000000",
+					},
+				],
+			},
+		});
+		expect(gaugeMetric.gauge.dataPoints).toHaveLength(1);
+	});
+
 	it("posts OTLP JSON to the normalized metrics endpoint", async () => {
 		const fetchFn = vi
 			.fn()

--- a/test/metrics/runtime/grafana-otlp-sink.spec.ts
+++ b/test/metrics/runtime/grafana-otlp-sink.spec.ts
@@ -274,6 +274,30 @@ describe("GrafanaOtlpMetricsSink", () => {
 		);
 	});
 
+	it("encodes Grafana Cloud Basic auth credentials as UTF-8", async () => {
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(new Response(null, { status: 200 }));
+		const sink = new GrafanaOtlpMetricsSink({
+			endpoint: "https://otlp.example.com/otlp",
+			username: "üser",
+			apiToken: "päss",
+			fetchFn,
+		});
+
+		await sink.flush(payload);
+
+		expect(fetchFn).toHaveBeenCalledWith(
+			"https://otlp.example.com/otlp/v1/metrics",
+			expect.objectContaining({
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Basic w7xzZXI6cMOkc3M=",
+				},
+			}),
+		);
+	});
+
 	it("skips export when there are no observations", async () => {
 		const fetchFn = vi.fn();
 		const sink = new GrafanaOtlpMetricsSink({
@@ -297,6 +321,20 @@ describe("GrafanaOtlpMetricsSink", () => {
 
 		await expect(sink.flush(payload)).rejects.toThrow(
 			"Grafana OTLP metrics export failed with status 401: bad token",
+		);
+	});
+
+	it("truncates large export error bodies", async () => {
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(new Response("x".repeat(1_010), { status: 500 }));
+		const sink = new GrafanaOtlpMetricsSink({
+			endpoint: "https://otlp.example.com",
+			fetchFn,
+		});
+
+		await expect(sink.flush(payload)).rejects.toThrow(
+			`Grafana OTLP metrics export failed with status 500: ${"x".repeat(1_000)}...`,
 		);
 	});
 

--- a/test/metrics/runtime/grafana-otlp-sink.spec.ts
+++ b/test/metrics/runtime/grafana-otlp-sink.spec.ts
@@ -132,7 +132,7 @@ describe("GrafanaOtlpMetricsSink", () => {
 						status_class: "2xx",
 						route_group: "mcp",
 					},
-					timestampMs: 1_714_000_000_123.456,
+					timestampMs: 1_714_000_000_123.5,
 				},
 				{
 					kind: "histogram",
@@ -181,7 +181,7 @@ describe("GrafanaOtlpMetricsSink", () => {
 				dataPoints: [
 					{
 						asDouble: 3,
-						timeUnixNano: "1714000000123456000",
+						timeUnixNano: "1714000000123500000",
 					},
 				],
 			},
@@ -222,6 +222,34 @@ describe("GrafanaOtlpMetricsSink", () => {
 			},
 		});
 		expect(gaugeMetric.gauge.dataPoints).toHaveLength(1);
+	});
+
+	it("keeps nanosecond precision when fractional milliseconds round up a microsecond", () => {
+		const otlpPayload = toOtlpMetricsPayload({
+			observations: [
+				{
+					kind: "counter",
+					name: METRIC_NAMES.httpRequestsTotal,
+					value: 1,
+					labels: {
+						route_group: "mcp",
+					},
+					timestampMs: 1_714_000_000_123.9995,
+				},
+			],
+			resourceAttributes: {},
+		});
+		const [metric] = otlpPayload.resourceMetrics[0].scopeMetrics[0].metrics;
+
+		expect(metric).toMatchObject({
+			sum: {
+				dataPoints: [
+					{
+						timeUnixNano: "1714000000123999512",
+					},
+				],
+			},
+		});
 	});
 
 	it("posts OTLP JSON to the normalized metrics endpoint", async () => {
@@ -334,7 +362,7 @@ describe("GrafanaOtlpMetricsSink", () => {
 		});
 
 		await expect(sink.flush(payload)).rejects.toThrow(
-			`Grafana OTLP metrics export failed with status 500: ${"x".repeat(1_000)}...`,
+			`Grafana OTLP metrics export failed with status 500: ${"x".repeat(997)}...`,
 		);
 	});
 

--- a/test/metrics/runtime/grafana-otlp-sink.spec.ts
+++ b/test/metrics/runtime/grafana-otlp-sink.spec.ts
@@ -302,7 +302,7 @@ describe("GrafanaOtlpMetricsSink", () => {
 		);
 	});
 
-	it("encodes Grafana Cloud Basic auth credentials as UTF-8", async () => {
+	it("encodes Basic auth credentials as UTF-8", async () => {
 		const fetchFn = vi
 			.fn()
 			.mockResolvedValue(new Response(null, { status: 200 }));
@@ -366,12 +366,12 @@ describe("GrafanaOtlpMetricsSink", () => {
 		);
 	});
 
-	it("resolves config from Grafana and OTLP environment names", () => {
+	it("resolves config from canonical Grafana environment names", () => {
 		expect(
 			resolveGrafanaOtlpSinkConfig({
 				GRAFANA_OTLP_ENDPOINT: "https://otlp.example.com/otlp",
-				GRAFANA_CLOUD_ACCOUNT_ID: "12345",
-				GRAFANA_CLOUD_API_TOKEN: "test-api-token",
+				GRAFANA_OTLP_USERNAME: "12345",
+				GRAFANA_OTLP_API_TOKEN: "test-api-token",
 			}),
 		).toEqual({
 			endpoint: "https://otlp.example.com/otlp/v1/metrics",
@@ -381,24 +381,23 @@ describe("GrafanaOtlpMetricsSink", () => {
 		});
 		expect(
 			resolveGrafanaOtlpSinkConfig({
-				OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example.com",
+				GRAFANA_OTLP_ENDPOINT: "https://collector.example.com",
+				GRAFANA_OTLP_AUTH_HEADER: "Bearer test",
 			}),
 		).toMatchObject({
 			endpoint: "https://collector.example.com/v1/metrics",
+			authHeader: "Bearer test",
 		});
 		expect(resolveGrafanaOtlpSinkConfig()).toBeUndefined();
 	});
 
-	it("supports Grafana Cloud generated OTLP headers", () => {
+	it("ignores non-canonical OTLP environment names", () => {
 		expect(
 			resolveGrafanaOtlpSinkConfig({
 				OTEL_EXPORTER_OTLP_ENDPOINT: "https://otlp.example.com/otlp",
 				OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic%20abc123",
 			}),
-		).toMatchObject({
-			endpoint: "https://otlp.example.com/otlp/v1/metrics",
-			authHeader: "Basic abc123",
-		});
+		).toBeUndefined();
 	});
 
 	it("only creates a sink when an OTLP endpoint is configured", () => {

--- a/test/metrics/runtime/grafana-otlp-sink.spec.ts
+++ b/test/metrics/runtime/grafana-otlp-sink.spec.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	GrafanaOtlpMetricsSink,
+	createGrafanaOtlpMetricsSink,
+	resolveGrafanaOtlpSinkConfig,
+	toOtlpMetricsPayload,
+} from "../../../src/metrics/runtime/grafana-otlp-sink";
+import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
+import type { MetricsFlushPayload } from "../../../src/metrics/runtime/metrics-sink";
+
+describe("GrafanaOtlpMetricsSink", () => {
+	const payload = {
+		observations: [
+			{
+				kind: "counter",
+				name: METRIC_NAMES.httpRequestsTotal,
+				value: 1,
+				labels: {
+					route_group: "mcp",
+					status_class: "2xx",
+				},
+				timestampMs: 1_714_000_000_000,
+			},
+			{
+				kind: "histogram",
+				name: METRIC_NAMES.httpRequestDurationMs,
+				value: 123,
+				labels: {
+					route_group: "mcp",
+				},
+				timestampMs: 1_714_000_000_123,
+			},
+			{
+				kind: "gauge",
+				name: METRIC_NAMES.httpInflightRequests,
+				value: 3,
+				labels: {},
+				timestampMs: 1_714_000_000_456,
+			},
+		],
+		resourceAttributes: {
+			"deployment.environment": "production",
+			"service.name": "thoughtspot-mcp-server",
+			"service.namespace": "thoughtspot",
+		},
+	} satisfies MetricsFlushPayload;
+
+	it("maps observations into OTLP JSON metrics payloads", () => {
+		const otlpPayload = toOtlpMetricsPayload(payload);
+		const metrics = otlpPayload.resourceMetrics[0].scopeMetrics[0].metrics;
+
+		expect(otlpPayload.resourceMetrics[0].resource.attributes).toEqual([
+			{
+				key: "deployment.environment",
+				value: { stringValue: "production" },
+			},
+			{
+				key: "service.name",
+				value: { stringValue: "thoughtspot-mcp-server" },
+			},
+			{ key: "service.namespace", value: { stringValue: "thoughtspot" } },
+		]);
+		expect(metrics).toHaveLength(3);
+		expect(metrics[0]).toMatchObject({
+			name: METRIC_NAMES.httpRequestsTotal,
+			sum: {
+				aggregationTemporality: 1,
+				isMonotonic: true,
+				dataPoints: [
+					{
+						asDouble: 1,
+						timeUnixNano: "1714000000000000000",
+						attributes: [
+							{ key: "route_group", value: { stringValue: "mcp" } },
+							{ key: "status_class", value: { stringValue: "2xx" } },
+						],
+					},
+				],
+			},
+		});
+		expect(metrics[1]).toMatchObject({
+			name: METRIC_NAMES.httpRequestDurationMs,
+			histogram: {
+				aggregationTemporality: 1,
+				dataPoints: [
+					{
+						count: "1",
+						sum: 123,
+						bucketCounts: [
+							"0",
+							"0",
+							"0",
+							"1",
+							"0",
+							"0",
+							"0",
+							"0",
+							"0",
+							"0",
+							"0",
+						],
+					},
+				],
+			},
+		});
+		expect(metrics[2]).toMatchObject({
+			name: METRIC_NAMES.httpInflightRequests,
+			gauge: {
+				dataPoints: [{ asDouble: 3 }],
+			},
+		});
+	});
+
+	it("posts OTLP JSON to the normalized metrics endpoint", async () => {
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(new Response(null, { status: 200 }));
+		const sink = new GrafanaOtlpMetricsSink({
+			endpoint: "https://otlp.example.com/otlp",
+			username: "12345",
+			apiToken: "secret",
+			fetchFn,
+		});
+
+		await sink.flush(payload);
+
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+		expect(fetchFn).toHaveBeenCalledWith(
+			"https://otlp.example.com/otlp/v1/metrics",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Basic MTIzNDU6c2VjcmV0",
+				},
+				body: expect.any(String),
+			}),
+		);
+	});
+
+	it("supports full metrics endpoints and explicit auth headers", async () => {
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(new Response(null, { status: 200 }));
+		const sink = new GrafanaOtlpMetricsSink({
+			endpoint: "https://otlp.example.com/v1/metrics",
+			authHeader: "Bearer token",
+			fetchFn,
+		});
+
+		await sink.flush(payload);
+
+		expect(fetchFn).toHaveBeenCalledWith(
+			"https://otlp.example.com/v1/metrics",
+			expect.objectContaining({
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer token",
+				},
+			}),
+		);
+	});
+
+	it("skips export when there are no observations", async () => {
+		const fetchFn = vi.fn();
+		const sink = new GrafanaOtlpMetricsSink({
+			endpoint: "https://otlp.example.com",
+			fetchFn,
+		});
+
+		await sink.flush({ observations: [], resourceAttributes: {} });
+
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	it("throws on non-2xx responses so the recorder can isolate failures", async () => {
+		const fetchFn = vi
+			.fn()
+			.mockResolvedValue(new Response("bad token", { status: 401 }));
+		const sink = new GrafanaOtlpMetricsSink({
+			endpoint: "https://otlp.example.com",
+			fetchFn,
+		});
+
+		await expect(sink.flush(payload)).rejects.toThrow(
+			"Grafana OTLP metrics export failed with status 401: bad token",
+		);
+	});
+
+	it("resolves config from Grafana and OTLP environment names", () => {
+		expect(
+			resolveGrafanaOtlpSinkConfig({
+				GRAFANA_OTLP_ENDPOINT: "https://otlp.example.com/otlp",
+				GRAFANA_CLOUD_ACCOUNT_ID: "12345",
+				GRAFANA_CLOUD_API_TOKEN: "test-api-token",
+			}),
+		).toEqual({
+			endpoint: "https://otlp.example.com/otlp/v1/metrics",
+			username: "12345",
+			apiToken: "test-api-token",
+			authHeader: undefined,
+		});
+		expect(
+			resolveGrafanaOtlpSinkConfig({
+				OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example.com",
+			}),
+		).toMatchObject({
+			endpoint: "https://collector.example.com/v1/metrics",
+		});
+		expect(resolveGrafanaOtlpSinkConfig()).toBeUndefined();
+	});
+
+	it("supports Grafana Cloud generated OTLP headers", () => {
+		expect(
+			resolveGrafanaOtlpSinkConfig({
+				OTEL_EXPORTER_OTLP_ENDPOINT: "https://otlp.example.com/otlp",
+				OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic%20abc123",
+			}),
+		).toMatchObject({
+			endpoint: "https://otlp.example.com/otlp/v1/metrics",
+			authHeader: "Basic abc123",
+		});
+	});
+
+	it("only creates a sink when an OTLP endpoint is configured", () => {
+		expect(
+			createGrafanaOtlpMetricsSink({
+				GRAFANA_OTLP_ENDPOINT: "https://otlp.example.com",
+			}),
+		).toBeInstanceOf(GrafanaOtlpMetricsSink);
+		expect(createGrafanaOtlpMetricsSink({})).toBeUndefined();
+	});
+});

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -194,6 +194,34 @@ describe("withRequestMetrics", () => {
 		);
 	});
 
+	it("uses Grafana OTLP config as the default grafana sink", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(null, { status: 200 }));
+		const recorder = createRequestMetricsRecorder({
+			METRICS_SINK_MODE: "grafana",
+			GRAFANA_OTLP_ENDPOINT: "https://otlp.example.com/otlp",
+			GRAFANA_OTLP_AUTH_HEADER: "Bearer test",
+		});
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+			route_group: "mcp",
+		});
+		await recorder.flush();
+
+		expect(fetchSpy).toHaveBeenCalledWith(
+			"https://otlp.example.com/otlp/v1/metrics",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer test",
+				},
+				body: expect.any(String),
+			}),
+		);
+	});
+
 	it("does not fail the request when waitUntil rejects scheduling", async () => {
 		const errorSpy = vi
 			.spyOn(console, "error")

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -283,6 +283,46 @@ describe("withRequestMetrics", () => {
 		);
 	});
 
+	it("reuses the default Grafana sink for the same env object", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(null, { status: 200 }));
+		const env = {
+			METRICS_SINK_MODE: "grafana",
+			GRAFANA_OTLP_ENDPOINT: "https://otlp.example.com/first",
+			GRAFANA_OTLP_AUTH_HEADER: "Bearer first",
+		};
+		const firstRecorder = createRequestMetricsRecorder(env);
+
+		env.GRAFANA_OTLP_ENDPOINT = "https://otlp.example.com/second";
+		env.GRAFANA_OTLP_AUTH_HEADER = "Bearer second";
+		const secondRecorder = createRequestMetricsRecorder(env);
+
+		firstRecorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+			route_group: "mcp",
+		});
+		secondRecorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+			route_group: "mcp",
+		});
+		await firstRecorder.flush();
+		await secondRecorder.flush();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect(fetchSpy).toHaveBeenCalledWith(
+			"https://otlp.example.com/first/v1/metrics",
+			expect.objectContaining({
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer first",
+				},
+			}),
+		);
+		expect(fetchSpy).not.toHaveBeenCalledWith(
+			"https://otlp.example.com/second/v1/metrics",
+			expect.anything(),
+		);
+	});
+
 	it("supports setting and clearing the recorder on the execution context", () => {
 		const ctx = {} as ExecutionContext;
 		const recorder = createRequestMetricsRecorder();


### PR DESCRIPTION
## Summary

Add the direct Grafana OTLP/HTTP sink for low-cardinality MCP service metrics. This keeps PR 3 independent from the Analytics Engine sink so it can be reviewed and merged in parallel.

## What Changed

- add a Grafana OTLP metrics sink that emits OTLP JSON over HTTP
- convert counters, gauges, and histograms into OTLP metric datapoints
- normalize OTLP endpoints to `/v1/metrics`
- support Grafana Cloud Basic auth and explicit OTLP auth headers
- wire request metrics to build the Grafana sink from env config
- test payload mapping, endpoint config, auth headers, and failure behavior

## Semantics

The sink sends delta sums and histograms because request-scoped observations are emitted as per-flush deltas. Export failures are surfaced to the recorder, where the existing metrics flush isolation logs and drops them without changing business responses.