### PR TITLE
Store messages in separate keys in DurableObject KV store

### DIFF
--- a/src/servers/conversation-storage-server.ts
+++ b/src/servers/conversation-storage-server.ts
@@ -1,9 +1,12 @@
+import { isBoolean, isNumber } from "lodash";
 import type { Message, StreamingMessagesState } from "../thoughtspot/types";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
-const STATE_KEY = "streaming-messages-state";
-const BOOKMARK_KEY = "streaming-messages-bookmark";
+const MESSAGE_KEY_PREFIX = "message-";
+const IS_DONE_KEY = "is-done";
+const WRITE_BOOKMARK_KEY = "write-bookmark";
+const READ_BOOKMARK_KEY = "read-bookmark";
 
 /**
  * A Durable Object that stores streaming conversation messages and exposes them over HTTP.
@@ -18,6 +21,8 @@ const BOOKMARK_KEY = "streaming-messages-bookmark";
  *   GET   /storage/<conversation-id>/messages   —> getNewMessagesAndUpdateBookmark
  */
 export class ConversationStorageServer {
+	private conversationId = "";
+
 	constructor(
 		private state: DurableObjectState,
 		private env: Env,
@@ -29,6 +34,7 @@ export class ConversationStorageServer {
 		// e.g. /storage/abc123/initialize -> /initialize
 		const parts = url.pathname.split("/");
 		// parts: ["", "storage", "<conversationId>", "<operation>"]
+		this.conversationId = parts[2];
 		const operation = parts[3] ?? "";
 
 		try {
@@ -54,76 +60,139 @@ export class ConversationStorageServer {
 			}
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			console.error("Error handling conversation storage request:", message);
+			console.error(
+				`Error handling conversation storage request for conversation ${this.conversationId}:`,
+				message,
+			);
 			return Response.json({ error: "Something went wrong" }, { status: 500 });
 		}
 	}
 
 	/*
 	 * Initialize the conversation. This can be a brand new conversation, or it can be priming an
-	 * existing conversation which is already marked done for a followup message.
+	 * existing conversation which is already marked done for a followup message. We never delete
+	 * messages in the conversation, instead the next messages begin at the existing bookmark.
 	 */
 	private async initializeConversation(): Promise<void> {
-		const existing =
-			await this.state.storage.get<StreamingMessagesState>(STATE_KEY);
-		if (existing && !existing.isDone) {
-			throw new Error("Conversation already exists and is not marked done");
+		const existingIsDone = await this.state.storage.get<boolean>(IS_DONE_KEY);
+		if (isBoolean(existingIsDone) && !existingIsDone) {
+			throw new Error(
+				`Conversation ${this.conversationId} already exists and is not marked done`,
+			);
 		}
 
-		await this.setStateAndRestartTtl({ messages: [], isDone: false });
-		await this.state.storage.put<number>(BOOKMARK_KEY, 0);
+		await this.state.storage.put<boolean>(IS_DONE_KEY, false);
+		await this.restartTtl();
 	}
 
+	/*
+	 * Append new messages to the conversation, starting at the current state of WRITE_BOOKMARK and
+	 * saving the new state of WRITE_BOOKMARK after. We write the isDone flag state after writing
+	 * all messages, so that if a reader is executing concurrently, they will never think the
+	 * conversation is done without having already seen all messages. We also restart the TTL for
+	 * the conversation after all writes are done.
+	 */
 	private async appendMessagesAndRestartTtl(
 		newMessages: Message[],
 		isDone = false,
 	): Promise<void> {
-		const oldState =
-			await this.state.storage.get<StreamingMessagesState>(STATE_KEY);
-		if (!oldState) {
-			throw new Error("Conversation not found");
+		const existingIsDone = await this.state.storage.get<boolean>(IS_DONE_KEY);
+		if (!isBoolean(existingIsDone)) {
+			throw new Error(`Conversation ${this.conversationId} not found`);
 		}
-		if (oldState.isDone) {
-			throw new Error("Cannot append messages to a conversation marked done");
+		if (existingIsDone) {
+			throw new Error(
+				`Cannot append messages to conversation ${this.conversationId} marked done`,
+			);
 		}
 
-		await this.setStateAndRestartTtl({
-			messages: [...oldState.messages, ...newMessages],
-			isDone,
-		});
+		let idx = (await this.state.storage.get<number>(WRITE_BOOKMARK_KEY)) ?? 0;
+		for (const message of newMessages) {
+			await this.state.storage.put<Message>(
+				`${MESSAGE_KEY_PREFIX}${idx}`,
+				message,
+			);
+			idx++;
+		}
+		await this.state.storage.put<number>(WRITE_BOOKMARK_KEY, idx);
+
+		if (isDone) {
+			await this.state.storage.put<boolean>(IS_DONE_KEY, true);
+		}
+
+		await this.restartTtl();
 	}
 
+	/*
+	 * Retrieve all new messages since the last time this was called. We use a READ_BOOKMARK to
+	 * track the index of the last returned message, and update it when returning new messages. We
+	 * read the isDone flag state before reading messages, so that if a writer is executing
+	 * concurrently, we will only see isDone=true if all messages have already been written. Note
+	 * that we don't restart the TTL here, since it is only meant to be based on writes.
+	 */
 	private async getNewMessagesAndUpdateBookmark(): Promise<StreamingMessagesState> {
-		const bookmark = (await this.state.storage.get<number>(BOOKMARK_KEY)) ?? 0;
-
-		const conversationState =
-			await this.state.storage.get<StreamingMessagesState>(STATE_KEY);
-		if (!conversationState) {
-			throw new Error("Conversation not found");
+		const isDone = await this.state.storage.get<boolean>(IS_DONE_KEY);
+		if (!isBoolean(isDone)) {
+			throw new Error(`Conversation ${this.conversationId} not found`);
 		}
 
-		await this.state.storage.put<number>(
-			BOOKMARK_KEY,
-			conversationState.messages.length,
-		);
+		let bookmark =
+			(await this.state.storage.get<number>(READ_BOOKMARK_KEY)) ?? 0;
+		const newMessages: Message[] = [];
+		while (true) {
+			const message = await this.state.storage.get<Message>(
+				`${MESSAGE_KEY_PREFIX}${bookmark}`,
+			);
+			if (!message) {
+				break;
+			}
+			newMessages.push(message);
+			bookmark++;
+		}
+		await this.state.storage.put<number>(READ_BOOKMARK_KEY, bookmark);
 
 		return {
-			messages: conversationState.messages.slice(bookmark),
-			isDone: conversationState.isDone,
+			messages: newMessages,
+			isDone,
 		};
 	}
 
-	private async setStateAndRestartTtl(
-		newState: StreamingMessagesState,
-	): Promise<void> {
+	private async restartTtl(): Promise<void> {
 		// Cancel any existing alarm and schedule a fresh one
 		await this.state.storage.deleteAlarm();
 		await this.state.storage.setAlarm(Date.now() + DEFAULT_TTL_MS);
-
-		await this.state.storage.put<StreamingMessagesState>(STATE_KEY, newState);
 	}
 
 	async alarm(): Promise<void> {
-		await this.state.storage.delete([STATE_KEY, BOOKMARK_KEY]);
+		// Check for any abnormalities in the state prior to deleting
+		const isDone = await this.state.storage.get<boolean>(IS_DONE_KEY);
+		if (!isBoolean(isDone) || !isDone) {
+			console.warn(
+				`Conversation ${this.conversationId} expired without being marked done`,
+				{
+					isDone,
+				},
+			);
+		}
+		const writeBookmark =
+			await this.state.storage.get<number>(WRITE_BOOKMARK_KEY);
+		const readBookmark =
+			await this.state.storage.get<number>(READ_BOOKMARK_KEY);
+		if (!isNumber(writeBookmark)) {
+			console.warn(
+				`Conversation ${this.conversationId} expired without any messages written`,
+			);
+		} else if (!isNumber(readBookmark) || writeBookmark !== readBookmark) {
+			console.warn(
+				`Conversation ${this.conversationId} expired with unread messages`,
+				{
+					writeBookmark,
+					readBookmark,
+				},
+			);
+		}
+
+		// Delete everything in storage
+		await this.state.storage.deleteAll();
 	}
 }

--- a/test/servers/conversation-storage-server.spec.ts
+++ b/test/servers/conversation-storage-server.spec.ts
@@ -36,6 +36,9 @@ function createMockStorage() {
 			deleteAlarm: vi.fn(async (): Promise<void> => {
 				alarm = null;
 			}),
+			deleteAll: vi.fn(async (): Promise<void> => {
+				store.clear();
+			}),
 		},
 	};
 }
@@ -59,14 +62,23 @@ function makeRequest(
 }
 
 // Sample messages
-const textMessage: Message = { type: "text", text: "Hello" };
-const chunkMessage: Message = { type: "text_chunk", text: " world" };
+const textMessage: Message = {
+	type: "text",
+	text: "Hello",
+	is_thinking: false,
+};
+const chunkMessage: Message = {
+	type: "text_chunk",
+	text: " world",
+	is_thinking: false,
+};
 const answerMessage: Message = {
 	type: "answer",
 	answer_id: "ans-1",
 	answer_title: "My Answer",
 	answer_query: "SELECT 1",
 	iframe_url: "https://example.com/answer/1",
+	is_thinking: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -112,16 +124,17 @@ describe("ConversationStorageServer", () => {
 		it("stores empty messages and isDone=false", async () => {
 			await server.fetch(makeRequest("POST", "initialize"));
 
-			const state = mock.store.get(
-				"streaming-messages-state",
-			) as StreamingMessagesState;
-			expect(state).toMatchObject({ messages: [], isDone: false });
+			expect(mock.store.get("is-done")).toBe(false);
+			// No message keys should exist yet
+			expect(mock.store.has("message-0")).toBe(false);
 		});
 
 		it("sets bookmark to 0", async () => {
 			await server.fetch(makeRequest("POST", "initialize"));
 
-			expect(mock.store.get("streaming-messages-bookmark")).toBe(0);
+			// write-bookmark and read-bookmark are lazily initialised to 0
+			expect(mock.store.get("write-bookmark") ?? 0).toBe(0);
+			expect(mock.store.get("read-bookmark") ?? 0).toBe(0);
 		});
 
 		it("schedules a TTL alarm", async () => {
@@ -152,10 +165,7 @@ describe("ConversationStorageServer", () => {
 			const res = await server.fetch(makeRequest("POST", "initialize"));
 			expect(res.status).toBe(200);
 
-			const state = mock.store.get(
-				"streaming-messages-state",
-			) as StreamingMessagesState;
-			expect(state).toMatchObject({ messages: [], isDone: false });
+			expect(mock.store.get("is-done")).toBe(false);
 		});
 	});
 
@@ -182,10 +192,8 @@ describe("ConversationStorageServer", () => {
 				makeRequest("POST", "append", { messages: [textMessage] }),
 			);
 
-			const state = mock.store.get(
-				"streaming-messages-state",
-			) as StreamingMessagesState;
-			expect(state.messages).toEqual([textMessage]);
+			expect(mock.store.get("message-0")).toEqual(textMessage);
+			expect(mock.store.get("write-bookmark")).toBe(1);
 		});
 
 		it("accumulates messages across multiple calls", async () => {
@@ -198,14 +206,10 @@ describe("ConversationStorageServer", () => {
 				}),
 			);
 
-			const state = mock.store.get(
-				"streaming-messages-state",
-			) as StreamingMessagesState;
-			expect(state.messages).toEqual([
-				textMessage,
-				chunkMessage,
-				answerMessage,
-			]);
+			expect(mock.store.get("message-0")).toEqual(textMessage);
+			expect(mock.store.get("message-1")).toEqual(chunkMessage);
+			expect(mock.store.get("message-2")).toEqual(answerMessage);
+			expect(mock.store.get("write-bookmark")).toBe(3);
 		});
 
 		it("marks the conversation done when isDone is true", async () => {
@@ -216,10 +220,7 @@ describe("ConversationStorageServer", () => {
 				}),
 			);
 
-			const state = mock.store.get(
-				"streaming-messages-state",
-			) as StreamingMessagesState;
-			expect(state.isDone).toBe(true);
+			expect(mock.store.get("is-done")).toBe(true);
 		});
 
 		it("restarts the TTL alarm on each call", async () => {
@@ -345,8 +346,10 @@ describe("ConversationStorageServer", () => {
 		it("deletes the conversation state and bookmark", async () => {
 			await server.alarm();
 
-			expect(mock.store.has("streaming-messages-state")).toBe(false);
-			expect(mock.store.has("streaming-messages-bookmark")).toBe(false);
+			expect(mock.store.has("is-done")).toBe(false);
+			expect(mock.store.has("message-0")).toBe(false);
+			expect(mock.store.has("write-bookmark")).toBe(false);
+			expect(mock.store.has("read-bookmark")).toBe(false);
 		});
 
 		it("causes subsequent append to return 500", async () => {


### PR DESCRIPTION
- Each value has a maximum of 131072 bytes, and we are running into that limit in real world scenarios
- Instead of storing the full conversation in a single key, split each message into its own key, giving us much higher storage
- Update tests