### PR TITLE
SCAL-309983 Harden metrics request isolation

### DIFF
--- a/src/metrics/runtime/metrics-recorder.ts
+++ b/src/metrics/runtime/metrics-recorder.ts
@@ -21,7 +21,7 @@ export interface MetricsRecorder {
 	count(name: MetricName, value?: number, labels?: MetricLabelInput): void;
 	histogram(name: MetricName, value: number, labels?: MetricLabelInput): void;
 	gauge(name: MetricName, value: number, labels?: MetricLabelInput): void;
-	flush(ctx?: Pick<ExecutionContext, "waitUntil">): Promise<void>;
+	flush(): Promise<void>;
 	snapshot(): readonly MetricObservation[];
 }
 
@@ -48,13 +48,9 @@ export class RequestMetricsRecorder implements MetricsRecorder {
 		return [...this.observations];
 	}
 
-	async flush(ctx?: Pick<ExecutionContext, "waitUntil">): Promise<void> {
+	flush(): Promise<void> {
 		if (!this.flushPromise) {
 			this.flushPromise = this.flushInternal();
-		}
-
-		if (ctx) {
-			ctx.waitUntil(this.flushPromise);
 		}
 
 		return this.flushPromise;

--- a/src/metrics/runtime/metrics-recorder.ts
+++ b/src/metrics/runtime/metrics-recorder.ts
@@ -25,6 +25,21 @@ export interface MetricsRecorder {
 	snapshot(): readonly MetricObservation[];
 }
 
+const NOOP_FLUSH_PROMISE: Promise<void> = Promise.resolve();
+const NOOP_METRIC_OBSERVATIONS: readonly MetricObservation[] = [];
+
+export const NOOP_METRICS_RECORDER: MetricsRecorder = {
+	count(_name, _value, _labels): void {},
+	histogram(_name, _value, _labels): void {},
+	gauge(_name, _value, _labels): void {},
+	flush(): Promise<void> {
+		return NOOP_FLUSH_PROMISE;
+	},
+	snapshot(): readonly MetricObservation[] {
+		return NOOP_METRIC_OBSERVATIONS;
+	},
+};
+
 export class RequestMetricsRecorder implements MetricsRecorder {
 	private readonly observations: MetricObservation[] = [];
 	private flushPromise?: Promise<void>;

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -2,6 +2,7 @@ import {
 	type MetricsRecorder,
 	RequestMetricsRecorder,
 } from "./metrics-recorder";
+import { NoopMetricsSink } from "./noop-sink";
 import {
 	type ConfiguredMetricsSinks,
 	type MetricsEnvLike,
@@ -41,13 +42,45 @@ export function createRequestMetricsRecorder(
 	env?: MetricsEnvLike,
 	sinks: ConfiguredMetricsSinks = {},
 ): RequestMetricsRecorder {
-	const config = resolveMetricsRuntimeConfig(env);
-	const sink = createConfiguredMetricsSink(config, sinks);
+	try {
+		const config = resolveMetricsRuntimeConfig(env);
+		const sink = createConfiguredMetricsSink(config, sinks);
 
-	return new RequestMetricsRecorder({
-		sink,
-		resourceAttributes: config.resourceAttributes,
-	});
+		return new RequestMetricsRecorder({
+			sink,
+			resourceAttributes: config.resourceAttributes,
+		});
+	} catch (error) {
+		console.error(
+			"[metrics] Failed to initialize request metrics recorder; using noop sink",
+			error,
+		);
+		return new RequestMetricsRecorder({
+			sink: new NoopMetricsSink(),
+			resourceAttributes: {},
+		});
+	}
+}
+
+function scheduleRequestMetricsFlush(
+	recorder: MetricsRecorder,
+	ctx: ExecutionContext,
+): void {
+	let flushPromise: Promise<void>;
+	try {
+		flushPromise = recorder.flush().catch((error) => {
+			console.error("[metrics] Failed to execute request metrics flush", error);
+		});
+	} catch (error) {
+		console.error("[metrics] Failed to execute request metrics flush", error);
+		return;
+	}
+
+	try {
+		ctx.waitUntil(flushPromise);
+	} catch (error) {
+		console.error("[metrics] Failed to schedule request metrics flush", error);
+	}
 }
 
 export async function withRequestMetrics<T>(
@@ -62,7 +95,7 @@ export async function withRequestMetrics<T>(
 	try {
 		return await handler(recorder);
 	} finally {
-		await recorder.flush(ctx);
+		scheduleRequestMetricsFlush(recorder, ctx);
 		clearMetricsRecorderFromExecutionContext(ctx);
 	}
 }

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -1,8 +1,8 @@
 import {
 	type MetricsRecorder,
+	NOOP_METRICS_RECORDER,
 	RequestMetricsRecorder,
 } from "./metrics-recorder";
-import { NoopMetricsSink } from "./noop-sink";
 import {
 	type ConfiguredMetricsSinks,
 	type MetricsEnvLike,
@@ -41,7 +41,7 @@ export function clearMetricsRecorderFromExecutionContext(
 export function createRequestMetricsRecorder(
 	env?: MetricsEnvLike,
 	sinks: ConfiguredMetricsSinks = {},
-): RequestMetricsRecorder {
+): MetricsRecorder {
 	try {
 		const config = resolveMetricsRuntimeConfig(env);
 		const sink = createConfiguredMetricsSink(config, sinks);
@@ -52,13 +52,10 @@ export function createRequestMetricsRecorder(
 		});
 	} catch (error) {
 		console.error(
-			"[metrics] Failed to initialize request metrics recorder; using noop sink",
+			"[metrics] Failed to initialize request metrics recorder; using noop recorder",
 			error,
 		);
-		return new RequestMetricsRecorder({
-			sink: new NoopMetricsSink(),
-			resourceAttributes: {},
-		});
+		return NOOP_METRICS_RECORDER;
 	}
 }
 

--- a/test/metrics/runtime/metrics-recorder.spec.ts
+++ b/test/metrics/runtime/metrics-recorder.spec.ts
@@ -60,19 +60,28 @@ describe("RequestMetricsRecorder", () => {
 		});
 	});
 
-	it("schedules the flush with waitUntil when an execution context is provided", async () => {
+	it("returns the same in-flight flush promise when called repeatedly", async () => {
+		let resolveFlush!: () => void;
 		const flushSpy = vi.fn().mockResolvedValue(undefined);
-		const waitUntil = vi.fn();
+		flushSpy.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveFlush = resolve;
+				}),
+		);
 		const recorder = new RequestMetricsRecorder({
 			sink: { flush: flushSpy },
 		});
 
 		recorder.count(METRIC_NAMES.httpRequestsTotal);
-		const flushPromise = recorder.flush({ waitUntil } as ExecutionContext);
+		const firstFlushPromise = recorder.flush();
+		const secondFlushPromise = recorder.flush();
 
-		expect(waitUntil).toHaveBeenCalledTimes(1);
-		expect(waitUntil).toHaveBeenCalledWith(flushPromise);
-		await flushPromise;
+		expect(secondFlushPromise).toBe(firstFlushPromise);
+		expect(flushSpy).toHaveBeenCalledTimes(1);
+
+		resolveFlush();
+		await firstFlushPromise;
 		expect(flushSpy).toHaveBeenCalledTimes(1);
 	});
 

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
 import {
 	clearMetricsRecorderFromExecutionContext,
@@ -9,6 +9,10 @@ import {
 } from "../../../src/metrics/runtime/request-metrics";
 
 describe("withRequestMetrics", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("exposes a request-scoped recorder during handler execution and clears it afterwards", async () => {
 		const waitUntil = vi.fn();
 		const analyticsEngineSink = { flush: vi.fn().mockResolvedValue(undefined) };
@@ -29,6 +33,40 @@ describe("withRequestMetrics", () => {
 		expect(getMetricsRecorderFromExecutionContext(ctx)).toBeUndefined();
 		expect(waitUntil).toHaveBeenCalledTimes(1);
 		expect(analyticsEngineSink.flush).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not await slow metrics flushes on the request path", async () => {
+		let resolveFlush!: () => void;
+		const waitUntil = vi.fn();
+		const analyticsEngineSink = {
+			flush: vi.fn(
+				() =>
+					new Promise<void>((resolve) => {
+						resolveFlush = resolve;
+					}),
+			),
+		};
+		const ctx = { waitUntil } as unknown as ExecutionContext;
+
+		const result = await withRequestMetrics(
+			{ METRICS_SINK_MODE: "analytics_engine" },
+			ctx,
+			async (recorder) => {
+				recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+					route_group: "mcp",
+				});
+				return "handler-result";
+			},
+			{ analyticsEngineSink },
+		);
+
+		expect(result).toBe("handler-result");
+		expect(analyticsEngineSink.flush).toHaveBeenCalledTimes(1);
+		expect(waitUntil).toHaveBeenCalledTimes(1);
+		expect(getMetricsRecorderFromExecutionContext(ctx)).toBeUndefined();
+
+		resolveFlush();
+		await waitUntil.mock.calls[0][0];
 	});
 
 	it("flushes and clears the request-scoped recorder when the handler throws", async () => {
@@ -55,6 +93,38 @@ describe("withRequestMetrics", () => {
 		expect(analyticsEngineSink.flush).toHaveBeenCalledTimes(1);
 	});
 
+	it("does not mask handler failures with slow metrics flushes", async () => {
+		let resolveFlush!: () => void;
+		const waitUntil = vi.fn();
+		const analyticsEngineSink = {
+			flush: vi.fn(
+				() =>
+					new Promise<void>((resolve) => {
+						resolveFlush = resolve;
+					}),
+			),
+		};
+		const ctx = { waitUntil } as unknown as ExecutionContext;
+
+		await expect(
+			withRequestMetrics(
+				{ METRICS_SINK_MODE: "analytics_engine" },
+				ctx,
+				async (recorder) => {
+					recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+						route_group: "mcp",
+					});
+					throw new Error("boom");
+				},
+				{ analyticsEngineSink },
+			),
+		).rejects.toThrow("boom");
+
+		expect(waitUntil).toHaveBeenCalledTimes(1);
+		resolveFlush();
+		await waitUntil.mock.calls[0][0];
+	});
+
 	it("creates a recorder with resolved resource attributes", async () => {
 		const grafanaSink = { flush: vi.fn().mockResolvedValue(undefined) };
 		const recorder = createRequestMetricsRecorder(
@@ -76,6 +146,110 @@ describe("withRequestMetrics", () => {
 					"service.version": "1.2.3",
 				}),
 			}),
+		);
+	});
+
+	it("falls back to a noop sink when metrics config resolution throws", async () => {
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		const env = Object.defineProperty({}, "METRICS_SINK_MODE", {
+			get() {
+				throw new Error("env unavailable");
+			},
+		});
+		const recorder = createRequestMetricsRecorder(env);
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		await expect(recorder.flush()).resolves.toBeUndefined();
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			"[metrics] Failed to initialize request metrics recorder; using noop sink",
+			expect.any(Error),
+		);
+	});
+
+	it("falls back to a noop sink when sink construction throws", async () => {
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		const sinks = Object.defineProperty({}, "analyticsEngineSink", {
+			get() {
+				throw new Error("sink unavailable");
+			},
+		});
+		const recorder = createRequestMetricsRecorder(
+			{ METRICS_SINK_MODE: "analytics_engine" },
+			sinks,
+		);
+
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		await expect(recorder.flush()).resolves.toBeUndefined();
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			"[metrics] Failed to initialize request metrics recorder; using noop sink",
+			expect.any(Error),
+		);
+	});
+
+	it("does not fail the request when waitUntil rejects scheduling", async () => {
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		const ctx = {
+			waitUntil: vi.fn(() => {
+				throw new Error("waitUntil unavailable");
+			}),
+		} as unknown as ExecutionContext;
+		const analyticsEngineSink = { flush: vi.fn().mockResolvedValue(undefined) };
+
+		const result = await withRequestMetrics(
+			{ METRICS_SINK_MODE: "analytics_engine" },
+			ctx,
+			async (recorder) => {
+				recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+					route_group: "mcp",
+				});
+				return "handler-result";
+			},
+			{ analyticsEngineSink },
+		);
+
+		expect(result).toBe("handler-result");
+		expect(errorSpy).toHaveBeenCalledWith(
+			"[metrics] Failed to schedule request metrics flush",
+			expect.any(Error),
+		);
+	});
+
+	it("does not fail the request when metrics delivery fails", async () => {
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		const waitUntil = vi.fn();
+		const ctx = { waitUntil } as unknown as ExecutionContext;
+		const analyticsEngineSink = {
+			flush: vi.fn().mockRejectedValue(new Error("metrics unavailable")),
+		};
+
+		const result = await withRequestMetrics(
+			{ METRICS_SINK_MODE: "analytics_engine" },
+			ctx,
+			async (recorder) => {
+				recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+					route_group: "mcp",
+				});
+				return "handler-result";
+			},
+			{ analyticsEngineSink },
+		);
+
+		expect(result).toBe("handler-result");
+		expect(waitUntil).toHaveBeenCalledTimes(1);
+		await waitUntil.mock.calls[0][0];
+		expect(errorSpy).toHaveBeenCalledWith(
+			"[metrics] Flush failed",
+			expect.any(Error),
 		);
 	});
 

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -149,7 +149,7 @@ describe("withRequestMetrics", () => {
 		);
 	});
 
-	it("falls back to a noop sink when metrics config resolution throws", async () => {
+	it("falls back to a noop recorder when metrics config resolution throws", async () => {
 		const errorSpy = vi
 			.spyOn(console, "error")
 			.mockImplementation(() => undefined);
@@ -162,14 +162,15 @@ describe("withRequestMetrics", () => {
 
 		recorder.count(METRIC_NAMES.httpRequestsTotal);
 		await expect(recorder.flush()).resolves.toBeUndefined();
+		expect(recorder.snapshot()).toEqual([]);
 
 		expect(errorSpy).toHaveBeenCalledWith(
-			"[metrics] Failed to initialize request metrics recorder; using noop sink",
+			"[metrics] Failed to initialize request metrics recorder; using noop recorder",
 			expect.any(Error),
 		);
 	});
 
-	it("falls back to a noop sink when sink construction throws", async () => {
+	it("falls back to a noop recorder when sink construction throws", async () => {
 		const errorSpy = vi
 			.spyOn(console, "error")
 			.mockImplementation(() => undefined);
@@ -185,9 +186,10 @@ describe("withRequestMetrics", () => {
 
 		recorder.count(METRIC_NAMES.httpRequestsTotal);
 		await expect(recorder.flush()).resolves.toBeUndefined();
+		expect(recorder.snapshot()).toEqual([]);
 
 		expect(errorSpy).toHaveBeenCalledWith(
-			"[metrics] Failed to initialize request metrics recorder; using noop sink",
+			"[metrics] Failed to initialize request metrics recorder; using noop recorder",
 			expect.any(Error),
 		);
 	});


### PR DESCRIPTION
## Summary

Harden the metrics request wrapper so metrics setup, scheduling, and flush failures cannot
block MCP business logic or become visible to MCP clients.

## What Changed

- fall back to a noop sink if metrics config or sink construction throws
- keep `recorder.flush()` focused on metrics delivery, not Worker scheduling
- schedule request metrics flush through `ctx.waitUntil(...)` without awaiting delivery
- log waitUntil scheduling failures separately from metrics execution failures
- add tests for setup fallback, slow flushes, handler failures, waitUntil failures, and
  delivery failures

## Semantics

Direct `recorder.flush()` calls still await delivery. `withRequestMetrics(...)` only schedules
the request-scoped flush so slow, failing, or unavailable sinks do not delay responses.

Metrics failures remain best-effort side effects and are never propagated to MCP clients.