### PR TITLE
Release 2026-05-01 version

### DIFF
--- a/src/bearer.ts
+++ b/src/bearer.ts
@@ -9,15 +9,15 @@ import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "./routes";
  * @param env - Environment bindings
  * @param ctx - Execution context
  * @param MCPServer - MCP server instance
- * @param supportApiVersion - Whether to support api-version query param
+ * @param apiVersionOverride - Optional API version override (ignore value in request)
  */
 function handleTokenAuth(
 	req: Request,
 	env: Env,
 	ctx: ExecutionContext,
 	MCPServer: typeof ThoughtSpotMCP,
-	supportApiVersion: boolean,
-): Response {
+	apiVersionOverride?: string,
+): Response | Promise<Response> {
 	const authHeader = req.headers.get("authorization");
 	if (!authHeader) {
 		return new Response("Bearer token is required", { status: 400 });
@@ -51,12 +51,10 @@ function handleTokenAuth(
 		clientName,
 	};
 
-	// Add api-version support only for /token endpoints (supports "beta" or "YYYY-MM-DD" format)
-	if (supportApiVersion) {
-		const apiVersion = url.searchParams.get("api-version");
-		if (apiVersion) {
-			props.apiVersion = apiVersion;
-		}
+	// Resolve API version to use
+	const apiVersion = apiVersionOverride ?? url.searchParams.get("api-version");
+	if (apiVersion) {
+		props.apiVersion = apiVersion;
 	}
 
 	(ctx as any).props = props;
@@ -81,13 +79,19 @@ export function withBearerHandler(
 	// These endpoints do NOT support api-version query params (will be removed in future)
 	// Use /token endpoints instead for new implementations
 	app.mount(PUBLIC_ROUTE_PREFIXES.bearer, (req, env, ctx) => {
-		return handleTokenAuth(req, env, ctx, MCPServer, false);
+		return handleTokenAuth(
+			req,
+			env,
+			ctx,
+			MCPServer,
+			"backwards-compatibility-default",
+		);
 	});
 
 	// NEW: /token endpoints - supports api-version query params
 	// Recommended for all new implementations
 	app.mount(PUBLIC_ROUTE_PREFIXES.token, (req, env, ctx) => {
-		return handleTokenAuth(req, env, ctx, MCPServer, true);
+		return handleTokenAuth(req, env, ctx, MCPServer);
 	});
 
 	return app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,16 +51,20 @@ function createMCPRouter(
 			ctx: ExecutionContext,
 		): Promise<Response> {
 			const url = new URL(request.url);
-			const apiVersion = url.searchParams.get("api-version");
+			let apiVersion = url.searchParams.get("api-version");
 
-			// Inject apiVersion into props if provided (supports "beta" or "YYYY-MM-DD" format)
-			if (apiVersion) {
-				const originalProps = (ctx as any).props || {};
-				(ctx as any).props = {
-					...originalProps,
-					apiVersion,
-				};
+			// TODO(Rifdhan): this is a temporary backwards compatibility measure. In the future
+			// we will use latest by default.
+			if (!apiVersion) {
+				apiVersion = "backwards-compatibility-default";
 			}
+
+			// Inject apiVersion into props
+			const originalProps = (ctx as any).props || {};
+			(ctx as any).props = {
+				...originalProps,
+				apiVersion,
+			};
 
 			// Route to the appropriate serve method
 			return serverClass[serveMethod](path, options).fetch(request, env, ctx);

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -9,7 +9,7 @@ import { TrackEvent } from "../metrics";
 import { WithSpan } from "../metrics/tracing/tracing-utils";
 import { context, SpanStatusCode, trace } from "@opentelemetry/api";
 import { BaseMCPServer, type Context } from "./mcp-server-base";
-import { resolveApiVersion } from "./version-registry";
+import { resolveApiVersion, type VersionConfig } from "./version-registry";
 import {
 	GetRelevantQuestionsSchema,
 	GetAnswerSchema,
@@ -32,9 +32,28 @@ export class MCPServer extends BaseMCPServer {
 		super(ctx, "ThoughtSpot", "2.0.0");
 	}
 
+	@WithSpan("call-list-tools")
 	protected async listTools() {
+		const span = this.initSpanWithCommonAttributes();
+		span?.setAttribute(
+			"api_version_requested",
+			this.ctx.props.apiVersion ?? "(not passed)",
+		);
+
 		// Resolve the API version to get the appropriate tool configuration
-		const versionConfig = resolveApiVersion(this.ctx.props.apiVersion);
+		let versionConfig: VersionConfig;
+		try {
+			versionConfig = resolveApiVersion(this.ctx.props.apiVersion);
+		} catch (error) {
+			console.error("Error resolving API version, using default:", error);
+			span?.recordException(error as Error);
+			versionConfig = resolveApiVersion();
+		}
+		span?.setAttribute(
+			"api_version_resolved",
+			// The plain date will be the last entry if multiple labels
+			versionConfig.version[versionConfig.version.length - 1],
+		);
 
 		// Get base tools from version config
 		let tools = [...versionConfig.tools];

--- a/src/servers/version-registry.ts
+++ b/src/servers/version-registry.ts
@@ -1,5 +1,7 @@
 import { toolDefinitionsV1, toolDefinitionsV2 } from "./tool-definitions";
 
+const YYYY_MM_DD_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
 /**
  * Version configuration interface
  */
@@ -13,26 +15,23 @@ export interface VersionConfig {
 }
 
 /**
- * Parses the release date from a version's date identifiers
- * @param versions - The version identifiers array (e.g., ["beta", "2026-03-25"])
- * @returns The parsed date from the first valid YYYY-MM-DD string in the array, or null if none found
+ * Given a list of version names, returns a date if there is a valid date-based version identifier.
+ * This should always be the last entry in the list if present.
  */
 function getReleaseDateFromVersion(versions: string[]): Date | null {
-	const dateVersion = versions.find((v) => /^\d{4}-\d{2}-\d{2}$/.test(v));
-	if (dateVersion) {
-		return new Date(dateVersion);
+	const possibleDateVersion = versions[versions.length - 1];
+	const isDate = YYYY_MM_DD_DATE_REGEX.test(possibleDateVersion);
+	if (!isDate) {
+		return null;
 	}
-	return null;
+	return new Date(possibleDateVersion);
 }
 
 /**
- * Version registry mapping version identifiers to their configurations
- *
- * IMPORTANT: Versions MUST be ordered by release date (newest first).
- * When adding new versions, ensure they are inserted in the correct position
- * to maintain this ordering, as the resolution logic depends on it.
- * There should always be a "default" stable version that serves as the fallback for
- * any requests without a specified version or with a date before all versions.
+ * Version registry, with respective tools to expose by API version. The "version" field can
+ * contain multiple identifiers for the same version. Important ordering rules:
+ * - Entries in the registry must be in chronological order, with newest first
+ * - Entries in the "version" field must include the plain date (if present) as the last entry
  */
 export const VERSION_REGISTRY: VersionConfig[] = [
 	{
@@ -41,39 +40,22 @@ export const VERSION_REGISTRY: VersionConfig[] = [
 		description: "Spotter3 agent conversation tools released",
 	},
 	{
-		version: ["default", "2025-01-01"],
+		version: ["latest", "2026-05-01"],
+		tools: [...toolDefinitionsV2],
+		description: "Spotter3 agent conversation tools released",
+	},
+	{
+		version: ["backwards-compatibility-default", "2025-01-01"],
 		tools: [...toolDefinitionsV1],
 		description: "Base version with getRelevantQuestions and getAnswer tools",
 	},
 ];
 
-function getDefaultVersionConfig() {
-	const defaultVersion = VERSION_REGISTRY.find((v) =>
-		v.version.includes("default"),
-	);
-	if (defaultVersion) {
-		return defaultVersion;
-	}
-	if (VERSION_REGISTRY.length > 0) {
-		return VERSION_REGISTRY[0];
-	}
-	throw new Error("No available API versions in registry.");
-}
-
 /**
- * Resolves an API version string to a version configuration
- * @param apiVersion - The API version string (e.g., "beta", "2025-03-01", or null for default)
- * @returns The resolved version configuration
+ * Resolves an API version string to a version configuration, defaulting to latest
  */
-export function resolveApiVersion(
-	apiVersion: string | null | undefined,
-): VersionConfig {
-	// No version specified - return the entry marked as "default"
-	if (!apiVersion) {
-		return getDefaultVersionConfig();
-	}
-
-	// Check for exact match (including "beta")
+export function resolveApiVersion(apiVersion = "latest"): VersionConfig {
+	// Check for exact match (including non-dates like "beta", "latest", etc)
 	const exactMatch = VERSION_REGISTRY.find((v) =>
 		v.version.includes(apiVersion),
 	);
@@ -81,31 +63,36 @@ export function resolveApiVersion(
 		return exactMatch;
 	}
 
-	// Try to parse as date (YYYY-MM-DD format)
-	const dateMatch = apiVersion.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-	if (!dateMatch) {
-		return getDefaultVersionConfig();
+	// Try to parse as date
+	const isDate = YYYY_MM_DD_DATE_REGEX.test(apiVersion);
+	if (!isDate) {
+		throw new Error(
+			`Invalid date format in API version, expected YYYY-MM-DD: ${apiVersion}`,
+		);
 	}
 
 	const requestedDate = new Date(apiVersion);
-
-	// Validate the date is valid
 	if (Number.isNaN(requestedDate.getTime())) {
-		return getDefaultVersionConfig();
+		throw new Error(
+			`Invalid date format in API version, expected YYYY-MM-DD: ${apiVersion}`,
+		);
 	}
 
-	// Find the latest version released on or before the requested date
-	// Entries without a date identifier are excluded from date-based resolution
-	// Note: No sort needed as VERSION_REGISTRY is already ordered by release date (newest first)
-	const matchingVersion = VERSION_REGISTRY.filter((v) => {
+	// Find the newest version on or before the requested date. Note that the version registry is
+	// already ordered from newest to oldest. We ignore any entries without a date-based version.
+	const matchingVersion = VERSION_REGISTRY.find((v) => {
 		const releaseDate = getReleaseDateFromVersion(v.version);
 		return releaseDate !== null && releaseDate <= requestedDate;
-	})[0];
-
+	});
 	if (matchingVersion) {
 		return matchingVersion;
 	}
 
-	// If no version found on or before the date, return the default entry
-	return getDefaultVersionConfig();
+	// If requesting an API version older than the oldest available version, return the oldest
+	// available version
+	console.warn(
+		"Requested API version is older than all available versions, defaulting to oldest available version",
+		apiVersion,
+	);
+	return VERSION_REGISTRY[VERSION_REGISTRY.length - 1];
 }

--- a/test/bearer.spec.ts
+++ b/test/bearer.spec.ts
@@ -177,6 +177,7 @@ describe("Bearer Handler", () => {
 				accessToken: "my-access-token",
 				instanceUrl: "https://my-instance.thoughtspot.cloud",
 				clientName: "Custom Test Client",
+				apiVersion: "backwards-compatibility-default",
 			});
 
 			// Verify the response
@@ -201,6 +202,7 @@ describe("Bearer Handler", () => {
 				accessToken: "my-access-token",
 				instanceUrl: "https://my-instance.thoughtspot.cloud",
 				clientName: "Bearer Token client",
+				apiVersion: "backwards-compatibility-default",
 			});
 
 			// Verify the response
@@ -479,8 +481,8 @@ describe("Bearer Handler", () => {
 		});
 	});
 
-	describe("DEPRECATED: /bearer endpoints - No API Version Support", () => {
-		it("should NOT inject apiVersion even when query param is present on /bearer/mcp", async () => {
+	describe("DEPRECATED: /bearer endpoints - Fixed API Version Override", () => {
+		it("should use backwards-compatibility-default apiVersion and ignore query param on /bearer/mcp", async () => {
 			const appWithBearer = withBearerHandler(app, ThoughtSpotMCP);
 
 			const request = new Request(
@@ -494,15 +496,15 @@ describe("Bearer Handler", () => {
 
 			await appWithBearer.fetch(request, mockEnv, mockCtx);
 
-			// LEGACY: /bearer endpoints do NOT support api-version for backward compatibility
+			// LEGACY: /bearer endpoints always use backwards-compatibility-default, ignoring any query param
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
 			});
-			expect(mockCtx.props.apiVersion).toBeUndefined();
+			expect(mockCtx.props.apiVersion).toBe("backwards-compatibility-default");
 		});
 
-		it("should NOT inject apiVersion even when query param is present on /bearer/sse", async () => {
+		it("should use backwards-compatibility-default apiVersion and ignore query param on /bearer/sse", async () => {
 			const appWithBearer = withBearerHandler(app, ThoughtSpotMCP);
 
 			const request = new Request(
@@ -516,12 +518,12 @@ describe("Bearer Handler", () => {
 
 			await appWithBearer.fetch(request, mockEnv, mockCtx);
 
-			// LEGACY: /bearer endpoints do NOT support api-version
+			// LEGACY: /bearer endpoints always use backwards-compatibility-default, ignoring any query param
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
 			});
-			expect(mockCtx.props.apiVersion).toBeUndefined();
+			expect(mockCtx.props.apiVersion).toBe("backwards-compatibility-default");
 		});
 	});
 

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -178,14 +178,14 @@ describe("MCP Server", () => {
 
 			const result = await listTools();
 
-			// Common tools (2) + Standard tools (2) + DataSourceDiscovery (1) = 5
+			// V2 tools (latest version): 5 tools
 			expect(result.tools).toHaveLength(5);
 			expect(result.tools?.map((t) => t.name)).toEqual([
-				"ping",
-				"createLiveboard",
-				"getDataSourceSuggestions",
-				"getRelevantQuestions",
-				"getAnswer",
+				"check_connectivity",
+				"create_analysis_session",
+				"send_session_message",
+				"get_session_updates",
+				"create_dashboard",
 			]);
 		});
 
@@ -195,32 +195,27 @@ describe("MCP Server", () => {
 
 			const result = await listTools();
 
-			const pingTool = result.tools?.find((t) => t.name === "ping");
-			expect(pingTool?.description).toBe(
-				"Simple ping tool to test connectivity and Auth",
+			const connectivityTool = result.tools?.find(
+				(t) => t.name === "check_connectivity",
+			);
+			expect(connectivityTool?.description).toBe(
+				"Ping tool to test connectivity and authentication. This can be used if other tool calls are failing to verify if the connection is working.",
 			);
 
-			const questionsTool = result.tools?.find(
-				(t) => t.name === "getRelevantQuestions",
+			const sessionTool = result.tools?.find(
+				(t) => t.name === "create_analysis_session",
 			);
-			expect(questionsTool?.description).toBe(
-				"Get relevant data questions from ThoughtSpot database",
-			);
+			expect(sessionTool).toBeDefined();
 
-			const answerTool = result.tools?.find((t) => t.name === "getAnswer");
-			expect(answerTool?.description).toBe(
-				"Get the answer to a question from ThoughtSpot database",
+			const dashboardTool = result.tools?.find(
+				(t) => t.name === "create_dashboard",
 			);
-
-			const liveboardTool = result.tools?.find(
-				(t) => t.name === "createLiveboard",
-			);
-			expect(liveboardTool?.description).toBe(
-				"Create a liveboard from a list of answers",
+			expect(dashboardTool?.description).toBe(
+				"Create a dashboard from a list of answers, allowing the user to revisit the results later. Use this if the user asks for a dashboard, or asks to save the results from the analysis.",
 			);
 		});
 
-		it("should return 4 tools when enableSpotterDataSourceDiscovery is false", async () => {
+		it("should return 5 tools regardless of enableSpotterDataSourceDiscovery when using latest (V2)", async () => {
 			// Mock getThoughtSpotClient with enableSpotterDataSourceDiscovery set to false
 			vi.spyOn(thoughtspotClient, "getThoughtSpotClient").mockReturnValue({
 				getSessionInfo: vi.fn().mockResolvedValue({
@@ -256,20 +251,15 @@ describe("MCP Server", () => {
 
 			const result = await listTools();
 
-			// Common tools (2) + Standard tools (2) = 4 (no datasource discovery)
-			expect(result.tools).toHaveLength(4);
+			// V2 tools don't have a datasource discovery tool, so filtering has no effect
+			expect(result.tools).toHaveLength(5);
 			expect(result.tools?.map((t) => t.name)).toEqual([
-				"ping",
-				"createLiveboard",
-				"getRelevantQuestions",
-				"getAnswer",
+				"check_connectivity",
+				"create_analysis_session",
+				"send_session_message",
+				"get_session_updates",
+				"create_dashboard",
 			]);
-
-			// Verify that getDataSourceSuggestions is not included
-			const dataSourceTool = result.tools?.find(
-				(t) => t.name === "getDataSourceSuggestions",
-			);
-			expect(dataSourceTool).toBeUndefined();
 		});
 	});
 

--- a/test/servers/version-registry.spec.ts
+++ b/test/servers/version-registry.spec.ts
@@ -16,19 +16,24 @@ function isValidApiVersion(apiVersion: string): boolean {
 
 describe("Version Registry", () => {
 	describe("resolveApiVersion", () => {
-		it("should return default version when no apiVersion is provided", () => {
-			const result = resolveApiVersion(null);
-			expect(result.version).toContain("default");
+		it("should throw for null apiVersion", () => {
+			expect(() => resolveApiVersion(null as any)).toThrow();
 		});
 
-		it("should return default version when undefined is provided", () => {
+		it("should return latest version when undefined is provided", () => {
 			const result = resolveApiVersion(undefined);
-			expect(result.version).toContain("default");
+			expect(result.version).toContain("latest");
 		});
 
 		it("should return beta version when 'beta' is specified", () => {
 			const result = resolveApiVersion("beta");
 			expect(result.version).toContain("beta");
+		});
+
+		it("should return latest stable version when 'latest' is specified", () => {
+			const result = resolveApiVersion("latest");
+			expect(result.version).toContain("latest");
+			expect(result.version).not.toContain("beta");
 		});
 
 		it("should resolve exact date match", () => {
@@ -46,10 +51,10 @@ describe("Version Registry", () => {
 			expect(result.version).toContain("2025-01-01");
 		});
 
-		it("should return default version when date is before all versions", () => {
+		it("should return oldest version when date is before all versions", () => {
 			// Use a date before the earliest version in VERSION_REGISTRY
 			const result = resolveApiVersion("2020-01-01");
-			expect(result.version).toContain("default");
+			expect(result.version).toContain("backwards-compatibility-default");
 		});
 
 		it("should exclude beta from date-based resolution", () => {
@@ -58,25 +63,23 @@ describe("Version Registry", () => {
 			expect(result.version).not.toContain("beta");
 		});
 
-		it("should return default version for invalid date format", () => {
-			const result = resolveApiVersion("invalid-date");
-			expect(result.version).toContain("default");
+		it("should throw for invalid date format", () => {
+			expect(() => resolveApiVersion("invalid-date")).toThrow();
 		});
 
-		it("should return default version for malformed date", () => {
-			const result = resolveApiVersion("2025-13-01");
-			expect(result.version).toContain("default");
+		it("should throw for malformed date", () => {
+			expect(() => resolveApiVersion("2025-13-01")).toThrow();
 		});
 
-		it("should return default version for partial date", () => {
-			const result = resolveApiVersion("2025-03");
-			expect(result.version).toContain("default");
+		it("should throw for partial date", () => {
+			expect(() => resolveApiVersion("2025-03")).toThrow();
 		});
 
 		it("should handle future dates", () => {
 			const result = resolveApiVersion("2030-01-01");
-			// Only dated entry is 2025-01-01, so future dates resolve to it
-			expect(result.version).toContain("2025-01-01");
+			// Resolves to the latest dated stable entry
+			expect(result.version).toContain("latest");
+			expect(result.version).not.toContain("beta");
 		});
 	});
 
@@ -89,16 +92,16 @@ describe("Version Registry", () => {
 			expect(isValidApiVersion("2025-03-01")).toBe(true);
 		});
 
-		it("should return true for invalid format (falls back to default)", () => {
-			expect(isValidApiVersion("invalid")).toBe(true);
+		it("should return false for invalid format (throws)", () => {
+			expect(isValidApiVersion("invalid")).toBe(false);
 		});
 
-		it("should return true for malformed date (falls back to default)", () => {
-			expect(isValidApiVersion("2025-13-45")).toBe(true);
+		it("should return false for malformed date (throws)", () => {
+			expect(isValidApiVersion("2025-13-45")).toBe(false);
 		});
 
-		it("should return true for partial date (falls back to default)", () => {
-			expect(isValidApiVersion("2025-03")).toBe(true);
+		it("should return false for partial date (throws)", () => {
+			expect(isValidApiVersion("2025-03")).toBe(false);
 		});
 	});
 
@@ -106,7 +109,8 @@ describe("Version Registry", () => {
 		it("should return all version identifiers", () => {
 			const versions = VERSION_REGISTRY.flatMap((v) => v.version);
 			expect(versions).toContain("beta");
-			expect(versions).toContain("default");
+			expect(versions).toContain("backwards-compatibility-default");
+			expect(versions).toContain("latest");
 			expect(versions).toContain("2025-01-01");
 			expect(versions.length).toBeGreaterThan(0);
 		});
@@ -170,9 +174,10 @@ describe("Version Registry", () => {
 	describe("Date range resolution", () => {
 		// Registry:
 		//   ["beta"] → Spotter3 tools (no date, only reachable via "beta")
-		//   ["default", "2025-01-01"] → base MCP tools
+		//   ["latest", "2026-05-01"] → newest stable entry
+		//   ["backwards-compatibility-default", "2025-01-01"] → base MCP tools
 		it.each([
-			// Before all dated versions → falls back to default (2025-01-01)
+			// Before all dated versions → falls back to oldest (2025-01-01)
 			{
 				apiVersion: "2020-01-01",
 				expectedVersionDate: "2025-01-01",
@@ -183,7 +188,7 @@ describe("Version Registry", () => {
 				expectedVersionDate: "2025-01-01",
 				label: "day before earliest version",
 			},
-			// On or after 2025-01-01 → resolves to 2025-01-01 (only dated entry)
+			// On or after 2025-01-01 but before 2026-05-01 → resolves to 2025-01-01
 			{
 				apiVersion: "2025-01-01",
 				expectedVersionDate: "2025-01-01",
@@ -204,14 +209,20 @@ describe("Version Registry", () => {
 				expectedVersionDate: "2025-01-01",
 				label: "end of 2025",
 			},
+			// On or after 2026-05-01 → resolves to latest stable (2026-05-01)
 			{
-				apiVersion: "2026-01-01",
-				expectedVersionDate: "2025-01-01",
+				apiVersion: "2026-05-01",
+				expectedVersionDate: "2026-05-01",
+				label: "exact match for latest version",
+			},
+			{
+				apiVersion: "2026-06-01",
+				expectedVersionDate: "2026-05-01",
 				label: "start of 2026",
 			},
 			{
 				apiVersion: "2030-01-01",
-				expectedVersionDate: "2025-01-01",
+				expectedVersionDate: "2026-05-01",
 				label: "far future date",
 			},
 		])(
@@ -230,9 +241,14 @@ describe("Version Registry", () => {
 				label: "beta identifier",
 			},
 			{
-				apiVersion: "default",
-				expectedIdentifier: "default",
-				label: "default identifier",
+				apiVersion: "backwards-compatibility-default",
+				expectedIdentifier: "backwards-compatibility-default",
+				label: "backwards-compatibility-default identifier",
+			},
+			{
+				apiVersion: "latest",
+				expectedIdentifier: "latest",
+				label: "latest identifier",
 			},
 		])(
 			"$label: apiVersion=$apiVersion → contains $expectedIdentifier",
@@ -242,27 +258,23 @@ describe("Version Registry", () => {
 			},
 		);
 
-		// Invalid versions → fall back to default
+		// Invalid versions → throw
 		it.each([
 			{ apiVersion: "beta2", label: "unknown identifier" },
 			{ apiVersion: "invalid", label: "invalid string" },
 			{ apiVersion: "2025-13-01", label: "malformed date" },
-		])(
-			"$label: apiVersion=$apiVersion → falls back to default",
-			({ apiVersion }) => {
-				const result = resolveApiVersion(apiVersion);
-				expect(result.version).toContain("default");
-			},
-		);
+		])("$label: apiVersion=$apiVersion → throws", ({ apiVersion }) => {
+			expect(() => resolveApiVersion(apiVersion)).toThrow();
+		});
 
-		// Null/undefined → default
-		it.each([
-			{ apiVersion: null, label: "null" },
-			{ apiVersion: undefined, label: "undefined" },
-		])("$label → resolves to default (2025-01-01)", ({ apiVersion }) => {
-			const result = resolveApiVersion(apiVersion);
-			expect(result.version).toContain("default");
-			expect(result.version).toContain("2025-01-01");
+		// Null → throws; undefined → resolves to latest
+		it("null → throws", () => {
+			expect(() => resolveApiVersion(null as any)).toThrow();
+		});
+
+		it("undefined → resolves to latest", () => {
+			const result = resolveApiVersion(undefined);
+			expect(result.version).toContain("latest");
 		});
 	});
 });


### PR DESCRIPTION
- Add new entry in version registry for 2026-05-01
- Add new "latest" version option, mapping to newest available non-beta version
- Remove "default" version, default will now be latest
- Add "backwards-compatibility-default" version which points to older version for now, will be removed in the future
- Add metrics tracking of versioning
- Update tests