### PR TITLE
SCAL-308280 Instrument request and auth health metrics

### DIFF
--- a/src/bearer.ts
+++ b/src/bearer.ts
@@ -37,8 +37,9 @@ async function handleTokenAuth(
 	authRouteFamily: AuthRouteFamily = "token",
 ): Promise<Response> {
 	const recorder = getMetricsRecorderFromExecutionContext(ctx);
+	const url = new URL(req.url);
 	const authMetricRouteGroup = getAuthMetricRouteGroup(
-		new URL(req.url).pathname,
+		url.pathname,
 		authRouteFamily,
 	);
 
@@ -82,8 +83,6 @@ async function handleTokenAuth(
 
 		const clientName =
 			req.headers.get("x-ts-client-name") || "Bearer Token client";
-
-		const url = new URL(req.url);
 
 		// Build props object
 		const props: any = {

--- a/src/bearer.ts
+++ b/src/bearer.ts
@@ -1,7 +1,24 @@
 import type { ThoughtSpotMCP } from ".";
 import type honoApp from "./handlers";
+import {
+	getMetricsRecorderFromExecutionContext,
+	recordBearerAuthRequestMetric,
+} from "./metrics/runtime/request-metrics";
 import { validateAndSanitizeUrl } from "./oauth-manager/oauth-utils";
 import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "./routes";
+
+type AuthRouteFamily = "bearer" | "token";
+
+function getAuthMetricRouteGroup(
+	pathname: string,
+	authRouteFamily: AuthRouteFamily,
+): "bearer_mcp" | "bearer_sse" | "token_mcp" | "token_sse" {
+	if (pathname.endsWith(PUBLIC_ROUTES.sse)) {
+		return authRouteFamily === "bearer" ? "bearer_sse" : "token_sse";
+	}
+
+	return authRouteFamily === "bearer" ? "bearer_mcp" : "token_mcp";
+}
 
 /**
  * Handler function for bearer/token authentication endpoints
@@ -11,65 +28,104 @@ import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "./routes";
  * @param MCPServer - MCP server instance
  * @param apiVersionOverride - Optional API version override (ignore value in request)
  */
-function handleTokenAuth(
+async function handleTokenAuth(
 	req: Request,
 	env: Env,
 	ctx: ExecutionContext,
 	MCPServer: typeof ThoughtSpotMCP,
 	apiVersionOverride?: string,
-): Response | Promise<Response> {
-	const authHeader = req.headers.get("authorization");
-	if (!authHeader) {
-		return new Response("Bearer token is required", { status: 400 });
-	}
+	authRouteFamily: AuthRouteFamily = "token",
+): Promise<Response> {
+	const recorder = getMetricsRecorderFromExecutionContext(ctx);
+	const authMetricRouteGroup = getAuthMetricRouteGroup(
+		new URL(req.url).pathname,
+		authRouteFamily,
+	);
 
-	let accessToken = authHeader.split(" ")[1];
-	let tsHost: string | null;
+	try {
+		const authHeader = req.headers.get("authorization");
+		if (!authHeader) {
+			const response = new Response("Bearer token is required", {
+				status: 400,
+			});
+			recordBearerAuthRequestMetric(
+				recorder,
+				req,
+				response.status,
+				authMetricRouteGroup,
+			);
+			return response;
+		}
 
-	if (accessToken.includes("@")) {
-		[accessToken, tsHost] = accessToken.split("@");
-	} else {
-		tsHost = req.headers.get("x-ts-host");
-	}
+		let accessToken = authHeader.split(" ")[1];
+		let tsHost: string | null;
 
-	if (!tsHost) {
-		return new Response(
-			"TS Host is required, either in the authorization header as 'token@ts-host' or as a separate 'x-ts-host' header",
-			{ status: 400 },
+		if (accessToken.includes("@")) {
+			[accessToken, tsHost] = accessToken.split("@");
+		} else {
+			tsHost = req.headers.get("x-ts-host");
+		}
+
+		if (!tsHost) {
+			const response = new Response(
+				"TS Host is required, either in the authorization header as 'token@ts-host' or as a separate 'x-ts-host' header",
+				{ status: 400 },
+			);
+			recordBearerAuthRequestMetric(
+				recorder,
+				req,
+				response.status,
+				authMetricRouteGroup,
+			);
+			return response;
+		}
+
+		const clientName =
+			req.headers.get("x-ts-client-name") || "Bearer Token client";
+
+		const url = new URL(req.url);
+
+		// Build props object
+		const props: any = {
+			accessToken: accessToken,
+			instanceUrl: validateAndSanitizeUrl(tsHost),
+			clientName,
+		};
+
+		// Resolve API version to use
+		const apiVersion =
+			apiVersionOverride ?? url.searchParams.get("api-version");
+		if (apiVersion) {
+			props.apiVersion = apiVersion;
+		}
+
+		(ctx as any).props = props;
+
+		let response: Response;
+		const pathname = url.pathname;
+		if (pathname.endsWith(PUBLIC_ROUTES.mcp)) {
+			response = await MCPServer.serve(PUBLIC_ROUTES.mcp).fetch(req, env, ctx);
+		} else if (pathname.endsWith(PUBLIC_ROUTES.sse)) {
+			response = await MCPServer.serveSSE(PUBLIC_ROUTES.sse).fetch(
+				req,
+				env,
+				ctx,
+			);
+		} else {
+			response = new Response("Not found", { status: 404 });
+		}
+
+		recordBearerAuthRequestMetric(
+			recorder,
+			req,
+			response.status,
+			authMetricRouteGroup,
 		);
+		return response;
+	} catch (error) {
+		recordBearerAuthRequestMetric(recorder, req, 500, authMetricRouteGroup);
+		throw error;
 	}
-
-	const clientName =
-		req.headers.get("x-ts-client-name") || "Bearer Token client";
-
-	const url = new URL(req.url);
-
-	// Build props object
-	const props: any = {
-		accessToken: accessToken,
-		instanceUrl: validateAndSanitizeUrl(tsHost),
-		clientName,
-	};
-
-	// Resolve API version to use
-	const apiVersion = apiVersionOverride ?? url.searchParams.get("api-version");
-	if (apiVersion) {
-		props.apiVersion = apiVersion;
-	}
-
-	(ctx as any).props = props;
-
-	// Route to appropriate handler
-	const pathname = url.pathname;
-	if (pathname.endsWith(PUBLIC_ROUTES.mcp)) {
-		return MCPServer.serve(PUBLIC_ROUTES.mcp).fetch(req, env, ctx);
-	}
-
-	if (pathname.endsWith(PUBLIC_ROUTES.sse)) {
-		return MCPServer.serveSSE(PUBLIC_ROUTES.sse).fetch(req, env, ctx);
-	}
-
-	return new Response("Not found", { status: 404 });
 }
 
 export function withBearerHandler(
@@ -85,13 +141,14 @@ export function withBearerHandler(
 			ctx,
 			MCPServer,
 			"backwards-compatibility-default",
+			"bearer",
 		);
 	});
 
 	// NEW: /token endpoints - supports api-version query params
 	// Recommended for all new implementations
 	app.mount(PUBLIC_ROUTE_PREFIXES.token, (req, env, ctx) => {
-		return handleTokenAuth(req, env, ctx, MCPServer);
+		return handleTokenAuth(req, env, ctx, MCPServer, undefined, "token");
 	});
 
 	return app;

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -7,6 +7,11 @@ import { Hono } from "hono";
 import { decodeBase64Url, encodeBase64Url } from "hono/utils/encode";
 import { any } from "zod";
 import { openApiSpecHandler } from "./api-schemas/open-api-spec";
+import { METRIC_NAMES } from "./metrics/runtime/metric-types";
+import {
+	getMetricsRecorderFromExecutionContext,
+	recordStatusMetric,
+} from "./metrics/runtime/request-metrics";
 import { WithSpan, getActiveSpan } from "./metrics/tracing/tracing-utils";
 import {
 	buildSamlRedirectUrl,
@@ -19,6 +24,37 @@ import type { Props } from "./utils";
 import { McpServerError } from "./utils";
 
 const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
+
+function getExecutionContextOrUndefined(context: {
+	executionCtx: ExecutionContext;
+}): ExecutionContext | undefined {
+	try {
+		return context.executionCtx;
+	} catch {
+		return undefined;
+	}
+}
+
+function recordAuthFlowMetric(
+	context: { executionCtx: ExecutionContext },
+	name:
+		| typeof METRIC_NAMES.oauthAuthorizeRequestsTotal
+		| typeof METRIC_NAMES.oauthAuthorizeSubmitTotal
+		| typeof METRIC_NAMES.oauthCallbackTotal
+		| typeof METRIC_NAMES.oauthStoreTokenTotal,
+	status: number,
+): void {
+	const executionContext = getExecutionContextOrUndefined(context);
+	if (!executionContext) {
+		return;
+	}
+
+	recordStatusMetric(
+		getMetricsRecorderFromExecutionContext(executionContext),
+		name,
+		status,
+	);
+}
 
 class Handler {
 	@WithSpan("serve-index")
@@ -252,24 +288,55 @@ app.get(PUBLIC_ROUTES.authorize, async (c) => {
 			c.req.raw,
 			c.env.OAUTH_PROVIDER,
 		);
+		recordAuthFlowMetric(
+			c,
+			METRIC_NAMES.oauthAuthorizeRequestsTotal,
+			response.status,
+		);
 		return response;
 	} catch (error) {
-		return c.text(`Internal Server Error ${error}`, 500);
+		const response = c.text(`Internal Server Error ${error}`, 500);
+		recordAuthFlowMetric(
+			c,
+			METRIC_NAMES.oauthAuthorizeRequestsTotal,
+			response.status,
+		);
+		return response;
 	}
 });
 
 app.post(PUBLIC_ROUTES.authorize, async (c) => {
 	try {
 		const redirectUrl = await handler.postAuthorize(c.req.raw, c.req.url);
-		return Response.redirect(redirectUrl);
+		const response = Response.redirect(redirectUrl);
+		recordAuthFlowMetric(
+			c,
+			METRIC_NAMES.oauthAuthorizeSubmitTotal,
+			response.status,
+		);
+		return response;
 	} catch (error) {
 		if (
 			error instanceof Error &&
 			error.message.includes("Missing instance URL")
 		) {
-			return new Response("Missing instance URL", { status: 400 });
+			const response = new Response("Missing instance URL", { status: 400 });
+			recordAuthFlowMetric(
+				c,
+				METRIC_NAMES.oauthAuthorizeSubmitTotal,
+				response.status,
+			);
+			return response;
 		}
-		return new Response(`Internal Server Error ${error}`, { status: 500 });
+		const response = new Response(`Internal Server Error ${error}`, {
+			status: 500,
+		});
+		recordAuthFlowMetric(
+			c,
+			METRIC_NAMES.oauthAuthorizeSubmitTotal,
+			response.status,
+		);
+		return response;
 	}
 });
 
@@ -280,53 +347,94 @@ app.get(PUBLIC_ROUTES.callback, async (c) => {
 			c.env.ASSETS,
 			c.req.url,
 		);
-		return new Response(htmlContent, {
+		const response = new Response(htmlContent, {
 			headers: {
 				"Content-Type": "text/html",
 			},
 		});
+		recordAuthFlowMetric(c, METRIC_NAMES.oauthCallbackTotal, response.status);
+		return response;
 	} catch (error) {
 		if (error instanceof Error) {
 			if (error.message.includes("Missing instance URL")) {
-				return c.text(`Missing instance URL ${error}`, 400);
+				const response = c.text(`Missing instance URL ${error}`, 400);
+				recordAuthFlowMetric(
+					c,
+					METRIC_NAMES.oauthCallbackTotal,
+					response.status,
+				);
+				return response;
 			}
 			if (error.message.includes("Missing OAuth request info")) {
-				return c.text(`Missing OAuth request info ${error}`, 400);
+				const response = c.text(`Missing OAuth request info ${error}`, 400);
+				recordAuthFlowMetric(
+					c,
+					METRIC_NAMES.oauthCallbackTotal,
+					response.status,
+				);
+				return response;
 			}
 			if (error.message.includes("Invalid OAuth request info format")) {
-				return c.text(`Invalid OAuth request info format ${error}`, 400);
+				const response = c.text(
+					`Invalid OAuth request info format ${error}`,
+					400,
+				);
+				recordAuthFlowMetric(
+					c,
+					METRIC_NAMES.oauthCallbackTotal,
+					response.status,
+				);
+				return response;
 			}
 		}
-		return c.text(`Internal server error ${error}`, 500);
+		const response = c.text(`Internal server error ${error}`, 500);
+		recordAuthFlowMetric(c, METRIC_NAMES.oauthCallbackTotal, response.status);
+		return response;
 	}
 });
 
 app.post(PUBLIC_ROUTES.storeToken, async (c) => {
 	try {
 		const result = await handler.storeToken(c.req.raw, c.env.OAUTH_PROVIDER);
-		return new Response(JSON.stringify(result), {
+		const response = new Response(JSON.stringify(result), {
 			status: 200,
 			headers: {
 				"Content-Type": "application/json",
 			},
 		});
+		recordAuthFlowMetric(c, METRIC_NAMES.oauthStoreTokenTotal, response.status);
+		return response;
 	} catch (error) {
 		if (error instanceof Error) {
 			if (error.message.includes("Invalid JSON format")) {
-				return c.text(`Invalid JSON format ${error}`, 400);
+				const response = c.text(`Invalid JSON format ${error}`, 400);
+				recordAuthFlowMetric(
+					c,
+					METRIC_NAMES.oauthStoreTokenTotal,
+					response.status,
+				);
+				return response;
 			}
 			if (
 				error.message.includes(
 					"Missing token or OAuth request info or instanceUrl",
 				)
 			) {
-				return c.text(
+				const response = c.text(
 					`Missing token or OAuth request info or instanceUrl ${error}`,
 					400,
 				);
+				recordAuthFlowMetric(
+					c,
+					METRIC_NAMES.oauthStoreTokenTotal,
+					response.status,
+				);
+				return response;
 			}
 		}
-		return c.text(`Internal server error ${error}`, 500);
+		const response = c.text(`Internal server error ${error}`, 500);
+		recordAuthFlowMetric(c, METRIC_NAMES.oauthStoreTokenTotal, response.status);
+		return response;
 	}
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,10 @@ import { trace } from "@opentelemetry/api";
 import { withBearerHandler } from "./bearer";
 import { instrumentedMCPServer } from "./cloudflare-utils";
 import handler from "./handlers";
-import { withRequestMetrics } from "./metrics/runtime/request-metrics";
+import {
+	recordHttpRequestMetrics,
+	withRequestMetrics,
+} from "./metrics/runtime/request-metrics";
 import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "./routes";
 import { apiServer } from "./servers/api-server";
 import { ConversationStorageServer } from "./servers/conversation-storage-server";
@@ -147,8 +150,33 @@ export default {
 		return withRequestMetrics(
 			env as unknown as Record<string, unknown>,
 			ctx,
-			async () => {
-				return instrumentedOAuthHandler.fetch!(request, env, ctx);
+			async (recorder) => {
+				const requestStartMs = Date.now();
+
+				try {
+					const response = await instrumentedOAuthHandler.fetch!(
+						request,
+						env,
+						ctx,
+					);
+					recordHttpRequestMetrics(
+						recorder,
+						request,
+						response,
+						ctx,
+						Date.now() - requestStartMs,
+					);
+					return response;
+				} catch (error) {
+					recordHttpRequestMetrics(
+						recorder,
+						request,
+						new Response(null, { status: 500 }),
+						ctx,
+						Date.now() - requestStartMs,
+					);
+					throw error;
+				}
 			},
 		);
 	},

--- a/src/metrics/runtime/grafana-otlp-sink.ts
+++ b/src/metrics/runtime/grafana-otlp-sink.ts
@@ -153,15 +153,19 @@ function toOtlpValue(value: MetricLabelValue): OtlpAttributeValue {
 function toOtlpAttributes(
 	attributes: Record<string, MetricLabelValue | undefined>,
 ): OtlpAttribute[] {
-	return Object.keys(attributes)
-		.sort()
-		.flatMap((key) => {
-			const value = attributes[key];
-			if (value === undefined || value === "") {
-				return [];
-			}
-			return [{ key, value: toOtlpValue(value) }];
-		});
+	return (
+		Object.keys(attributes)
+			// Keep attribute ordering deterministic so identical metric series
+			// aggregate the same way regardless of insertion order upstream.
+			.sort()
+			.flatMap((key) => {
+				const value = attributes[key];
+				if (value === undefined || value === "") {
+					return [];
+				}
+				return [{ key, value: toOtlpValue(value) }];
+			})
+	);
 }
 
 function toTimeUnixNano(timestampMs: number): string {

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -1,5 +1,13 @@
-import { createGrafanaOtlpMetricsSink } from "./grafana-otlp-sink";
+import { resolveApiVersion } from "../../servers/version-registry";
 import { createAnalyticsEngineMetricsSink } from "./analytics-engine-sink";
+import { createGrafanaOtlpMetricsSink } from "./grafana-otlp-sink";
+import { getStatusClass, resolveRequestMetricContext } from "./metric-context";
+import {
+	METRIC_NAMES,
+	type MetricLabelInput,
+	type MetricName,
+	type MetricOutcome,
+} from "./metric-types";
 import {
 	type MetricsRecorder,
 	NOOP_METRICS_RECORDER,
@@ -17,9 +25,25 @@ const METRICS_RECORDER_SYMBOL = Symbol.for(
 	"thoughtspot.mcp.metrics.requestRecorder",
 );
 const GRAFANA_SINK_CACHE = new WeakMap<object, MetricsSink>();
+const VERSIONED_REQUEST_ROUTE_GROUPS = new Set([
+	"mcp",
+	"sse",
+	"bearer_mcp",
+	"bearer_sse",
+	"token_mcp",
+	"token_sse",
+] as const);
+type BearerAuthRouteGroup =
+	| "bearer_mcp"
+	| "bearer_sse"
+	| "token_mcp"
+	| "token_sse";
 
 type MetricsExecutionContext = ExecutionContext & {
 	[METRICS_RECORDER_SYMBOL]?: MetricsRecorder;
+	props?: {
+		apiVersion?: unknown;
+	};
 };
 
 export function setMetricsRecorderOnExecutionContext(
@@ -54,6 +78,135 @@ export function clearMetricsRecorderFromExecutionContext(
 	delete (ctx as MetricsExecutionContext)[METRICS_RECORDER_SYMBOL];
 }
 
+export function getMetricOutcomeForStatus(status: number): MetricOutcome {
+	if (status >= 400 && status < 500) {
+		return "client_error";
+	}
+	if (status >= 500) {
+		return "error";
+	}
+	return "success";
+}
+
+function getCanonicalResolvedApiVersion(apiVersion: string): string {
+	if (apiVersion === "backwards-compatibility-default") {
+		return "default";
+	}
+
+	const versionConfig = resolveApiVersion(apiVersion);
+	if (versionConfig.version.includes("beta")) {
+		return "beta";
+	}
+
+	return versionConfig.version[versionConfig.version.length - 1] ?? "unknown";
+}
+
+export function resolveCanonicalApiVersionLabel(
+	request: Request,
+	ctx: ExecutionContext,
+): string | undefined {
+	const requestContext = resolveRequestMetricContext(request);
+	if (!VERSIONED_REQUEST_ROUTE_GROUPS.has(requestContext.routeGroup)) {
+		return undefined;
+	}
+
+	const requestedApiVersion = new URL(request.url).searchParams.get(
+		"api-version",
+	);
+	const effectiveApiVersion = (ctx as MetricsExecutionContext).props
+		?.apiVersion;
+	if (
+		typeof effectiveApiVersion === "string" &&
+		effectiveApiVersion.length > 0
+	) {
+		try {
+			return getCanonicalResolvedApiVersion(effectiveApiVersion);
+		} catch {
+			return "unknown";
+		}
+	}
+
+	if (!requestedApiVersion) {
+		return "default";
+	}
+
+	try {
+		return getCanonicalResolvedApiVersion(requestedApiVersion);
+	} catch {
+		return "unknown";
+	}
+}
+
+export function recordStatusMetric(
+	recorder: MetricsRecorder | undefined,
+	name: MetricName,
+	status: number,
+	labels: MetricLabelInput = {},
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	recorder.count(name, 1, {
+		...labels,
+		outcome: getMetricOutcomeForStatus(status),
+	});
+}
+
+export function recordBearerAuthRequestMetric(
+	recorder: MetricsRecorder | undefined,
+	request: Request,
+	status: number,
+	routeGroupOverride?: BearerAuthRouteGroup,
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	const requestContext = resolveRequestMetricContext(request);
+	recordStatusMetric(recorder, METRIC_NAMES.bearerAuthRequestsTotal, status, {
+		route_group: routeGroupOverride ?? requestContext.routeGroup,
+		transport: routeGroupOverride?.endsWith("_sse")
+			? "sse"
+			: routeGroupOverride?.endsWith("_mcp")
+				? "mcp"
+				: requestContext.transport,
+	});
+}
+
+export function recordHttpRequestMetrics(
+	recorder: MetricsRecorder,
+	request: Request,
+	response: Response,
+	ctx: ExecutionContext,
+	durationMs: number,
+): void {
+	const requestContext = resolveRequestMetricContext(request);
+	const outcome = getMetricOutcomeForStatus(response.status);
+	const apiVersion = resolveCanonicalApiVersionLabel(request, ctx);
+	const baseLabels: MetricLabelInput = {
+		route_group: requestContext.routeGroup,
+		transport: requestContext.transport,
+		auth_mode: requestContext.authMode,
+		api_surface: requestContext.apiSurface,
+		outcome,
+	};
+
+	if (apiVersion) {
+		baseLabels.api_version = apiVersion;
+	}
+
+	recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {
+		...baseLabels,
+		status_class: getStatusClass(response.status),
+	});
+	recorder.histogram(
+		METRIC_NAMES.httpRequestDurationMs,
+		durationMs,
+		baseLabels,
+	);
+}
+
 function getCachedGrafanaSink(
 	env: MetricsEnvLike | undefined,
 ): MetricsSink | undefined {
@@ -61,6 +214,8 @@ function getCachedGrafanaSink(
 		return createGrafanaOtlpMetricsSink(env);
 	}
 
+	// Reuse the sink for the same env object so repeated request recorders do not
+	// rebuild identical Grafana exporter configuration within one Worker runtime.
 	const cachedSink = GRAFANA_SINK_CACHE.get(env);
 	if (cachedSink) {
 		return cachedSink;

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -89,16 +89,18 @@ export function getMetricOutcomeForStatus(status: number): MetricOutcome {
 }
 
 function getCanonicalResolvedApiVersion(apiVersion: string): string {
-	if (apiVersion === "backwards-compatibility-default") {
-		return "default";
-	}
-
 	const versionConfig = resolveApiVersion(apiVersion);
 	if (versionConfig.version.includes("beta")) {
 		return "beta";
 	}
+	if (versionConfig.version.includes("backwards-compatibility-default")) {
+		return "default";
+	}
+	if (versionConfig.version.includes("latest")) {
+		return "latest";
+	}
 
-	return versionConfig.version[versionConfig.version.length - 1] ?? "unknown";
+	return "unknown";
 }
 
 export function resolveCanonicalApiVersionLabel(

--- a/test/bearer.spec.ts
+++ b/test/bearer.spec.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { withBearerHandler } from "../src/bearer";
-import { ThoughtSpotMCP } from "../src";
 import { Hono } from "hono";
-import { encodeBase64Url, decodeBase64Url } from "hono/utils/encode";
+import { decodeBase64Url, encodeBase64Url } from "hono/utils/encode";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThoughtSpotMCP } from "../src";
+import { withBearerHandler } from "../src/bearer";
+import { METRIC_NAMES } from "../src/metrics/runtime/metric-types";
+import {
+	createRequestMetricsRecorder,
+	setMetricsRecorderOnExecutionContext,
+} from "../src/metrics/runtime/request-metrics";
 
 // For correctly-typed Request
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
@@ -212,6 +217,32 @@ describe("Bearer Handler", () => {
 	});
 
 	describe("Authorization Header Parsing", () => {
+		it("records bearer auth metrics for rejected requests", async () => {
+			const appWithBearer = withBearerHandler(app, ThoughtSpotMCP);
+			const recorder = createRequestMetricsRecorder();
+			setMetricsRecorderOnExecutionContext(
+				mockCtx as ExecutionContext,
+				recorder,
+			);
+
+			const request = new Request("https://example.com/bearer/mcp");
+			const result = await appWithBearer.fetch(request, mockEnv, mockCtx);
+
+			expect(result.status).toBe(400);
+			expect(recorder.snapshot()).toContainEqual(
+				expect.objectContaining({
+					kind: "counter",
+					name: METRIC_NAMES.bearerAuthRequestsTotal,
+					value: 1,
+					labels: {
+						outcome: "client_error",
+						route_group: "bearer_mcp",
+						transport: "mcp",
+					},
+				}),
+			);
+		});
+
 		it("should return 400 when authorization header is missing", async () => {
 			const appWithBearer = withBearerHandler(app, ThoughtSpotMCP);
 

--- a/test/handlers.spec.ts
+++ b/test/handlers.spec.ts
@@ -1,18 +1,23 @@
 import {
+	createExecutionContext,
 	env,
 	runInDurableObject,
-	createExecutionContext,
 	waitOnExecutionContext,
 } from "cloudflare:test";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import worker, { ThoughtSpotMCP } from "../src";
 import app from "../src/handlers";
+import { METRIC_NAMES } from "../src/metrics/runtime/metric-types";
+import {
+	createRequestMetricsRecorder,
+	setMetricsRecorderOnExecutionContext,
+} from "../src/metrics/runtime/request-metrics";
 
 // Type assertion for worker to have fetch method
 const typedWorker = worker as {
 	fetch: (request: Request, env: any, ctx: any) => Promise<Response>;
 };
-import { encodeBase64Url, decodeBase64Url } from "hono/utils/encode";
+import { decodeBase64Url, encodeBase64Url } from "hono/utils/encode";
 
 // For correctly-typed Request
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
@@ -137,6 +142,40 @@ describe("Handlers", () => {
 	});
 
 	describe("POST /authorize", () => {
+		it("records authorize submit metrics for client errors", async () => {
+			const recorder = createRequestMetricsRecorder();
+			setMetricsRecorderOnExecutionContext(
+				mockCtx as ExecutionContext,
+				recorder,
+			);
+			const formData = new FormData();
+			formData.append(
+				"state",
+				btoa(JSON.stringify({ oauthReqInfo: { clientId: "test" } })),
+			);
+
+			const result = await app.fetch(
+				new Request("https://example.com/authorize", {
+					method: "POST",
+					body: formData,
+				}),
+				mockEnv,
+				mockCtx,
+			);
+
+			expect(result.status).toBe(400);
+			expect(recorder.snapshot()).toContainEqual(
+				expect.objectContaining({
+					kind: "counter",
+					name: METRIC_NAMES.oauthAuthorizeSubmitTotal,
+					value: 1,
+					labels: {
+						outcome: "client_error",
+					},
+				}),
+			);
+		});
+
 		it("should return 400 for missing instance URL", async () => {
 			const id = env.MCP_OBJECT.idFromName("test");
 			const object = env.MCP_OBJECT.get(id);

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -422,6 +422,24 @@ describe("withRequestMetrics", () => {
 		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
 	});
 
+	it("maps stable date-based versions onto the latest label", () => {
+		const ctx = {} as ExecutionContext;
+		const request = new Request(
+			"https://example.com/token/mcp?api-version=2026-05-01",
+		);
+
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("latest");
+	});
+
+	it("maps older date-based versions onto the default label", () => {
+		const ctx = {} as ExecutionContext;
+		const request = new Request(
+			"https://example.com/token/mcp?api-version=2025-12-01",
+		);
+
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
+	});
+
 	it("labels unresolved api-version values as unknown", () => {
 		const ctx = {
 			props: {

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -4,6 +4,10 @@ import {
 	clearMetricsRecorderFromExecutionContext,
 	createRequestMetricsRecorder,
 	getMetricsRecorderFromExecutionContext,
+	recordBearerAuthRequestMetric,
+	recordHttpRequestMetrics,
+	recordStatusMetric,
+	resolveCanonicalApiVersionLabel,
 	setMetricsRecorderOnExecutionContext,
 	withRequestMetrics,
 } from "../../../src/metrics/runtime/request-metrics";
@@ -353,5 +357,118 @@ describe("withRequestMetrics", () => {
 		clearMetricsRecorderFromExecutionContext(ctx);
 
 		expect(getMetricsRecorderFromExecutionContext(ctx)).toBeUndefined();
+	});
+
+	it("records HTTP request metrics with canonical route and version labels", () => {
+		const recorder = createRequestMetricsRecorder();
+		const ctx = {
+			props: {
+				apiVersion: "beta",
+			},
+		} as unknown as ExecutionContext;
+		const request = new Request("https://example.com/mcp?api-version=beta");
+		const response = new Response("ok", { status: 200 });
+
+		recordHttpRequestMetrics(recorder, request, response, ctx, 123);
+
+		expect(recorder.snapshot()).toEqual([
+			expect.objectContaining({
+				kind: "counter",
+				name: METRIC_NAMES.httpRequestsTotal,
+				value: 1,
+				labels: {
+					api_surface: "mcp",
+					api_version: "beta",
+					auth_mode: "oauth",
+					outcome: "success",
+					route_group: "mcp",
+					status_class: "2xx",
+					transport: "mcp",
+				},
+			}),
+			expect.objectContaining({
+				kind: "histogram",
+				name: METRIC_NAMES.httpRequestDurationMs,
+				value: 123,
+				labels: {
+					api_surface: "mcp",
+					api_version: "beta",
+					auth_mode: "oauth",
+					outcome: "success",
+					route_group: "mcp",
+					transport: "mcp",
+				},
+			}),
+		]);
+	});
+
+	it("labels versioned MCP routes as default when no explicit API version is requested", () => {
+		const ctx = {} as ExecutionContext;
+		const request = new Request("https://example.com/token/mcp");
+
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
+	});
+
+	it("uses the effective default surface when bearer routes ignore an api-version query", () => {
+		const ctx = {
+			props: {
+				apiVersion: "backwards-compatibility-default",
+			},
+		} as unknown as ExecutionContext;
+		const request = new Request(
+			"https://example.com/bearer/mcp?api-version=beta",
+		);
+
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
+	});
+
+	it("labels unresolved api-version values as unknown", () => {
+		const ctx = {
+			props: {
+				apiVersion: "garbage",
+			},
+		} as unknown as ExecutionContext;
+		const request = new Request(
+			"https://example.com/token/mcp?api-version=garbage",
+		);
+
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("unknown");
+	});
+
+	it("records auth outcome counters from response status", () => {
+		const recorder = createRequestMetricsRecorder();
+
+		recordStatusMetric(recorder, METRIC_NAMES.oauthAuthorizeSubmitTotal, 302);
+
+		expect(recorder.snapshot()).toEqual([
+			expect.objectContaining({
+				kind: "counter",
+				name: METRIC_NAMES.oauthAuthorizeSubmitTotal,
+				value: 1,
+				labels: {
+					outcome: "success",
+				},
+			}),
+		]);
+	});
+
+	it("records bearer auth traffic with route and transport labels", () => {
+		const recorder = createRequestMetricsRecorder();
+		const request = new Request("https://example.com/token/sse");
+
+		recordBearerAuthRequestMetric(recorder, request, 401);
+
+		expect(recorder.snapshot()).toEqual([
+			expect.objectContaining({
+				kind: "counter",
+				name: METRIC_NAMES.bearerAuthRequestsTotal,
+				value: 1,
+				labels: {
+					outcome: "client_error",
+					route_group: "token_sse",
+					transport: "sse",
+				},
+			}),
+		]);
 	});
 });


### PR DESCRIPTION
## Summary

Add the request-layer metrics for SCAL-308280 so MCP traffic and auth flows emit bounded counters and latency through the shared runtime recorder.

## What Changed

- record ts_mcp_http_requests_total and ts_mcp_http_request_duration_ms at the worker edge with route, transport, auth mode, api surface, outcome, status class, and canonical api version labels
- add helpers to resolve bounded api_version values through the version registry instead of copying raw query params
- emit auth outcome counters for /authorize, /callback, /store-token, and /bearer/* / /token/* requests
- add focused tests for request metric labeling and auth metric emission
- include the small metrics-runtime review nits from PR #126 while touching the same files