### PR TITLE
SCAL-308281 Add tool and upstream health metrics

### DIFF
--- a/src/bearer.ts
+++ b/src/bearer.ts
@@ -2,7 +2,9 @@ import type { ThoughtSpotMCP } from ".";
 import type honoApp from "./handlers";
 import {
 	getMetricsRecorderFromExecutionContext,
+	normalizeRequestedApiVersionForAnalytics,
 	recordBearerAuthRequestMetric,
+	resolveRequestedApiVersionMode,
 } from "./metrics/runtime/request-metrics";
 import { validateAndSanitizeUrl } from "./oauth-manager/oauth-utils";
 import { PUBLIC_ROUTES, PUBLIC_ROUTE_PREFIXES } from "./routes";
@@ -90,17 +92,35 @@ async function handleTokenAuth(
 			instanceUrl: validateAndSanitizeUrl(tsHost),
 			clientName,
 		};
+		const requestedApiVersion = url.searchParams.get("api-version");
 
 		// Stamp the effective served surface into props so downstream request/tool metrics
 		// can distinguish:
-		// - `api_version=default` => tenants still on the legacy/v1 surface
-		// - `api_version_mode=pinned|latest` => pinned callers vs callers following latest
+		// - `api_version=backwards-compatibility-default` => tenants still on the legacy/v1 surface
+		// - `api_version_mode` => implicit route defaults vs explicit/latest/pinned selectors
+		// - `api_requested_version` (stored only in Analytics Engine) => the exact selector
+		//   the client sent, which helps debug version-resolution confusion and future-dated pins
+		// - `api_release_date` (derived later from the registry) => which exact dated release is served
 		const apiVersion =
 			apiVersionOverride ??
-			url.searchParams.get("api-version") ??
+			requestedApiVersion ??
 			(authRouteFamily === "token" ? "latest" : undefined);
+		const apiVersionMode = apiVersionOverride
+			? "implicit_legacy"
+			: requestedApiVersion
+				? resolveRequestedApiVersionMode(requestedApiVersion)
+				: authRouteFamily === "token"
+					? "implicit_latest"
+					: undefined;
+		if (requestedApiVersion) {
+			props.apiRequestedVersion =
+				normalizeRequestedApiVersionForAnalytics(requestedApiVersion);
+		}
 		if (apiVersion) {
 			props.apiVersion = apiVersion;
+		}
+		if (apiVersionMode) {
+			props.apiVersionMode = apiVersionMode;
 		}
 
 		(ctx as any).props = props;

--- a/src/bearer.ts
+++ b/src/bearer.ts
@@ -91,9 +91,14 @@ async function handleTokenAuth(
 			clientName,
 		};
 
-		// Resolve API version to use
+		// Stamp the effective served surface into props so downstream request/tool metrics
+		// can distinguish:
+		// - `api_version=default` => tenants still on the legacy/v1 surface
+		// - `api_version_mode=pinned|latest` => pinned callers vs callers following latest
 		const apiVersion =
-			apiVersionOverride ?? url.searchParams.get("api-version");
+			apiVersionOverride ??
+			url.searchParams.get("api-version") ??
+			(authRouteFamily === "token" ? "latest" : undefined);
 		if (apiVersion) {
 			props.apiVersion = apiVersion;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,11 @@ import { trace } from "@opentelemetry/api";
 import { withBearerHandler } from "./bearer";
 import { instrumentedMCPServer } from "./cloudflare-utils";
 import handler from "./handlers";
+import type { ApiVersionMode } from "./metrics/runtime/metric-types";
 import {
+	normalizeRequestedApiVersionForAnalytics,
 	recordHttpRequestMetrics,
+	resolveRequestedApiVersionMode,
 	withRequestMetrics,
 } from "./metrics/runtime/request-metrics";
 import { PUBLIC_ROUTES } from "./routes";
@@ -47,12 +50,17 @@ function createMCPRouter(
 			ctx: ExecutionContext,
 		): Promise<Response> {
 			const url = new URL(request.url);
-			let apiVersion = url.searchParams.get("api-version");
+			const requestedApiVersion = url.searchParams.get("api-version");
+			let apiVersion = requestedApiVersion;
+			let apiVersionMode: ApiVersionMode;
 
 			// TODO(Rifdhan): this is a temporary backwards compatibility measure. In the future
 			// we will use latest by default.
 			if (!apiVersion) {
 				apiVersion = "backwards-compatibility-default";
+				apiVersionMode = "implicit_legacy";
+			} else {
+				apiVersionMode = resolveRequestedApiVersionMode(apiVersion);
 			}
 
 			// Inject apiVersion into props
@@ -60,6 +68,10 @@ function createMCPRouter(
 			(ctx as any).props = {
 				...originalProps,
 				apiVersion,
+				apiRequestedVersion: requestedApiVersion
+					? normalizeRequestedApiVersionForAnalytics(requestedApiVersion)
+					: undefined,
+				apiVersionMode,
 			};
 
 			// Route to the appropriate serve method

--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -5,6 +5,7 @@ import {
 	type MetricName,
 } from "./metric-types";
 import type {
+	MetricAnalyticsContext,
 	MetricObservation,
 	MetricResourceAttributes,
 	MetricsFlushPayload,
@@ -21,7 +22,7 @@ export type AnalyticsEngineDatasetLike = {
 	writeDataPoint(event?: AnalyticsEngineDataPointLike): void;
 };
 
-export const ANALYTICS_ENGINE_SCHEMA_VERSION = "mcp_metrics_v1";
+export const ANALYTICS_ENGINE_SCHEMA_VERSION = "mcp_metrics_v2";
 
 export const ANALYTICS_ENGINE_INDEX_FIELDS = [
 	"schema_version",
@@ -32,6 +33,13 @@ export const ANALYTICS_ENGINE_INDEX_FIELDS = [
 ] as const;
 
 export const ANALYTICS_ENGINE_LABEL_FIELDS = APPROVED_METRIC_LABEL_KEYS;
+
+export const ANALYTICS_ENGINE_CONTEXT_FIELDS = [
+	["api_requested_version", "apiRequestedVersion"],
+] as const satisfies readonly (readonly [
+	string,
+	keyof MetricAnalyticsContext,
+])[];
 
 export const ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS = [
 	["deployment_environment", "deployment.environment"],
@@ -46,6 +54,7 @@ export const ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS = [
 export const ANALYTICS_ENGINE_BLOB_FIELDS = [
 	"metric_kind",
 	...ANALYTICS_ENGINE_LABEL_FIELDS,
+	...ANALYTICS_ENGINE_CONTEXT_FIELDS.map(([field]) => field),
 	...ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS.map(([field]) => field),
 ] as const;
 
@@ -85,6 +94,13 @@ function getResourceAttribute(
 	key: keyof MetricResourceAttributes,
 ): string | null {
 	return nullableString(resourceAttributes[key]);
+}
+
+function getAnalyticsContextField(
+	analyticsContext: MetricAnalyticsContext,
+	key: keyof MetricAnalyticsContext,
+): string | null {
+	return nullableString(analyticsContext[key]);
 }
 
 export function getAnalyticsEngineMetricFamily(
@@ -138,6 +154,7 @@ export function getAnalyticsEngineMetricFamily(
 export function toAnalyticsEngineDataPoint(
 	observation: MetricObservation,
 	resourceAttributes: MetricResourceAttributes,
+	analyticsContext: MetricAnalyticsContext = {},
 	identity: AnalyticsEngineIdentity = {},
 ): AnalyticsEngineDataPointLike {
 	return {
@@ -152,6 +169,9 @@ export function toAnalyticsEngineDataPoint(
 			observation.kind,
 			...ANALYTICS_ENGINE_LABEL_FIELDS.map((key) =>
 				getLabel(observation.labels, key),
+			),
+			...ANALYTICS_ENGINE_CONTEXT_FIELDS.map(([, key]) =>
+				getAnalyticsContextField(analyticsContext, key),
 			),
 			...ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS.map(([, key]) =>
 				getResourceAttribute(resourceAttributes, key),
@@ -171,6 +191,7 @@ export class AnalyticsEngineMetricsSink implements MetricsSink {
 					toAnalyticsEngineDataPoint(
 						observation,
 						payload.resourceAttributes,
+						payload.analyticsContext,
 						payload.eventIdentity,
 					),
 				);

--- a/src/metrics/runtime/metric-types.ts
+++ b/src/metrics/runtime/metric-types.ts
@@ -92,6 +92,8 @@ export const APPROVED_METRIC_LABEL_KEYS = [
 	"auth_mode",
 	"api_surface",
 	"api_version",
+	"api_version_mode",
+	"api_release_date",
 	"outcome",
 	"status_class",
 	"tool_name",
@@ -161,6 +163,14 @@ export type RouteGroup =
 export type Transport = "mcp" | "sse" | "http" | "unknown";
 export type AuthMode = "oauth" | "bearer" | "token" | "none" | "unknown";
 export type ApiSurface = "mcp" | "oauth" | "static" | "unknown";
+export type ApiVersionMode =
+	| "implicit_legacy"
+	| "implicit_latest"
+	| "explicit_legacy"
+	| "explicit_latest"
+	| "pinned"
+	| "beta"
+	| "unknown";
 export type StatusClass = "1xx" | "2xx" | "3xx" | "4xx" | "5xx" | "unknown";
 
 function warnOnInvalidMetricLabel(key: string, reason: string) {

--- a/src/metrics/runtime/metrics-recorder.ts
+++ b/src/metrics/runtime/metrics-recorder.ts
@@ -6,6 +6,7 @@ import {
 	normalizeMetricLabels,
 } from "./metric-types";
 import type {
+	MetricEventIdentity,
 	MetricObservation,
 	MetricResourceAttributes,
 	MetricsSink,
@@ -21,6 +22,7 @@ export interface MetricsRecorder {
 	count(name: MetricName, value?: number, labels?: MetricLabelInput): void;
 	histogram(name: MetricName, value: number, labels?: MetricLabelInput): void;
 	gauge(name: MetricName, value: number, labels?: MetricLabelInput): void;
+	setEventIdentity(identity?: MetricEventIdentity): void;
 	flush(): Promise<void>;
 	snapshot(): readonly MetricObservation[];
 }
@@ -32,6 +34,7 @@ export const NOOP_METRICS_RECORDER: MetricsRecorder = {
 	count(_name, _value, _labels): void {},
 	histogram(_name, _value, _labels): void {},
 	gauge(_name, _value, _labels): void {},
+	setEventIdentity(_identity): void {},
 	flush(): Promise<void> {
 		return NOOP_FLUSH_PROMISE;
 	},
@@ -42,6 +45,7 @@ export const NOOP_METRICS_RECORDER: MetricsRecorder = {
 
 export class RequestMetricsRecorder implements MetricsRecorder {
 	private readonly observations: MetricObservation[] = [];
+	private eventIdentity?: MetricEventIdentity;
 	private flushPromise?: Promise<void>;
 	private flushed = false;
 
@@ -57,6 +61,23 @@ export class RequestMetricsRecorder implements MetricsRecorder {
 
 	gauge(name: MetricName, value: number, labels?: MetricLabelInput): void {
 		this.record("gauge", name, value, labels);
+	}
+
+	setEventIdentity(identity?: MetricEventIdentity): void {
+		if (!identity) {
+			return;
+		}
+
+		const nextIdentity: MetricEventIdentity = {
+			...this.eventIdentity,
+		};
+		if (identity.tenantId) {
+			nextIdentity.tenantId = identity.tenantId;
+		}
+		if (identity.userId) {
+			nextIdentity.userId = identity.userId;
+		}
+		this.eventIdentity = nextIdentity;
 	}
 
 	snapshot(): readonly MetricObservation[] {
@@ -115,9 +136,40 @@ export class RequestMetricsRecorder implements MetricsRecorder {
 			await this.options.sink.flush({
 				observations,
 				resourceAttributes: { ...this.options.resourceAttributes },
+				eventIdentity: this.eventIdentity
+					? { ...this.eventIdentity }
+					: undefined,
 			});
 		} catch (error) {
 			console.error("[metrics] Flush failed", error);
 		}
+	}
+}
+
+export type MetricsWaitUntil = (promise: Promise<any>) => void;
+
+export function scheduleMetricsFlush(
+	recorder: MetricsRecorder,
+	waitUntil?: MetricsWaitUntil,
+): void {
+	let flushPromise: Promise<void>;
+	try {
+		flushPromise = recorder.flush().catch((error) => {
+			console.error("[metrics] Failed to execute metrics flush", error);
+		});
+	} catch (error) {
+		console.error("[metrics] Failed to execute metrics flush", error);
+		return;
+	}
+
+	if (!waitUntil) {
+		void flushPromise;
+		return;
+	}
+
+	try {
+		waitUntil(flushPromise);
+	} catch (error) {
+		console.error("[metrics] Failed to schedule metrics flush", error);
 	}
 }

--- a/src/metrics/runtime/metrics-recorder.ts
+++ b/src/metrics/runtime/metrics-recorder.ts
@@ -6,6 +6,7 @@ import {
 	normalizeMetricLabels,
 } from "./metric-types";
 import type {
+	MetricAnalyticsContext,
 	MetricEventIdentity,
 	MetricObservation,
 	MetricResourceAttributes,
@@ -22,6 +23,7 @@ export interface MetricsRecorder {
 	count(name: MetricName, value?: number, labels?: MetricLabelInput): void;
 	histogram(name: MetricName, value: number, labels?: MetricLabelInput): void;
 	gauge(name: MetricName, value: number, labels?: MetricLabelInput): void;
+	setAnalyticsContext(context?: MetricAnalyticsContext): void;
 	setEventIdentity(identity?: MetricEventIdentity): void;
 	flush(): Promise<void>;
 	snapshot(): readonly MetricObservation[];
@@ -34,6 +36,7 @@ export const NOOP_METRICS_RECORDER: MetricsRecorder = {
 	count(_name, _value, _labels): void {},
 	histogram(_name, _value, _labels): void {},
 	gauge(_name, _value, _labels): void {},
+	setAnalyticsContext(_context): void {},
 	setEventIdentity(_identity): void {},
 	flush(): Promise<void> {
 		return NOOP_FLUSH_PROMISE;
@@ -45,6 +48,7 @@ export const NOOP_METRICS_RECORDER: MetricsRecorder = {
 
 export class RequestMetricsRecorder implements MetricsRecorder {
 	private readonly observations: MetricObservation[] = [];
+	private analyticsContext?: MetricAnalyticsContext;
 	private eventIdentity?: MetricEventIdentity;
 	private flushPromise?: Promise<void>;
 	private flushed = false;
@@ -61,6 +65,20 @@ export class RequestMetricsRecorder implements MetricsRecorder {
 
 	gauge(name: MetricName, value: number, labels?: MetricLabelInput): void {
 		this.record("gauge", name, value, labels);
+	}
+
+	setAnalyticsContext(context?: MetricAnalyticsContext): void {
+		if (!context) {
+			return;
+		}
+
+		const nextContext: MetricAnalyticsContext = {
+			...this.analyticsContext,
+		};
+		if (context.apiRequestedVersion) {
+			nextContext.apiRequestedVersion = context.apiRequestedVersion;
+		}
+		this.analyticsContext = nextContext;
 	}
 
 	setEventIdentity(identity?: MetricEventIdentity): void {
@@ -136,6 +154,9 @@ export class RequestMetricsRecorder implements MetricsRecorder {
 			await this.options.sink.flush({
 				observations,
 				resourceAttributes: { ...this.options.resourceAttributes },
+				analyticsContext: this.analyticsContext
+					? { ...this.analyticsContext }
+					: undefined,
 				eventIdentity: this.eventIdentity
 					? { ...this.eventIdentity }
 					: undefined,
@@ -152,17 +173,13 @@ export function scheduleMetricsFlush(
 	recorder: MetricsRecorder,
 	waitUntil?: MetricsWaitUntil,
 ): void {
-	let flushPromise: Promise<void>;
-	try {
-		flushPromise = recorder.flush().catch((error) => {
-			console.error("[metrics] Failed to execute metrics flush", error);
-		});
-	} catch (error) {
+	const flushPromise = recorder.flush().catch((error) => {
 		console.error("[metrics] Failed to execute metrics flush", error);
-		return;
-	}
+	});
 
 	if (!waitUntil) {
+		// Non-Worker runtimes and tests may not provide waitUntil. Start the guarded
+		// flush anyway and intentionally detach from it.
 		void flushPromise;
 		return;
 	}

--- a/src/metrics/runtime/metrics-sink.ts
+++ b/src/metrics/runtime/metrics-sink.ts
@@ -25,10 +25,20 @@ export type MetricEventIdentity = {
 	userId?: string;
 };
 
+// Sink-specific context for dimensions that should not become generic metric labels.
+// `api_version`, `api_version_mode`, and `api_release_date` stay in `MetricObservation.labels`
+// because both Grafana and Analytics Engine should receive them as low-cardinality dimensions.
+// `apiRequestedVersion` lives here instead because we only want it in Analytics Engine as
+// request-debug context, not as an extra Grafana label.
+export type MetricAnalyticsContext = {
+	apiRequestedVersion?: string;
+};
+
 export type MetricsFlushPayload = {
 	observations: readonly MetricObservation[];
 	resourceAttributes: MetricResourceAttributes;
 	eventIdentity?: MetricEventIdentity;
+	analyticsContext?: MetricAnalyticsContext;
 };
 
 export interface MetricsSink {

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -12,6 +12,7 @@ import {
 	type MetricsRecorder,
 	NOOP_METRICS_RECORDER,
 	RequestMetricsRecorder,
+	scheduleMetricsFlush,
 } from "./metrics-recorder";
 import type { MetricsSink } from "./metrics-sink";
 import {
@@ -88,7 +89,7 @@ export function getMetricOutcomeForStatus(status: number): MetricOutcome {
 	return "success";
 }
 
-function getCanonicalResolvedApiVersion(apiVersion: string): string {
+export function getCanonicalResolvedApiVersion(apiVersion: string): string {
 	const versionConfig = resolveApiVersion(apiVersion);
 	if (versionConfig.version.includes("beta")) {
 		return "beta";
@@ -258,21 +259,7 @@ function scheduleRequestMetricsFlush(
 	recorder: MetricsRecorder,
 	ctx: ExecutionContext,
 ): void {
-	let flushPromise: Promise<void>;
-	try {
-		flushPromise = recorder.flush().catch((error) => {
-			console.error("[metrics] Failed to execute request metrics flush", error);
-		});
-	} catch (error) {
-		console.error("[metrics] Failed to execute request metrics flush", error);
-		return;
-	}
-
-	try {
-		ctx.waitUntil(flushPromise);
-	} catch (error) {
-		console.error("[metrics] Failed to schedule request metrics flush", error);
-	}
+	scheduleMetricsFlush(recorder, ctx.waitUntil.bind(ctx));
 }
 
 export async function withRequestMetrics<T>(

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -1,4 +1,7 @@
-import { resolveApiVersion } from "../../servers/version-registry";
+import {
+	YYYY_MM_DD_DATE_REGEX,
+	resolveApiVersionMetrics,
+} from "../../servers/version-registry";
 import { createAnalyticsEngineMetricsSink } from "./analytics-engine-sink";
 import { createGrafanaOtlpMetricsSink } from "./grafana-otlp-sink";
 import { getStatusClass, resolveRequestMetricContext } from "./metric-context";
@@ -45,6 +48,8 @@ type MetricsExecutionContext = ExecutionContext & {
 	[METRICS_RECORDER_SYMBOL]?: MetricsRecorder;
 	props?: {
 		apiVersion?: unknown;
+		apiRequestedVersion?: unknown;
+		apiVersionMode?: unknown;
 	};
 };
 
@@ -90,47 +95,69 @@ export function getMetricOutcomeForStatus(status: number): MetricOutcome {
 	return "success";
 }
 
-export function getCanonicalResolvedApiVersion(apiVersion: string): string {
-	const versionConfig = resolveApiVersion(apiVersion);
-	if (versionConfig.version.includes("beta")) {
-		return "beta";
-	}
-	if (versionConfig.version.includes("backwards-compatibility-default")) {
-		return "default";
-	}
-	if (versionConfig.version.includes("latest")) {
-		return "latest";
-	}
-
-	return "unknown";
-}
-
 type ApiVersionLabels = {
+	apiRequestedVersion?: string;
+	apiReleaseDate?: string;
 	apiVersion?: string;
 	apiVersionMode?: ApiVersionMode;
 };
 
-function getRequestedApiVersionMode(
+export function normalizeRequestedApiVersionForAnalytics(
+	requestedApiVersion: string,
+): string {
+	if (
+		requestedApiVersion === "beta" ||
+		requestedApiVersion === "backwards-compatibility-default" ||
+		requestedApiVersion === "latest" ||
+		YYYY_MM_DD_DATE_REGEX.test(requestedApiVersion)
+	) {
+		return requestedApiVersion;
+	}
+
+	return "invalid";
+}
+
+export function resolveRequestedApiVersionMode(
 	requestedApiVersion: string,
 ): ApiVersionMode {
 	if (requestedApiVersion === "beta") {
 		return "beta";
 	}
-	if (requestedApiVersion === "latest") {
-		return "latest";
+	if (requestedApiVersion === "backwards-compatibility-default") {
+		return "explicit_legacy";
 	}
-	if (/^\d{4}-\d{2}-\d{2}$/.test(requestedApiVersion)) {
+	if (requestedApiVersion === "latest") {
+		return "explicit_latest";
+	}
+	if (YYYY_MM_DD_DATE_REGEX.test(requestedApiVersion)) {
 		return "pinned";
+	}
+	return "unknown";
+}
+
+function getImplicitApiVersionMode(apiVersion?: string): ApiVersionMode {
+	if (apiVersion === "backwards-compatibility-default") {
+		return "implicit_legacy";
+	}
+	if (apiVersion === "latest") {
+		return "implicit_latest";
+	}
+	if (apiVersion === "beta") {
+		return "beta";
 	}
 	return "unknown";
 }
 
 /**
  * We intentionally split version labeling into two dimensions:
- * - `api_version`: the effective served surface (`default` vs `latest`), which answers
- *   "which tenants are still on legacy/v1?"
+ * - `api_version`: the effective served surface (`backwards-compatibility-default`
+ *   vs `latest`), which answers "which tenants are still on the legacy/v1 surface?"
  * - `api_version_mode`: how the caller selected that surface, which answers
- *   "which tenants are pinned vs simply following the latest surface?"
+ *   "which tenants are pinned vs implicitly following a route default?"
+ * - `api_requested_version`: Analytics Engine-only context with the normalized selector
+ *   the caller actually sent (`latest`, `beta`, a date, or `invalid`)
+ * - `api_release_date`: the resolved dated release behind that surface, which answers
+ *   "what exact release date would be affected by a deprecation?"
  */
 export function resolveApiVersionLabels(
 	request: Request,
@@ -146,6 +173,10 @@ export function resolveApiVersionLabels(
 	);
 	const effectiveApiVersion = (ctx as MetricsExecutionContext).props
 		?.apiVersion;
+	const effectiveRequestedApiVersion = (ctx as MetricsExecutionContext).props
+		?.apiRequestedVersion;
+	const effectiveApiVersionMode = (ctx as MetricsExecutionContext).props
+		?.apiVersionMode;
 	if (requestedApiVersion) {
 		const apiVersionSource =
 			typeof effectiveApiVersion === "string" && effectiveApiVersion.length > 0
@@ -153,11 +184,26 @@ export function resolveApiVersionLabels(
 				: requestedApiVersion;
 		try {
 			return {
-				apiVersion: getCanonicalResolvedApiVersion(apiVersionSource),
-				apiVersionMode: getRequestedApiVersionMode(requestedApiVersion),
+				apiRequestedVersion:
+					typeof effectiveRequestedApiVersion === "string" &&
+					effectiveRequestedApiVersion.length > 0
+						? effectiveRequestedApiVersion
+						: normalizeRequestedApiVersionForAnalytics(requestedApiVersion),
+				...resolveApiVersionMetrics(apiVersionSource),
+				apiVersionMode:
+					typeof effectiveApiVersionMode === "string" &&
+					effectiveApiVersionMode.length > 0
+						? effectiveApiVersionMode
+						: resolveRequestedApiVersionMode(requestedApiVersion),
 			};
 		} catch {
 			return {
+				apiRequestedVersion:
+					typeof effectiveRequestedApiVersion === "string" &&
+					effectiveRequestedApiVersion.length > 0
+						? effectiveRequestedApiVersion
+						: normalizeRequestedApiVersionForAnalytics(requestedApiVersion),
+				apiReleaseDate: undefined,
 				apiVersion: "unknown",
 				apiVersionMode: "unknown",
 			};
@@ -169,20 +215,18 @@ export function resolveApiVersionLabels(
 		effectiveApiVersion.length > 0
 	) {
 		try {
-			const apiVersion = getCanonicalResolvedApiVersion(effectiveApiVersion);
+			const resolved = resolveApiVersionMetrics(effectiveApiVersion);
 			return {
-				apiVersion,
+				...resolved,
 				apiVersionMode:
-					apiVersion === "default"
-						? "implicit_default"
-						: apiVersion === "latest"
-							? "latest"
-							: apiVersion === "beta"
-								? "beta"
-								: "unknown",
+					typeof effectiveApiVersionMode === "string" &&
+					effectiveApiVersionMode.length > 0
+						? effectiveApiVersionMode
+						: getImplicitApiVersionMode(resolved.apiVersion),
 			};
 		} catch {
 			return {
+				apiReleaseDate: undefined,
 				apiVersion: "unknown",
 				apiVersionMode: "unknown",
 			};
@@ -193,15 +237,17 @@ export function resolveApiVersionLabels(
 		requestContext.routeGroup === "token_mcp" ||
 		requestContext.routeGroup === "token_sse"
 	) {
+		const resolved = resolveApiVersionMetrics("latest");
 		return {
-			apiVersion: "latest",
-			apiVersionMode: "latest",
+			...resolved,
+			apiVersionMode: "implicit_latest",
 		};
 	}
 
+	const resolved = resolveApiVersionMetrics("backwards-compatibility-default");
 	return {
-		apiVersion: "default",
-		apiVersionMode: "implicit_default",
+		...resolved,
+		apiVersionMode: "implicit_legacy",
 	};
 }
 
@@ -239,6 +285,15 @@ export function recordBearerAuthRequestMetric(
 	}
 
 	const requestContext = resolveRequestMetricContext(request);
+	const requestedApiVersion = new URL(request.url).searchParams.get(
+		"api-version",
+	);
+	if (requestedApiVersion) {
+		recorder.setAnalyticsContext({
+			apiRequestedVersion:
+				normalizeRequestedApiVersionForAnalytics(requestedApiVersion),
+		});
+	}
 	recordStatusMetric(recorder, METRIC_NAMES.bearerAuthRequestsTotal, status, {
 		route_group: routeGroupOverride ?? requestContext.routeGroup,
 		transport: routeGroupOverride?.endsWith("_sse")
@@ -258,7 +313,13 @@ export function recordHttpRequestMetrics(
 ): void {
 	const requestContext = resolveRequestMetricContext(request);
 	const outcome = getMetricOutcomeForStatus(response.status);
-	const { apiVersion, apiVersionMode } = resolveApiVersionLabels(request, ctx);
+	const { apiRequestedVersion, apiReleaseDate, apiVersion, apiVersionMode } =
+		resolveApiVersionLabels(request, ctx);
+	if (apiRequestedVersion) {
+		recorder.setAnalyticsContext({
+			apiRequestedVersion,
+		});
+	}
 	const baseLabels: MetricLabelInput = {
 		route_group: requestContext.routeGroup,
 		transport: requestContext.transport,
@@ -272,6 +333,9 @@ export function recordHttpRequestMetrics(
 	}
 	if (apiVersionMode) {
 		baseLabels.api_version_mode = apiVersionMode;
+	}
+	if (apiReleaseDate) {
+		baseLabels.api_release_date = apiReleaseDate;
 	}
 
 	recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {

--- a/src/metrics/runtime/request-metrics.ts
+++ b/src/metrics/runtime/request-metrics.ts
@@ -3,6 +3,7 @@ import { createAnalyticsEngineMetricsSink } from "./analytics-engine-sink";
 import { createGrafanaOtlpMetricsSink } from "./grafana-otlp-sink";
 import { getStatusClass, resolveRequestMetricContext } from "./metric-context";
 import {
+	type ApiVersionMode,
 	METRIC_NAMES,
 	type MetricLabelInput,
 	type MetricName,
@@ -104,13 +105,40 @@ export function getCanonicalResolvedApiVersion(apiVersion: string): string {
 	return "unknown";
 }
 
-export function resolveCanonicalApiVersionLabel(
+type ApiVersionLabels = {
+	apiVersion?: string;
+	apiVersionMode?: ApiVersionMode;
+};
+
+function getRequestedApiVersionMode(
+	requestedApiVersion: string,
+): ApiVersionMode {
+	if (requestedApiVersion === "beta") {
+		return "beta";
+	}
+	if (requestedApiVersion === "latest") {
+		return "latest";
+	}
+	if (/^\d{4}-\d{2}-\d{2}$/.test(requestedApiVersion)) {
+		return "pinned";
+	}
+	return "unknown";
+}
+
+/**
+ * We intentionally split version labeling into two dimensions:
+ * - `api_version`: the effective served surface (`default` vs `latest`), which answers
+ *   "which tenants are still on legacy/v1?"
+ * - `api_version_mode`: how the caller selected that surface, which answers
+ *   "which tenants are pinned vs simply following the latest surface?"
+ */
+export function resolveApiVersionLabels(
 	request: Request,
 	ctx: ExecutionContext,
-): string | undefined {
+): ApiVersionLabels {
 	const requestContext = resolveRequestMetricContext(request);
 	if (!VERSIONED_REQUEST_ROUTE_GROUPS.has(requestContext.routeGroup)) {
-		return undefined;
+		return {};
 	}
 
 	const requestedApiVersion = new URL(request.url).searchParams.get(
@@ -118,26 +146,70 @@ export function resolveCanonicalApiVersionLabel(
 	);
 	const effectiveApiVersion = (ctx as MetricsExecutionContext).props
 		?.apiVersion;
+	if (requestedApiVersion) {
+		const apiVersionSource =
+			typeof effectiveApiVersion === "string" && effectiveApiVersion.length > 0
+				? effectiveApiVersion
+				: requestedApiVersion;
+		try {
+			return {
+				apiVersion: getCanonicalResolvedApiVersion(apiVersionSource),
+				apiVersionMode: getRequestedApiVersionMode(requestedApiVersion),
+			};
+		} catch {
+			return {
+				apiVersion: "unknown",
+				apiVersionMode: "unknown",
+			};
+		}
+	}
+
 	if (
 		typeof effectiveApiVersion === "string" &&
 		effectiveApiVersion.length > 0
 	) {
 		try {
-			return getCanonicalResolvedApiVersion(effectiveApiVersion);
+			const apiVersion = getCanonicalResolvedApiVersion(effectiveApiVersion);
+			return {
+				apiVersion,
+				apiVersionMode:
+					apiVersion === "default"
+						? "implicit_default"
+						: apiVersion === "latest"
+							? "latest"
+							: apiVersion === "beta"
+								? "beta"
+								: "unknown",
+			};
 		} catch {
-			return "unknown";
+			return {
+				apiVersion: "unknown",
+				apiVersionMode: "unknown",
+			};
 		}
 	}
 
-	if (!requestedApiVersion) {
-		return "default";
+	if (
+		requestContext.routeGroup === "token_mcp" ||
+		requestContext.routeGroup === "token_sse"
+	) {
+		return {
+			apiVersion: "latest",
+			apiVersionMode: "latest",
+		};
 	}
 
-	try {
-		return getCanonicalResolvedApiVersion(requestedApiVersion);
-	} catch {
-		return "unknown";
-	}
+	return {
+		apiVersion: "default",
+		apiVersionMode: "implicit_default",
+	};
+}
+
+export function resolveCanonicalApiVersionLabel(
+	request: Request,
+	ctx: ExecutionContext,
+): string | undefined {
+	return resolveApiVersionLabels(request, ctx).apiVersion;
 }
 
 export function recordStatusMetric(
@@ -186,7 +258,7 @@ export function recordHttpRequestMetrics(
 ): void {
 	const requestContext = resolveRequestMetricContext(request);
 	const outcome = getMetricOutcomeForStatus(response.status);
-	const apiVersion = resolveCanonicalApiVersionLabel(request, ctx);
+	const { apiVersion, apiVersionMode } = resolveApiVersionLabels(request, ctx);
 	const baseLabels: MetricLabelInput = {
 		route_group: requestContext.routeGroup,
 		transport: requestContext.transport,
@@ -197,6 +269,9 @@ export function recordHttpRequestMetrics(
 
 	if (apiVersion) {
 		baseLabels.api_version = apiVersion;
+	}
+	if (apiVersionMode) {
+		baseLabels.api_version_mode = apiVersionMode;
 	}
 
 	recorder.count(METRIC_NAMES.httpRequestsTotal, 1, {

--- a/src/metrics/runtime/tool-metrics.ts
+++ b/src/metrics/runtime/tool-metrics.ts
@@ -1,6 +1,7 @@
 import { ZodError } from "zod";
 import { McpServerError } from "../../utils";
 import {
+	type ApiVersionMode,
 	METRIC_NAMES,
 	type MetricLabelInput,
 	type MetricOutcome,
@@ -37,6 +38,7 @@ function buildToolMetricLabels(
 	apiSurface: ToolMetricApiSurface,
 	outcome: MetricOutcome,
 	apiVersion?: string,
+	apiVersionMode?: ApiVersionMode,
 ): MetricLabelInput {
 	const labels: MetricLabelInput = {
 		tool_name: toolName,
@@ -46,6 +48,9 @@ function buildToolMetricLabels(
 
 	if (apiVersion) {
 		labels.api_version = apiVersion;
+	}
+	if (apiVersionMode) {
+		labels.api_version_mode = apiVersionMode;
 	}
 
 	return labels;
@@ -86,12 +91,14 @@ export function recordToolInvocationMetrics(
 	outcome: MetricOutcome,
 	durationMs: number,
 	apiVersion?: string,
+	apiVersionMode?: ApiVersionMode,
 ): void {
 	const labels = buildToolMetricLabels(
 		toolName,
 		apiSurface,
 		outcome,
 		apiVersion,
+		apiVersionMode,
 	);
 
 	recorder.count(METRIC_NAMES.toolCallsTotal, 1, labels);
@@ -134,6 +141,7 @@ export function recordUpstreamStreamStartedMetric(
 
 export function recordUpstreamStreamMessageMetric(
 	recorder: MetricsRecorder | undefined,
+	operation: UpstreamOperation,
 	messageType: UpstreamStreamMessageType,
 	isThinking: boolean,
 ): void {
@@ -142,6 +150,7 @@ export function recordUpstreamStreamMessageMetric(
 	}
 
 	recorder.count(METRIC_NAMES.upstreamStreamMessagesTotal, 1, {
+		upstream_operation: operation,
 		message_type: messageType,
 		is_thinking: isThinking,
 	});

--- a/src/metrics/runtime/tool-metrics.ts
+++ b/src/metrics/runtime/tool-metrics.ts
@@ -39,6 +39,7 @@ function buildToolMetricLabels(
 	outcome: MetricOutcome,
 	apiVersion?: string,
 	apiVersionMode?: ApiVersionMode,
+	apiReleaseDate?: string,
 ): MetricLabelInput {
 	const labels: MetricLabelInput = {
 		tool_name: toolName,
@@ -51,6 +52,9 @@ function buildToolMetricLabels(
 	}
 	if (apiVersionMode) {
 		labels.api_version_mode = apiVersionMode;
+	}
+	if (apiReleaseDate) {
+		labels.api_release_date = apiReleaseDate;
 	}
 
 	return labels;
@@ -92,6 +96,7 @@ export function recordToolInvocationMetrics(
 	durationMs: number,
 	apiVersion?: string,
 	apiVersionMode?: ApiVersionMode,
+	apiReleaseDate?: string,
 ): void {
 	const labels = buildToolMetricLabels(
 		toolName,
@@ -99,6 +104,7 @@ export function recordToolInvocationMetrics(
 		outcome,
 		apiVersion,
 		apiVersionMode,
+		apiReleaseDate,
 	);
 
 	recorder.count(METRIC_NAMES.toolCallsTotal, 1, labels);

--- a/src/metrics/runtime/tool-metrics.ts
+++ b/src/metrics/runtime/tool-metrics.ts
@@ -26,7 +26,7 @@ export const UPSTREAM_OPERATION_NAMES = {
 export type UpstreamOperation =
 	(typeof UPSTREAM_OPERATION_NAMES)[keyof typeof UPSTREAM_OPERATION_NAMES];
 
-export type ToolMetricApiSurface = "mcp" | "openai_mcp";
+export type ToolMetricApiSurface = "mcp";
 export type UpstreamStreamMessageType =
 	| "text"
 	| "text_chunk"

--- a/src/metrics/runtime/tool-metrics.ts
+++ b/src/metrics/runtime/tool-metrics.ts
@@ -1,0 +1,148 @@
+import { ZodError } from "zod";
+import { McpServerError } from "../../utils";
+import {
+	METRIC_NAMES,
+	type MetricLabelInput,
+	type MetricOutcome,
+} from "./metric-types";
+import type { MetricsRecorder } from "./metrics-recorder";
+
+export const UPSTREAM_OPERATION_NAMES = {
+	getSessionInfo: "get_session_info",
+	getDataSourceSuggestions: "get_data_source_suggestions",
+	queryGetDecomposedQuery: "query_get_decomposed_query",
+	singleAnswer: "single_answer",
+	exportAnswerReport: "export_answer_report",
+	getAnswerSession: "get_answer_session",
+	exportUnsavedAnswerTml: "export_unsaved_answer_tml",
+	createAgentConversation: "create_agent_conversation",
+	sendAgentConversationMessageStreaming:
+		"send_agent_conversation_message_streaming",
+	importMetadataTml: "import_metadata_tml",
+	searchMetadata: "search_metadata",
+} as const;
+
+export type UpstreamOperation =
+	(typeof UPSTREAM_OPERATION_NAMES)[keyof typeof UPSTREAM_OPERATION_NAMES];
+
+export type ToolMetricApiSurface = "mcp" | "openai_mcp";
+export type UpstreamStreamMessageType =
+	| "text"
+	| "text_chunk"
+	| "answer"
+	| "error";
+
+function buildToolMetricLabels(
+	toolName: string,
+	apiSurface: ToolMetricApiSurface,
+	outcome: MetricOutcome,
+	apiVersion?: string,
+): MetricLabelInput {
+	const labels: MetricLabelInput = {
+		tool_name: toolName,
+		api_surface: apiSurface,
+		outcome,
+	};
+
+	if (apiVersion) {
+		labels.api_version = apiVersion;
+	}
+
+	return labels;
+}
+
+export function getToolMetricOutcomeFromResult(result: unknown): MetricOutcome {
+	if (
+		typeof result === "object" &&
+		result !== null &&
+		"isError" in result &&
+		result.isError === true
+	) {
+		return "error";
+	}
+
+	return "success";
+}
+
+export function getToolMetricOutcomeFromError(error: unknown): MetricOutcome {
+	if (error instanceof ZodError) {
+		return "validation_error";
+	}
+
+	if (error instanceof McpServerError) {
+		if (error.statusCode >= 400 && error.statusCode < 500) {
+			return "client_error";
+		}
+		return "error";
+	}
+
+	return "error";
+}
+
+export function recordToolInvocationMetrics(
+	recorder: MetricsRecorder,
+	toolName: string,
+	apiSurface: ToolMetricApiSurface,
+	outcome: MetricOutcome,
+	durationMs: number,
+	apiVersion?: string,
+): void {
+	const labels = buildToolMetricLabels(
+		toolName,
+		apiSurface,
+		outcome,
+		apiVersion,
+	);
+
+	recorder.count(METRIC_NAMES.toolCallsTotal, 1, labels);
+	recorder.histogram(METRIC_NAMES.toolDurationMs, durationMs, labels);
+}
+
+export function recordUpstreamCallMetrics(
+	recorder: MetricsRecorder | undefined,
+	operation: UpstreamOperation,
+	outcome: MetricOutcome,
+	durationMs: number,
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	const labels: MetricLabelInput = {
+		upstream_operation: operation,
+		outcome,
+	};
+
+	recorder.count(METRIC_NAMES.upstreamCallsTotal, 1, labels);
+	recorder.histogram(METRIC_NAMES.upstreamDurationMs, durationMs, labels);
+}
+
+export function recordUpstreamStreamStartedMetric(
+	recorder: MetricsRecorder | undefined,
+	operation: UpstreamOperation,
+	outcome: MetricOutcome,
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	recorder.count(METRIC_NAMES.upstreamStreamsStartedTotal, 1, {
+		upstream_operation: operation,
+		outcome,
+	});
+}
+
+export function recordUpstreamStreamMessageMetric(
+	recorder: MetricsRecorder | undefined,
+	messageType: UpstreamStreamMessageType,
+	isThinking: boolean,
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	recorder.count(METRIC_NAMES.upstreamStreamMessagesTotal, 1, {
+		message_type: messageType,
+		is_thinking: isThinking,
+	});
+}

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -11,6 +11,7 @@ import { type Span, SpanStatusCode } from "@opentelemetry/api";
 import type { z } from "zod";
 import { TrackEvent, type Tracker, Trackers } from "../metrics";
 import { MixpanelTracker } from "../metrics/mixpanel/mixpanel";
+import type { ApiVersionMode } from "../metrics/runtime/metric-types";
 import {
 	type MetricsRecorder,
 	scheduleMetricsFlush,
@@ -215,6 +216,10 @@ export abstract class BaseMCPServer extends Server {
 		return undefined;
 	}
 
+	protected getToolMetricApiVersionModeLabel(): ApiVersionMode | undefined {
+		return undefined;
+	}
+
 	protected getMetricEventIdentity(): MetricEventIdentity | undefined {
 		if (!this.sessionInfo) {
 			return undefined;
@@ -262,6 +267,7 @@ export abstract class BaseMCPServer extends Server {
 				outcome,
 				durationMs,
 				this.getToolMetricApiVersionLabel(),
+				this.getToolMetricApiVersionModeLabel(),
 			);
 		} catch (error) {
 			console.error(

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -1,21 +1,33 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
 	CallToolRequestSchema,
-	ListToolsRequestSchema,
-	ToolSchema,
 	ListResourcesRequestSchema,
-	ReadResourceRequestSchema,
+	ListToolsRequestSchema,
 	type ListToolsResult,
+	ReadResourceRequestSchema,
+	ToolSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { z } from "zod";
 import { type Span, SpanStatusCode } from "@opentelemetry/api";
-import { getActiveSpan, withSpan } from "../metrics/tracing/tracing-utils";
-import { Trackers, type Tracker, TrackEvent } from "../metrics";
-import type { Props } from "../utils";
+import type { z } from "zod";
+import { TrackEvent, type Tracker, Trackers } from "../metrics";
 import { MixpanelTracker } from "../metrics/mixpanel/mixpanel";
+import {
+	type MetricsRecorder,
+	scheduleMetricsFlush,
+} from "../metrics/runtime/metrics-recorder";
+import type { MetricEventIdentity } from "../metrics/runtime/metrics-sink";
+import { createRequestMetricsRecorder } from "../metrics/runtime/request-metrics";
+import {
+	type ToolMetricApiSurface,
+	getToolMetricOutcomeFromError,
+	getToolMetricOutcomeFromResult,
+	recordToolInvocationMetrics,
+} from "../metrics/runtime/tool-metrics";
+import { getActiveSpan, withSpan } from "../metrics/tracing/tracing-utils";
+import { StorageServiceClient } from "../storage-service/storage-service";
 import { getThoughtSpotClient } from "../thoughtspot/thoughtspot-client";
 import { ThoughtSpotService } from "../thoughtspot/thoughtspot-service";
-import { StorageServiceClient } from "../storage-service/storage-service";
+import type { Props } from "../utils";
 
 const ToolInputSchema = ToolSchema.shape.inputSchema;
 type ToolInput = z.infer<typeof ToolInputSchema>;
@@ -41,6 +53,7 @@ export type ToolResponse = SuccessResponse | ErrorResponse;
 export interface Context {
 	props: Props;
 	env: Env;
+	ctx?: DurableObjectState;
 }
 
 export abstract class BaseMCPServer extends Server {
@@ -181,13 +194,109 @@ export abstract class BaseMCPServer extends Server {
 		);
 	}
 
-	protected getThoughtSpotService() {
+	protected getThoughtSpotService(recorder?: MetricsRecorder) {
 		return new ThoughtSpotService(
 			getThoughtSpotClient(
 				this.ctx.props.instanceUrl,
 				this.ctx.props.accessToken,
 			),
+			{
+				recorder,
+				metricsEnv: this.ctx.env as unknown as Record<string, unknown>,
+				waitUntil: this.getMetricsWaitUntil(),
+				eventIdentity: this.getMetricEventIdentity(),
+			},
 		);
+	}
+
+	protected abstract getToolMetricApiSurface(): ToolMetricApiSurface;
+
+	protected getToolMetricApiVersionLabel(): string | undefined {
+		return undefined;
+	}
+
+	protected getMetricEventIdentity(): MetricEventIdentity | undefined {
+		if (!this.sessionInfo) {
+			return undefined;
+		}
+
+		const tenantId = this.sessionInfo.currentOrgId
+			? String(this.sessionInfo.currentOrgId)
+			: undefined;
+		const userId = this.sessionInfo.userGUID
+			? String(this.sessionInfo.userGUID)
+			: undefined;
+		if (!tenantId && !userId) {
+			return undefined;
+		}
+
+		return {
+			tenantId,
+			userId,
+		};
+	}
+
+	private getMetricsWaitUntil() {
+		return this.ctx.ctx?.waitUntil?.bind(this.ctx.ctx);
+	}
+
+	private createToolMetricsRecorder(): MetricsRecorder {
+		const recorder = createRequestMetricsRecorder(
+			this.ctx.env as unknown as Record<string, unknown>,
+		);
+		recorder.setEventIdentity(this.getMetricEventIdentity());
+		return recorder;
+	}
+
+	private recordToolMetricsSafe(
+		recorder: MetricsRecorder,
+		toolName: string,
+		outcome: ReturnType<typeof getToolMetricOutcomeFromError>,
+		durationMs: number,
+	): void {
+		try {
+			recordToolInvocationMetrics(
+				recorder,
+				toolName,
+				this.getToolMetricApiSurface(),
+				outcome,
+				durationMs,
+				this.getToolMetricApiVersionLabel(),
+			);
+		} catch (error) {
+			console.error(
+				`[metrics] Failed to record tool metrics for ${toolName}`,
+				error,
+			);
+		}
+	}
+
+	private async withToolMetrics<T>(
+		request: z.infer<typeof CallToolRequestSchema>,
+		handler: (recorder: MetricsRecorder) => Promise<T>,
+	): Promise<T> {
+		const recorder = this.createToolMetricsRecorder();
+		const startedAt = Date.now();
+		let outcome: ReturnType<typeof getToolMetricOutcomeFromError> | undefined;
+
+		try {
+			const result = await handler(recorder);
+			outcome = getToolMetricOutcomeFromResult(result);
+			return result;
+		} catch (error) {
+			outcome = getToolMetricOutcomeFromError(error);
+			throw error;
+		} finally {
+			if (outcome) {
+				this.recordToolMetricsSafe(
+					recorder,
+					request.params.name,
+					outcome,
+					Date.now() - startedAt,
+				);
+			}
+			scheduleMetricsFlush(recorder, this.getMetricsWaitUntil());
+		}
 	}
 
 	protected async initializeService(): Promise<void> {
@@ -225,6 +334,7 @@ export abstract class BaseMCPServer extends Server {
 	 */
 	protected abstract callTool(
 		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
 	): Promise<any>;
 
 	async init() {
@@ -265,7 +375,9 @@ export abstract class BaseMCPServer extends Server {
 			async (request: z.infer<typeof CallToolRequestSchema>) => {
 				return withSpan("call-tool", async () => {
 					this.initSpanWithCommonAttributes();
-					return this.callTool(request);
+					return this.withToolMetrics(request, (recorder) =>
+						this.callTool(request, recorder),
+					);
 				});
 			},
 		);

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -16,7 +16,10 @@ import {
 	type MetricsRecorder,
 	scheduleMetricsFlush,
 } from "../metrics/runtime/metrics-recorder";
-import type { MetricEventIdentity } from "../metrics/runtime/metrics-sink";
+import type {
+	MetricAnalyticsContext,
+	MetricEventIdentity,
+} from "../metrics/runtime/metrics-sink";
 import { createRequestMetricsRecorder } from "../metrics/runtime/request-metrics";
 import {
 	type ToolMetricApiSurface,
@@ -205,6 +208,7 @@ export abstract class BaseMCPServer extends Server {
 				recorder,
 				metricsEnv: this.ctx.env as unknown as Record<string, unknown>,
 				waitUntil: this.getMetricsWaitUntil(),
+				analyticsContext: this.getMetricAnalyticsContext(),
 				eventIdentity: this.getMetricEventIdentity(),
 			},
 		);
@@ -218,6 +222,24 @@ export abstract class BaseMCPServer extends Server {
 
 	protected getToolMetricApiVersionModeLabel(): ApiVersionMode | undefined {
 		return undefined;
+	}
+
+	protected getToolMetricApiReleaseDateLabel(): string | undefined {
+		return undefined;
+	}
+
+	protected getMetricAnalyticsContext(): MetricAnalyticsContext | undefined {
+		const apiRequestedVersion = this.ctx.props.apiRequestedVersion;
+		if (
+			typeof apiRequestedVersion !== "string" ||
+			apiRequestedVersion.length === 0
+		) {
+			return undefined;
+		}
+
+		return {
+			apiRequestedVersion,
+		};
 	}
 
 	protected getMetricEventIdentity(): MetricEventIdentity | undefined {
@@ -249,6 +271,7 @@ export abstract class BaseMCPServer extends Server {
 		const recorder = createRequestMetricsRecorder(
 			this.ctx.env as unknown as Record<string, unknown>,
 		);
+		recorder.setAnalyticsContext(this.getMetricAnalyticsContext());
 		recorder.setEventIdentity(this.getMetricEventIdentity());
 		return recorder;
 	}
@@ -268,6 +291,7 @@ export abstract class BaseMCPServer extends Server {
 				durationMs,
 				this.getToolMetricApiVersionLabel(),
 				this.getToolMetricApiVersionModeLabel(),
+				this.getToolMetricApiReleaseDateLabel(),
 			);
 		} catch (error) {
 			console.error(

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -5,6 +5,7 @@ import type {
 import { SpanStatusCode, context, trace } from "@opentelemetry/api";
 import type { z } from "zod";
 import { TrackEvent } from "../metrics";
+import type { ApiVersionMode } from "../metrics/runtime/metric-types";
 import type { MetricsRecorder } from "../metrics/runtime/metrics-recorder";
 import { getCanonicalResolvedApiVersion } from "../metrics/runtime/request-metrics";
 import type { ToolMetricApiSurface } from "../metrics/runtime/tool-metrics";
@@ -50,6 +51,32 @@ export class MCPServer extends BaseMCPServer {
 		} catch {
 			return "unknown";
 		}
+	}
+
+	protected getToolMetricApiVersionModeLabel(): ApiVersionMode | undefined {
+		const apiVersion = this.ctx.props.apiVersion;
+		if (typeof apiVersion !== "string" || apiVersion.length === 0) {
+			return "implicit_default";
+		}
+
+		// Tool calls inherit the session-level version selection from the transport props.
+		// Together with `api_version`, this lets us answer:
+		// - "who is still on legacy/v1?" via `api_version=default`
+		// - "who is pinned vs following latest?" via `api_version_mode`
+		if (apiVersion === "beta") {
+			return "beta";
+		}
+		if (apiVersion === "latest") {
+			return "latest";
+		}
+		if (apiVersion === "backwards-compatibility-default") {
+			return "implicit_default";
+		}
+		if (/^\d{4}-\d{2}-\d{2}$/.test(apiVersion)) {
+			return "pinned";
+		}
+
+		return "unknown";
 	}
 
 	@WithSpan("call-list-tools")

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -7,7 +7,6 @@ import type { z } from "zod";
 import { TrackEvent } from "../metrics";
 import type { ApiVersionMode } from "../metrics/runtime/metric-types";
 import type { MetricsRecorder } from "../metrics/runtime/metrics-recorder";
-import { getCanonicalResolvedApiVersion } from "../metrics/runtime/request-metrics";
 import type { ToolMetricApiSurface } from "../metrics/runtime/tool-metrics";
 import { WithSpan } from "../metrics/tracing/tracing-utils";
 import type { StreamingMessagesStorageWithTtl } from "../streaming-message-storage-with-ttl/streaming-message-storage-with-ttl";
@@ -26,7 +25,11 @@ import {
 	SendSessionMessageInputSchema,
 	ToolName,
 } from "./tool-definitions";
-import { type VersionConfig, resolveApiVersion } from "./version-registry";
+import {
+	type VersionConfig,
+	resolveApiVersion,
+	resolveApiVersionMetrics,
+} from "./version-registry";
 
 export class MCPServer extends BaseMCPServer {
 	constructor(
@@ -43,40 +46,55 @@ export class MCPServer extends BaseMCPServer {
 	protected getToolMetricApiVersionLabel(): string | undefined {
 		const apiVersion = this.ctx.props.apiVersion;
 		if (typeof apiVersion !== "string" || apiVersion.length === 0) {
-			return "default";
+			return "backwards-compatibility-default";
 		}
 
 		try {
-			return getCanonicalResolvedApiVersion(apiVersion);
+			return resolveApiVersionMetrics(apiVersion).apiVersion;
 		} catch {
 			return "unknown";
 		}
 	}
 
 	protected getToolMetricApiVersionModeLabel(): ApiVersionMode | undefined {
+		const apiVersionMode = this.ctx.props.apiVersionMode;
+		if (typeof apiVersionMode === "string" && apiVersionMode.length > 0) {
+			return apiVersionMode;
+		}
+
+		const apiVersion = this.ctx.props.apiVersion;
+		if (typeof apiVersion === "string" && apiVersion.length > 0) {
+			try {
+				const resolved = resolveApiVersionMetrics(apiVersion);
+				if (resolved.apiVersion === "backwards-compatibility-default") {
+					return "implicit_legacy";
+				}
+				if (resolved.apiVersion === "latest") {
+					return "implicit_latest";
+				}
+				if (resolved.apiVersion === "beta") {
+					return "beta";
+				}
+			} catch {
+				return "unknown";
+			}
+		}
+
+		return "implicit_legacy";
+	}
+
+	protected getToolMetricApiReleaseDateLabel(): string | undefined {
 		const apiVersion = this.ctx.props.apiVersion;
 		if (typeof apiVersion !== "string" || apiVersion.length === 0) {
-			return "implicit_default";
+			return resolveApiVersionMetrics("backwards-compatibility-default")
+				.apiReleaseDate;
 		}
 
-		// Tool calls inherit the session-level version selection from the transport props.
-		// Together with `api_version`, this lets us answer:
-		// - "who is still on legacy/v1?" via `api_version=default`
-		// - "who is pinned vs following latest?" via `api_version_mode`
-		if (apiVersion === "beta") {
-			return "beta";
+		try {
+			return resolveApiVersionMetrics(apiVersion).apiReleaseDate;
+		} catch {
+			return undefined;
 		}
-		if (apiVersion === "latest") {
-			return "latest";
-		}
-		if (apiVersion === "backwards-compatibility-default") {
-			return "implicit_default";
-		}
-		if (/^\d{4}-\d{2}-\d{2}$/.test(apiVersion)) {
-			return "pinned";
-		}
-
-		return "unknown";
 	}
 
 	@WithSpan("call-list-tools")
@@ -92,7 +110,10 @@ export class MCPServer extends BaseMCPServer {
 		try {
 			versionConfig = resolveApiVersion(this.ctx.props.apiVersion);
 		} catch (error) {
-			console.error("Error resolving API version, using default:", error);
+			console.error(
+				"Error resolving API version, using latest fallback:",
+				error,
+			);
 			span?.recordException(error as Error);
 			versionConfig = resolveApiVersion();
 		}

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -2,27 +2,30 @@ import type {
 	CallToolRequestSchema,
 	ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { SpanStatusCode, context, trace } from "@opentelemetry/api";
 import type { z } from "zod";
-import { McpServerError } from "../utils";
-import type { DataSource } from "../thoughtspot/thoughtspot-service";
 import { TrackEvent } from "../metrics";
+import type { MetricsRecorder } from "../metrics/runtime/metrics-recorder";
+import { getCanonicalResolvedApiVersion } from "../metrics/runtime/request-metrics";
+import type { ToolMetricApiSurface } from "../metrics/runtime/tool-metrics";
 import { WithSpan } from "../metrics/tracing/tracing-utils";
-import { context, SpanStatusCode, trace } from "@opentelemetry/api";
-import { BaseMCPServer, type Context } from "./mcp-server-base";
-import { resolveApiVersion, type VersionConfig } from "./version-registry";
-import {
-	GetRelevantQuestionsSchema,
-	GetAnswerSchema,
-	CreateLiveboardSchema,
-	GetDataSourceSuggestionsSchema,
-	ToolName,
-	CreateAnalysisSessionInputSchema,
-	SendSessionMessageInputSchema,
-	GetSessionUpdatesInputSchema,
-	CreateDashboardInputSchema,
-} from "./tool-definitions";
 import type { StreamingMessagesStorageWithTtl } from "../streaming-message-storage-with-ttl/streaming-message-storage-with-ttl";
+import type { DataSource } from "../thoughtspot/thoughtspot-service";
 import type { Answer, StreamingMessagesState } from "../thoughtspot/types";
+import { McpServerError } from "../utils";
+import { BaseMCPServer, type Context } from "./mcp-server-base";
+import {
+	CreateAnalysisSessionInputSchema,
+	CreateDashboardInputSchema,
+	CreateLiveboardSchema,
+	GetAnswerSchema,
+	GetDataSourceSuggestionsSchema,
+	GetRelevantQuestionsSchema,
+	GetSessionUpdatesInputSchema,
+	SendSessionMessageInputSchema,
+	ToolName,
+} from "./tool-definitions";
+import { type VersionConfig, resolveApiVersion } from "./version-registry";
 
 export class MCPServer extends BaseMCPServer {
 	constructor(
@@ -30,6 +33,23 @@ export class MCPServer extends BaseMCPServer {
 		private streamingMessageStorage: StreamingMessagesStorageWithTtl,
 	) {
 		super(ctx, "ThoughtSpot", "2.0.0");
+	}
+
+	protected getToolMetricApiSurface(): ToolMetricApiSurface {
+		return "mcp";
+	}
+
+	protected getToolMetricApiVersionLabel(): string | undefined {
+		const apiVersion = this.ctx.props.apiVersion;
+		if (typeof apiVersion !== "string" || apiVersion.length === 0) {
+			return "default";
+		}
+
+		try {
+			return getCanonicalResolvedApiVersion(apiVersion);
+		} catch {
+			return "unknown";
+		}
 	}
 
 	@WithSpan("call-list-tools")
@@ -114,7 +134,10 @@ export class MCPServer extends BaseMCPServer {
 		};
 	}
 
-	protected async callTool(request: z.infer<typeof CallToolRequestSchema>) {
+	protected async callTool(
+		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
+	) {
 		const { name } = request.params;
 		this.trackers.track(TrackEvent.CallTool, { toolName: name });
 
@@ -127,19 +150,19 @@ export class MCPServer extends BaseMCPServer {
 			}
 
 			case ToolName.GetRelevantQuestions: {
-				return this.callGetRelevantQuestions(request);
+				return this.callGetRelevantQuestions(request, recorder);
 			}
 
 			case ToolName.GetAnswer: {
-				return this.callGetAnswer(request);
+				return this.callGetAnswer(request, recorder);
 			}
 
 			case ToolName.CreateLiveboard: {
-				return this.callCreateLiveboard(request);
+				return this.callCreateLiveboard(request, recorder);
 			}
 
 			case ToolName.GetDataSourceSuggestions: {
-				return this.callGetDataSourceSuggestions(request);
+				return this.callGetDataSourceSuggestions(request, recorder);
 			}
 
 			case ToolName.CheckConnectivity: {
@@ -156,19 +179,19 @@ export class MCPServer extends BaseMCPServer {
 			}
 
 			case ToolName.CreateAnalysisSession: {
-				return this.callCreateAnalysisSession(request);
+				return this.callCreateAnalysisSession(request, recorder);
 			}
 
 			case ToolName.SendSessionMessage: {
-				return this.callSendSessionMessage(request);
+				return this.callSendSessionMessage(request, recorder);
 			}
 
 			case ToolName.GetSessionUpdates: {
-				return this.callGetSessionUpdates(request);
+				return this.callGetSessionUpdates(request, recorder);
 			}
 
 			case ToolName.CreateDashboard: {
-				return this.callCreateDashboard(request);
+				return this.callCreateDashboard(request, recorder);
 			}
 
 			default:
@@ -179,6 +202,7 @@ export class MCPServer extends BaseMCPServer {
 	@WithSpan("call-get-relevant-questions")
 	async callGetRelevantQuestions(
 		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
 	) {
 		const {
 			query,
@@ -190,12 +214,9 @@ export class MCPServer extends BaseMCPServer {
 			sourceIds,
 		);
 
-		const relevantQuestions =
-			await this.getThoughtSpotService().getRelevantQuestions(
-				query,
-				sourceIds!,
-				additionalContext ?? "",
-			);
+		const relevantQuestions = await this.getThoughtSpotService(
+			recorder,
+		).getRelevantQuestions(query, sourceIds!, additionalContext ?? "");
 
 		if (relevantQuestions.error) {
 			console.error(
@@ -235,16 +256,17 @@ export class MCPServer extends BaseMCPServer {
 	}
 
 	@WithSpan("call-get-answer")
-	async callGetAnswer(request: z.infer<typeof CallToolRequestSchema>) {
+	async callGetAnswer(
+		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
+	) {
 		const { question, datasourceId: sourceId } = GetAnswerSchema.parse(
 			request.params.arguments,
 		);
 
-		const answer = await this.getThoughtSpotService().getAnswerForQuestion(
-			question,
-			sourceId,
-			false,
-		);
+		const answer = await this.getThoughtSpotService(
+			recorder,
+		).getAnswerForQuestion(question, sourceId, false);
 
 		if (answer.error) {
 			return this.createErrorResponse(
@@ -268,7 +290,10 @@ export class MCPServer extends BaseMCPServer {
 	}
 
 	@WithSpan("call-create-liveboard")
-	async callCreateLiveboard(request: z.infer<typeof CallToolRequestSchema>) {
+	async callCreateLiveboard(
+		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
+	) {
 		const { name, answers, noteTile } = CreateLiveboardSchema.parse(
 			request.params.arguments,
 		);
@@ -277,12 +302,9 @@ export class MCPServer extends BaseMCPServer {
 			session_identifier: answer.session_identifier,
 			generation_number: answer.generation_number,
 		}));
-		const liveboard =
-			await this.getThoughtSpotService().fetchTMLAndCreateLiveboard(
-				name,
-				transformedAnswers,
-				noteTile,
-			);
+		const liveboard = await this.getThoughtSpotService(
+			recorder,
+		).fetchTMLAndCreateLiveboard(name, transformedAnswers, noteTile);
 
 		if (liveboard.error) {
 			return this.createErrorResponse(
@@ -304,6 +326,7 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 	@WithSpan("call-create-analysis-session")
 	async callCreateAnalysisSession(
 		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
 	) {
 		const span = trace.getSpan(context.active());
 		const { data_source_id } = CreateAnalysisSessionInputSchema.parse(
@@ -312,7 +335,7 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		span?.setAttribute("data_source_id", data_source_id ?? "(none)");
 
 		const response =
-			await this.getThoughtSpotService().createAgentConversation(
+			await this.getThoughtSpotService(recorder).createAgentConversation(
 				data_source_id,
 			);
 		span?.setAttribute("analytical_session_id", response.conversation_id);
@@ -327,7 +350,10 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 	}
 
 	@WithSpan("call-send-session-message")
-	async callSendSessionMessage(request: z.infer<typeof CallToolRequestSchema>) {
+	async callSendSessionMessage(
+		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
+	) {
 		const span = trace.getSpan(context.active());
 		const { analytical_session_id, message, additional_context } =
 			SendSessionMessageInputSchema.parse(request.params.arguments);
@@ -350,7 +376,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			);
 		}
 
-		await this.getThoughtSpotService().sendAgentConversationMessageStreaming(
+		await this.getThoughtSpotService(
+			recorder,
+		).sendAgentConversationMessageStreaming(
 			analytical_session_id,
 			message,
 			storageService.appendMessages.bind(storageService),
@@ -364,7 +392,10 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 	}
 
 	@WithSpan("call-get-session-updates")
-	async callGetSessionUpdates(request: z.infer<typeof CallToolRequestSchema>) {
+	async callGetSessionUpdates(
+		request: z.infer<typeof CallToolRequestSchema>,
+		_recorder: MetricsRecorder,
+	) {
 		const span = trace.getSpan(context.active());
 		const { analytical_session_id } = GetSessionUpdatesInputSchema.parse(
 			request.params.arguments,
@@ -421,7 +452,10 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 	}
 
 	@WithSpan("call-create-dashboard")
-	async callCreateDashboard(request: z.infer<typeof CallToolRequestSchema>) {
+	async callCreateDashboard(
+		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
+	) {
 		const span = trace.getSpan(context.active());
 		const { title, answers, note_tile } = CreateDashboardInputSchema.parse(
 			request.params.arguments,
@@ -448,12 +482,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			);
 		}
 
-		const liveboard =
-			await this.getThoughtSpotService().fetchTMLAndCreateLiveboard(
-				title,
-				transformedAnswers,
-				note_tile,
-			);
+		const liveboard = await this.getThoughtSpotService(
+			recorder,
+		).fetchTMLAndCreateLiveboard(title, transformedAnswers, note_tile);
 
 		if (liveboard.error) {
 			return this.createErrorResponse(
@@ -473,12 +504,15 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 	@WithSpan("call-get-data-source-suggestions")
 	async callGetDataSourceSuggestions(
 		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
 	) {
 		const { query } = GetDataSourceSuggestionsSchema.parse(
 			request.params.arguments,
 		);
 		const dataSources =
-			await this.getThoughtSpotService().getDataSourceSuggestions(query);
+			await this.getThoughtSpotService(recorder).getDataSourceSuggestions(
+				query,
+			);
 
 		if (!dataSources || dataSources.length === 0) {
 			return this.createErrorResponse(
@@ -506,12 +540,12 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 	} | null = null;
 
 	@WithSpan("get-datasources")
-	async getDatasources() {
+	async getDatasources(recorder?: MetricsRecorder) {
 		if (this._sources) {
 			return this._sources;
 		}
 
-		const sources = await this.getThoughtSpotService().getDataSources();
+		const sources = await this.getThoughtSpotService(recorder).getDataSources();
 		this._sources = {
 			list: sources,
 			map: new Map(sources.map((s) => [s.id, s])),

--- a/src/servers/version-registry.ts
+++ b/src/servers/version-registry.ts
@@ -1,6 +1,17 @@
 import { toolDefinitionsV1, toolDefinitionsV2 } from "./tool-definitions";
 
-const YYYY_MM_DD_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+export const YYYY_MM_DD_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export type CanonicalApiVersionLabel =
+	| "backwards-compatibility-default"
+	| "latest"
+	| "beta"
+	| "unknown";
+
+export type ResolvedApiVersionMetrics = {
+	apiReleaseDate?: string;
+	apiVersion: CanonicalApiVersionLabel;
+};
 
 /**
  * Version configuration interface
@@ -25,6 +36,15 @@ function getReleaseDateFromVersion(versions: string[]): Date | null {
 		return null;
 	}
 	return new Date(possibleDateVersion);
+}
+
+export function getReleaseDateIdentifier(
+	versions: string[],
+): string | undefined {
+	const possibleDateVersion = versions[versions.length - 1];
+	return YYYY_MM_DD_DATE_REGEX.test(possibleDateVersion)
+		? possibleDateVersion
+		: undefined;
 }
 
 /**
@@ -95,4 +115,33 @@ export function resolveApiVersion(apiVersion = "latest"): VersionConfig {
 		apiVersion,
 	);
 	return VERSION_REGISTRY[VERSION_REGISTRY.length - 1];
+}
+
+export function resolveApiVersionMetrics(
+	apiVersion: string,
+): ResolvedApiVersionMetrics {
+	const versionConfig = resolveApiVersion(apiVersion);
+	if (versionConfig.version.includes("beta")) {
+		return {
+			apiVersion: "beta",
+			apiReleaseDate: getReleaseDateIdentifier(versionConfig.version),
+		};
+	}
+	if (versionConfig.version.includes("backwards-compatibility-default")) {
+		return {
+			apiVersion: "backwards-compatibility-default",
+			apiReleaseDate: getReleaseDateIdentifier(versionConfig.version),
+		};
+	}
+	if (versionConfig.version.includes("latest")) {
+		return {
+			apiVersion: "latest",
+			apiReleaseDate: getReleaseDateIdentifier(versionConfig.version),
+		};
+	}
+
+	return {
+		apiVersion: "unknown",
+		apiReleaseDate: getReleaseDateIdentifier(versionConfig.version),
+	};
 }

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -1,6 +1,8 @@
-import type { Message } from "./thoughtspot/types";
-import { withSpan } from "./metrics/tracing/tracing-utils";
 import { type Span, SpanStatusCode } from "@opentelemetry/api";
+import type { MetricsRecorder } from "./metrics/runtime/metrics-recorder";
+import { recordUpstreamStreamMessageMetric } from "./metrics/runtime/tool-metrics";
+import { withSpan } from "./metrics/tracing/tracing-utils";
+import type { Message } from "./thoughtspot/types";
 
 /*
  * Handles processing the event stream from a send agent conversation message response. Reads from
@@ -16,6 +18,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 		isDone?: boolean,
 	) => Promise<void>,
 	instanceUrl: string,
+	recorder?: MetricsRecorder,
 ) => {
 	return await withSpan(
 		"process-send-agent-conversation-message-streaming-response",
@@ -71,6 +74,11 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 						for (const item of data) {
 							if (item.type === "text") {
 								nTextMessagesParsed++;
+								recordUpstreamStreamMessageMetric(
+									recorder,
+									"text",
+									item.metadata?.type === "thinking",
+								);
 								newMessages.push({
 									is_thinking: item.metadata?.type === "thinking",
 									type: "text",
@@ -78,6 +86,11 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								});
 							} else if (item.type === "text-chunk") {
 								nTextMessagesParsed++;
+								recordUpstreamStreamMessageMetric(
+									recorder,
+									"text_chunk",
+									item.metadata?.type === "thinking",
+								);
 								newMessages.push({
 									is_thinking: item.metadata?.type === "thinking",
 									type: "text_chunk",
@@ -85,6 +98,11 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								});
 							} else if (item.type === "answer") {
 								nAnswerMessagesParsed++;
+								recordUpstreamStreamMessageMetric(
+									recorder,
+									"answer",
+									item.metadata?.type === "thinking",
+								);
 								const iframeUrl = `${instanceUrl}/?tsmcp=true#/embed/conv-assist-answer?sessionId=${item.metadata?.session_id}&genNo=${item.metadata?.gen_no}&acSessionId=${item.metadata?.transaction_id}&acGenNo=${item.metadata?.generation_number}`;
 								newMessages.push({
 									is_thinking: item.metadata?.type === "thinking",
@@ -108,7 +126,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								nMessagesIgnored++;
 							} else if (item.type === "error") {
 								console.error("Error event in event stream: ", item);
-								nTextMessagesParsed++;
+								recordUpstreamStreamMessageMetric(recorder, "error", false);
 								spanHasError = true;
 								span.setStatus({
 									code: SpanStatusCode.ERROR,

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -1,6 +1,9 @@
 import { type Span, SpanStatusCode } from "@opentelemetry/api";
 import type { MetricsRecorder } from "./metrics/runtime/metrics-recorder";
-import { recordUpstreamStreamMessageMetric } from "./metrics/runtime/tool-metrics";
+import {
+	UPSTREAM_OPERATION_NAMES,
+	recordUpstreamStreamMessageMetric,
+} from "./metrics/runtime/tool-metrics";
 import { withSpan } from "./metrics/tracing/tracing-utils";
 import type { Message } from "./thoughtspot/types";
 
@@ -23,6 +26,10 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 	return await withSpan(
 		"process-send-agent-conversation-message-streaming-response",
 		async (span: Span) => {
+			// Include the operation on every stream-message metric so future streamed
+			// upstream calls do not collapse into the same series.
+			const upstreamOperation =
+				UPSTREAM_OPERATION_NAMES.sendAgentConversationMessageStreaming;
 			span.setAttribute("conversation_id", conversationId);
 			let nTextMessagesParsed = 0;
 			let nAnswerMessagesParsed = 0;
@@ -76,6 +83,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								nTextMessagesParsed++;
 								recordUpstreamStreamMessageMetric(
 									recorder,
+									upstreamOperation,
 									"text",
 									item.metadata?.type === "thinking",
 								);
@@ -88,6 +96,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								nTextMessagesParsed++;
 								recordUpstreamStreamMessageMetric(
 									recorder,
+									upstreamOperation,
 									"text_chunk",
 									item.metadata?.type === "thinking",
 								);
@@ -100,6 +109,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								nAnswerMessagesParsed++;
 								recordUpstreamStreamMessageMetric(
 									recorder,
+									upstreamOperation,
 									"answer",
 									item.metadata?.type === "thinking",
 								);
@@ -126,7 +136,12 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 								nMessagesIgnored++;
 							} else if (item.type === "error") {
 								console.error("Error event in event stream: ", item);
-								recordUpstreamStreamMessageMetric(recorder, "error", false);
+								recordUpstreamStreamMessageMetric(
+									recorder,
+									upstreamOperation,
+									"error",
+									false,
+								);
 								spanHasError = true;
 								span.setStatus({
 									code: SpanStatusCode.ERROR,

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -7,7 +7,10 @@ import {
 	type MetricsRecorder,
 	scheduleMetricsFlush,
 } from "../metrics/runtime/metrics-recorder";
-import type { MetricEventIdentity } from "../metrics/runtime/metrics-sink";
+import type {
+	MetricAnalyticsContext,
+	MetricEventIdentity,
+} from "../metrics/runtime/metrics-sink";
 import { createRequestMetricsRecorder } from "../metrics/runtime/request-metrics";
 import type { MetricsEnvLike } from "../metrics/runtime/runtime-config";
 import {
@@ -30,6 +33,7 @@ type ThoughtSpotServiceMetricsOptions = {
 	recorder?: MetricsRecorder;
 	metricsEnv?: MetricsEnvLike;
 	waitUntil?: (promise: Promise<any>) => void;
+	analyticsContext?: MetricAnalyticsContext;
 	eventIdentity?: MetricEventIdentity;
 };
 
@@ -66,6 +70,7 @@ export class ThoughtSpotService {
 
 	private createStreamMetricsRecorder(): MetricsRecorder {
 		const recorder = createRequestMetricsRecorder(this.metrics.metricsEnv);
+		recorder.setAnalyticsContext(this.metrics.analyticsContext);
 		recorder.setEventIdentity(this.metrics.eventIdentity);
 		return recorder;
 	}
@@ -418,6 +423,8 @@ export class ThoughtSpotService {
 					);
 				}
 			} else {
+				// Tests and non-Worker runtimes may not expose waitUntil. Keep the
+				// best-effort stream processing running without blocking the caller.
 				void processStreamPromise;
 			}
 

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -1,23 +1,78 @@
+import { SpanStatusCode, context, trace } from "@opentelemetry/api";
 import type {
 	AgentConversation,
 	ThoughtSpotRestApi,
 } from "@thoughtspot/rest-api-sdk";
-import { SpanStatusCode, trace, context } from "@opentelemetry/api";
-import { getActiveSpan, WithSpan } from "../metrics/tracing/tracing-utils";
+import {
+	type MetricsRecorder,
+	scheduleMetricsFlush,
+} from "../metrics/runtime/metrics-recorder";
+import type { MetricEventIdentity } from "../metrics/runtime/metrics-sink";
+import { createRequestMetricsRecorder } from "../metrics/runtime/request-metrics";
+import type { MetricsEnvLike } from "../metrics/runtime/runtime-config";
+import {
+	UPSTREAM_OPERATION_NAMES,
+	type UpstreamOperation,
+	recordUpstreamCallMetrics,
+	recordUpstreamStreamStartedMetric,
+} from "../metrics/runtime/tool-metrics";
+import { WithSpan, getActiveSpan } from "../metrics/tracing/tracing-utils";
+import { processSendAgentConversationMessageStreamingResponse } from "../streaming-utils";
 import type {
+	Answer,
 	DataSource,
-	SessionInfo,
 	DataSourceSuggestion,
 	Message,
-	Answer,
+	SessionInfo,
 } from "./types";
-import { processSendAgentConversationMessageStreamingResponse } from "../streaming-utils";
+
+type ThoughtSpotServiceMetricsOptions = {
+	recorder?: MetricsRecorder;
+	metricsEnv?: MetricsEnvLike;
+	waitUntil?: (promise: Promise<any>) => void;
+	eventIdentity?: MetricEventIdentity;
+};
 
 /**
  * Main ThoughtSpot service class using decorator pattern for tracing
  */
 export class ThoughtSpotService {
-	constructor(private client: ThoughtSpotRestApi) {}
+	constructor(
+		private client: ThoughtSpotRestApi,
+		private readonly metrics: ThoughtSpotServiceMetricsOptions = {},
+	) {}
+
+	private async observeUpstreamCall<T>(
+		operation: UpstreamOperation,
+		call: () => Promise<T>,
+	): Promise<T> {
+		const startedAt = Date.now();
+		let outcome: "success" | "upstream_error" = "success";
+
+		try {
+			return await call();
+		} catch (error) {
+			outcome = "upstream_error";
+			throw error;
+		} finally {
+			recordUpstreamCallMetrics(
+				this.metrics.recorder,
+				operation,
+				outcome,
+				Date.now() - startedAt,
+			);
+		}
+	}
+
+	private createStreamMetricsRecorder(): MetricsRecorder {
+		const recorder = createRequestMetricsRecorder(this.metrics.metricsEnv);
+		recorder.setEventIdentity(this.metrics.eventIdentity);
+		return recorder;
+	}
+
+	private scheduleBackgroundMetricsFlush(recorder: MetricsRecorder): void {
+		scheduleMetricsFlush(recorder, this.metrics.waitUntil);
+	}
 
 	@WithSpan("discover-data-sources")
 	async discoverDataSources(
@@ -49,9 +104,13 @@ export class ThoughtSpotService {
 			span?.setAttribute("query", query);
 			span?.addEvent("query-get-data-source-suggestions");
 
-			const response = await this.client.getDataSourceSuggestions({
-				query,
-			});
+			const response = await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.getDataSourceSuggestions,
+				() =>
+					this.client.getDataSourceSuggestions({
+						query,
+					}),
+			);
 
 			span?.setStatus({
 				code: SpanStatusCode.OK,
@@ -112,14 +171,18 @@ export class ThoughtSpotService {
 			);
 			span?.addEvent("get-decomposed-query");
 
-			const resp = await this.client.queryGetDecomposedQuery({
-				nlsRequest: {
-					query: query,
-				},
-				content: [additionalContext],
-				worksheetIds: sourceIds,
-				maxDecomposedQueries: 5,
-			});
+			const resp = await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.queryGetDecomposedQuery,
+				() =>
+					this.client.queryGetDecomposedQuery({
+						nlsRequest: {
+							query: query,
+						},
+						content: [additionalContext],
+						worksheetIds: sourceIds,
+						maxDecomposedQueries: 5,
+					}),
+			);
 
 			const questions =
 				resp.decomposedQueryResponse?.decomposedQueries?.map((q) => ({
@@ -183,11 +246,15 @@ export class ThoughtSpotService {
 				"instanceUrl: ",
 				(this.client as any).instanceUrl,
 			);
-			const data = await this.client.exportAnswerReport({
-				session_identifier,
-				generation_number,
-				file_format: "CSV",
-			});
+			const data = await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.exportAnswerReport,
+				() =>
+					this.client.exportAnswerReport({
+						session_identifier,
+						generation_number,
+						file_format: "CSV",
+					}),
+			);
 
 			let csvData = await data.text();
 			// get only the first 100 lines of the csv data
@@ -223,10 +290,14 @@ export class ThoughtSpotService {
 		try {
 			span?.setAttribute("session_identifier", session_identifier);
 			console.log("[DEBUG] Getting TML for answer: ", title);
-			const tml = await (this.client as any).exportUnsavedAnswerTML({
-				session_identifier,
-				generation_number,
-			});
+			const tml = await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.exportUnsavedAnswerTml,
+				() =>
+					(this.client as any).exportUnsavedAnswerTML({
+						session_identifier,
+						generation_number,
+					}),
+			);
 			return tml;
 		} catch (error) {
 			span?.setStatus({
@@ -250,11 +321,13 @@ export class ThoughtSpotService {
 
 		try {
 			// Use auto mode by default, but support passing an explicit data source context
-			const response = await (
-				this.client as any
-			).createAgentConversationWithAutoMode({
-				dataSourceId,
-			});
+			const response = await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.createAgentConversation,
+				() =>
+					(this.client as any).createAgentConversationWithAutoMode({
+						dataSourceId,
+					}),
+			);
 
 			span?.setStatus({
 				code: SpanStatusCode.OK,
@@ -298,12 +371,14 @@ export class ThoughtSpotService {
 				? `${message}\n\nAdditional Context:\n${additionalContext}`
 				: message;
 
-			const response = await (
-				this.client as any
-			).sendAgentConversationMessageStreaming({
-				conversation_identifier: conversationId,
-				message: finalMessage,
-			});
+			const response = await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.sendAgentConversationMessageStreaming,
+				() =>
+					(this.client as any).sendAgentConversationMessageStreaming({
+						conversation_identifier: conversationId,
+						message: finalMessage,
+					}),
+			);
 
 			const reader = response.body?.getReader();
 			if (!reader) {
@@ -314,13 +389,36 @@ export class ThoughtSpotService {
 				throw new Error("Failed to get reader from response body");
 			}
 
-			// We don't await because we want to process the streaming response asynchronously
-			processSendAgentConversationMessageStreamingResponse(
-				conversationId,
-				reader,
-				appendStoredMessages,
-				(this.client as any).instanceUrl,
+			const streamRecorder = this.createStreamMetricsRecorder();
+			recordUpstreamStreamStartedMetric(
+				streamRecorder,
+				UPSTREAM_OPERATION_NAMES.sendAgentConversationMessageStreaming,
+				"success",
 			);
+
+			const processStreamPromise =
+				processSendAgentConversationMessageStreamingResponse(
+					conversationId,
+					reader,
+					appendStoredMessages,
+					(this.client as any).instanceUrl,
+					streamRecorder,
+				).finally(() => {
+					this.scheduleBackgroundMetricsFlush(streamRecorder);
+				});
+
+			if (this.metrics.waitUntil) {
+				try {
+					this.metrics.waitUntil(processStreamPromise);
+				} catch (error) {
+					console.error(
+						"[metrics] Failed to schedule upstream stream processing",
+						error,
+					);
+				}
+			} else {
+				void processStreamPromise;
+			}
 
 			span?.setStatus({
 				code: SpanStatusCode.OK,
@@ -363,10 +461,14 @@ export class ThoughtSpotService {
 		);
 
 		try {
-			const answer = await this.client.singleAnswer({
-				query: question,
-				metadata_identifier: sourceId,
-			});
+			const answer = await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.singleAnswer,
+				() =>
+					this.client.singleAnswer({
+						query: question,
+						metadata_identifier: sourceId,
+					}),
+			);
 
 			const { session_identifier, generation_number } = answer as any;
 			span?.setAttributes({
@@ -376,10 +478,14 @@ export class ThoughtSpotService {
 
 			const [data, session, tml] = await Promise.all([
 				this.getAnswerData(question, session_identifier, generation_number),
-				(this.client as any).getAnswerSession({
-					session_identifier,
-					generation_number,
-				}),
+				this.observeUpstreamCall(
+					UPSTREAM_OPERATION_NAMES.getAnswerSession,
+					() =>
+						(this.client as any).getAnswerSession({
+							session_identifier,
+							generation_number,
+						}),
+				),
 				shouldGetTML
 					? this.getAnswerTML(question, session_identifier, generation_number)
 					: Promise.resolve(null),
@@ -522,10 +628,14 @@ export class ThoughtSpotService {
 			},
 		};
 
-		const resp = await this.client.importMetadataTML({
-			metadata_tmls: [JSON.stringify(tml)],
-			import_policy: "ALL_OR_NONE",
-		});
+		const resp = await this.observeUpstreamCall(
+			UPSTREAM_OPERATION_NAMES.importMetadataTml,
+			() =>
+				this.client.importMetadataTML({
+					metadata_tmls: [JSON.stringify(tml)],
+					import_policy: "ALL_OR_NONE",
+				}),
+		);
 
 		const liveboardUrl = `${(this.client as any).instanceUrl}/#/pinboard/${resp[0].response.header.id_guid}`;
 		span?.setStatus({
@@ -544,18 +654,22 @@ export class ThoughtSpotService {
 
 		span?.addEvent("get-data-sources");
 
-		const resp = await this.client.searchMetadata({
-			metadata: [
-				{
-					type: "LOGICAL_TABLE",
-				},
-			],
-			record_size: 2000,
-			sort_options: {
-				field_name: "LAST_ACCESSED",
-				order: "DESC",
-			},
-		});
+		const resp = await this.observeUpstreamCall(
+			UPSTREAM_OPERATION_NAMES.searchMetadata,
+			() =>
+				this.client.searchMetadata({
+					metadata: [
+						{
+							type: "LOGICAL_TABLE",
+						},
+					],
+					record_size: 2000,
+					sort_options: {
+						field_name: "LAST_ACCESSED",
+						order: "DESC",
+					},
+				}),
+		);
 
 		const results = resp
 			// Tables can also be used for spotter now
@@ -577,7 +691,10 @@ export class ThoughtSpotService {
 	async getSessionInfo(): Promise<SessionInfo> {
 		const span = getActiveSpan();
 
-		const info = await (this.client as any).getSessionInfo();
+		const info = await this.observeUpstreamCall(
+			UPSTREAM_OPERATION_NAMES.getSessionInfo,
+			() => (this.client as any).getSessionInfo(),
+		);
 		const devMixpanelToken = info.configInfo.mixpanelConfig.devSdkKey;
 		const prodMixpanelToken = info.configInfo.mixpanelConfig.prodSdkKey;
 		const mixpanelToken = info.configInfo.mixpanelConfig.production
@@ -610,18 +727,22 @@ export class ThoughtSpotService {
 	async searchWorksheets(searchTerm: string): Promise<DataSource[]> {
 		const span = getActiveSpan();
 
-		const resp = await this.client.searchMetadata({
-			metadata: [
-				{
-					type: "LOGICAL_TABLE",
-				},
-			],
-			record_size: 100,
-			sort_options: {
-				field_name: "NAME",
-				order: "ASC",
-			},
-		});
+		const resp = await this.observeUpstreamCall(
+			UPSTREAM_OPERATION_NAMES.searchMetadata,
+			() =>
+				this.client.searchMetadata({
+					metadata: [
+						{
+							type: "LOGICAL_TABLE",
+						},
+					],
+					record_size: 100,
+					sort_options: {
+						field_name: "NAME",
+						order: "ASC",
+					},
+				}),
+		);
 
 		const results = resp
 			.filter((d) => d.metadata_header.type === "WORKSHEET")
@@ -645,7 +766,10 @@ export class ThoughtSpotService {
 	@WithSpan("validate-connection")
 	async validateConnection(): Promise<boolean> {
 		try {
-			await (this.client as any).getSessionInfo();
+			await this.observeUpstreamCall(
+				UPSTREAM_OPERATION_NAMES.getSessionInfo,
+				() => (this.client as any).getSessionInfo(),
+			);
 			return true;
 		} catch (error) {
 			// The decorator will automatically record the exception

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -371,23 +371,24 @@ export class ThoughtSpotService {
 				? `${message}\n\nAdditional Context:\n${additionalContext}`
 				: message;
 
-			const response = await this.observeUpstreamCall(
+			// Validate the response body inside the observed call so an unusable streaming
+			// response is counted as `upstream_error` instead of a false success.
+			const reader = await this.observeUpstreamCall(
 				UPSTREAM_OPERATION_NAMES.sendAgentConversationMessageStreaming,
-				() =>
-					(this.client as any).sendAgentConversationMessageStreaming({
+				async () => {
+					const response = await (
+						this.client as any
+					).sendAgentConversationMessageStreaming({
 						conversation_identifier: conversationId,
 						message: finalMessage,
-					}),
+					});
+					const reader = response.body?.getReader();
+					if (!reader) {
+						throw new Error("Failed to get reader from response body");
+					}
+					return reader;
+				},
 			);
-
-			const reader = response.body?.getReader();
-			if (!reader) {
-				span?.setStatus({
-					code: SpanStatusCode.ERROR,
-					message: "Failed to get reader from response body",
-				});
-				throw new Error("Failed to get reader from response body");
-			}
 
 			const streamRecorder = this.createStreamMetricsRecorder();
 			recordUpstreamStreamStartedMetric(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { type Span, SpanStatusCode } from "@opentelemetry/api";
+import type { ApiVersionMode } from "./metrics/runtime/metric-types";
 import { getActiveSpan } from "./metrics/tracing/tracing-utils";
 
 export type Props = {
@@ -10,6 +11,8 @@ export type Props = {
 		registrationDate: number;
 	};
 	apiVersion?: string;
+	apiVersionMode?: ApiVersionMode;
+	apiRequestedVersion?: string;
 };
 
 export class McpServerError extends Error {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export type Props = {
 		clientName: string;
 		registrationDate: number;
 	};
-	apiVersion?: "beta";
+	apiVersion?: string;
 };
 
 export class McpServerError extends Error {

--- a/test/bearer.spec.ts
+++ b/test/bearer.spec.ts
@@ -183,6 +183,7 @@ describe("Bearer Handler", () => {
 				instanceUrl: "https://my-instance.thoughtspot.cloud",
 				clientName: "Custom Test Client",
 				apiVersion: "backwards-compatibility-default",
+				apiVersionMode: "implicit_legacy",
 			});
 
 			// Verify the response
@@ -208,6 +209,7 @@ describe("Bearer Handler", () => {
 				instanceUrl: "https://my-instance.thoughtspot.cloud",
 				clientName: "Bearer Token client",
 				apiVersion: "backwards-compatibility-default",
+				apiVersionMode: "implicit_legacy",
 			});
 
 			// Verify the response
@@ -531,8 +533,10 @@ describe("Bearer Handler", () => {
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiRequestedVersion: "beta",
 			});
 			expect(mockCtx.props.apiVersion).toBe("backwards-compatibility-default");
+			expect(mockCtx.props.apiVersionMode).toBe("implicit_legacy");
 		});
 
 		it("should use backwards-compatibility-default apiVersion and ignore query param on /bearer/sse", async () => {
@@ -553,8 +557,10 @@ describe("Bearer Handler", () => {
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiRequestedVersion: "beta",
 			});
 			expect(mockCtx.props.apiVersion).toBe("backwards-compatibility-default");
+			expect(mockCtx.props.apiVersionMode).toBe("implicit_legacy");
 		});
 	});
 
@@ -577,7 +583,9 @@ describe("Bearer Handler", () => {
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiRequestedVersion: "beta",
 				apiVersion: "beta",
+				apiVersionMode: "beta",
 			});
 		});
 
@@ -599,7 +607,9 @@ describe("Bearer Handler", () => {
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiRequestedVersion: "beta",
 				apiVersion: "beta",
+				apiVersionMode: "beta",
 			});
 		});
 
@@ -619,6 +629,7 @@ describe("Bearer Handler", () => {
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
 				apiVersion: "latest",
+				apiVersionMode: "implicit_latest",
 			});
 		});
 
@@ -640,7 +651,9 @@ describe("Bearer Handler", () => {
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiRequestedVersion: "2025-03-01",
 				apiVersion: "2025-03-01",
+				apiVersionMode: "pinned",
 			});
 		});
 
@@ -662,7 +675,9 @@ describe("Bearer Handler", () => {
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiRequestedVersion: "2024-12-01",
 				apiVersion: "2024-12-01",
+				apiVersionMode: "pinned",
 			});
 		});
 
@@ -685,7 +700,9 @@ describe("Bearer Handler", () => {
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiRequestedVersion: "beta",
 				apiVersion: "beta",
+				apiVersionMode: "beta",
 			});
 		});
 
@@ -740,6 +757,7 @@ describe("Bearer Handler", () => {
 
 			expect(result.status).toBe(200);
 			expect(mockCtx.props.apiVersion).toBe("latest");
+			expect(mockCtx.props.apiVersionMode).toBe("implicit_latest");
 		});
 
 		it("should require bearer token on /token/mcp", async () => {

--- a/test/bearer.spec.ts
+++ b/test/bearer.spec.ts
@@ -603,7 +603,7 @@ describe("Bearer Handler", () => {
 			});
 		});
 
-		it("should not inject apiVersion when query param is not present on /token/mcp", async () => {
+		it("should default unversioned /token/mcp requests to latest", async () => {
 			const appWithBearer = withBearerHandler(app, ThoughtSpotMCP);
 
 			const request = new Request("https://example.com/token/mcp", {
@@ -614,12 +614,12 @@ describe("Bearer Handler", () => {
 
 			await appWithBearer.fetch(request, mockEnv, mockCtx);
 
-			// Verify that props do not have apiVersion
+			// Verify that props reflect the effective served surface
 			expect(mockCtx.props).toMatchObject({
 				accessToken: "test-token",
 				instanceUrl: "https://test.thoughtspot.cloud",
+				apiVersion: "latest",
 			});
-			expect(mockCtx.props.apiVersion).toBeUndefined();
 		});
 
 		it("should inject apiVersion with date format on /token/mcp", async () => {
@@ -739,7 +739,7 @@ describe("Bearer Handler", () => {
 			const result = await appWithBearer.fetch(request, mockEnv, mockCtx);
 
 			expect(result.status).toBe(200);
-			expect(mockCtx.props.apiVersion).toBeUndefined();
+			expect(mockCtx.props.apiVersion).toBe("latest");
 		});
 
 		it("should require bearer token on /token/mcp", async () => {

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	ANALYTICS_ENGINE_BLOB_FIELDS,
+	ANALYTICS_ENGINE_CONTEXT_FIELDS,
 	ANALYTICS_ENGINE_DOUBLE_FIELDS,
 	ANALYTICS_ENGINE_INDEX_FIELDS,
 	ANALYTICS_ENGINE_LABEL_FIELDS,
@@ -60,9 +61,11 @@ describe("AnalyticsEngineMetricsSink", () => {
 			"mcp",
 			null,
 			null,
+			null,
 			"success",
 			null,
 			"create_liveboard",
+			null,
 			null,
 			null,
 			null,
@@ -98,6 +101,9 @@ describe("AnalyticsEngineMetricsSink", () => {
 
 	it("keeps the Analytics Engine schema aligned with approved labels and resource attributes", () => {
 		expect(ANALYTICS_ENGINE_LABEL_FIELDS).toEqual(APPROVED_METRIC_LABEL_KEYS);
+		expect(ANALYTICS_ENGINE_CONTEXT_FIELDS).toEqual([
+			["api_requested_version", "apiRequestedVersion"],
+		]);
 		expect(ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS).toEqual([
 			["deployment_environment", "deployment.environment"],
 			["service_name", "service.name"],
@@ -114,6 +120,7 @@ describe("AnalyticsEngineMetricsSink", () => {
 		expect(ANALYTICS_ENGINE_BLOB_FIELDS).toEqual([
 			"metric_kind",
 			...APPROVED_METRIC_LABEL_KEYS,
+			"api_requested_version",
 			"deployment_environment",
 			"service_name",
 			"service_namespace",
@@ -173,6 +180,25 @@ describe("AnalyticsEngineMetricsSink", () => {
 					"tenant-123",
 					"user-456",
 				],
+			}),
+		);
+	});
+
+	it("maps analytics context into Analytics Engine blobs", async () => {
+		const dataset = { writeDataPoint: vi.fn() };
+		const sink = new AnalyticsEngineMetricsSink(dataset);
+
+		await sink.flush({
+			observations: [observation],
+			resourceAttributes: {},
+			analyticsContext: {
+				apiRequestedVersion: "2026-10-01",
+			},
+		});
+
+		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
+			expect.objectContaining({
+				blobs: expect.arrayContaining(["2026-10-01"]),
 			}),
 		);
 	});

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -59,6 +59,7 @@ describe("AnalyticsEngineMetricsSink", () => {
 			"oauth",
 			"mcp",
 			null,
+			null,
 			"success",
 			null,
 			"create_liveboard",

--- a/test/metrics/runtime/metrics-recorder.spec.ts
+++ b/test/metrics/runtime/metrics-recorder.spec.ts
@@ -57,6 +57,7 @@ describe("RequestMetricsRecorder", () => {
 		expect(flushSpy).toHaveBeenCalledWith({
 			observations: recorder.snapshot(),
 			resourceAttributes: { "service.name": "thoughtspot-mcp-server" },
+			analyticsContext: undefined,
 			eventIdentity: undefined,
 		});
 	});
@@ -151,6 +152,7 @@ describe("RequestMetricsRecorder", () => {
 				}),
 			],
 			resourceAttributes: {},
+			analyticsContext: undefined,
 			eventIdentity: undefined,
 		});
 	});
@@ -225,6 +227,27 @@ describe("RequestMetricsRecorder", () => {
 			expect.objectContaining({
 				eventIdentity: {
 					tenantId: "tenant-123",
+				},
+			}),
+		);
+	});
+
+	it("includes analytics context in the flush payload when present", async () => {
+		const flushSpy = vi.fn().mockResolvedValue(undefined);
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: flushSpy },
+		});
+
+		recorder.setAnalyticsContext({
+			apiRequestedVersion: "2026-10-01",
+		});
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		await recorder.flush();
+
+		expect(flushSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				analyticsContext: {
+					apiRequestedVersion: "2026-10-01",
 				},
 			}),
 		);

--- a/test/metrics/runtime/metrics-recorder.spec.ts
+++ b/test/metrics/runtime/metrics-recorder.spec.ts
@@ -57,6 +57,7 @@ describe("RequestMetricsRecorder", () => {
 		expect(flushSpy).toHaveBeenCalledWith({
 			observations: recorder.snapshot(),
 			resourceAttributes: { "service.name": "thoughtspot-mcp-server" },
+			eventIdentity: undefined,
 		});
 	});
 
@@ -150,6 +151,7 @@ describe("RequestMetricsRecorder", () => {
 				}),
 			],
 			resourceAttributes: {},
+			eventIdentity: undefined,
 		});
 	});
 
@@ -204,6 +206,27 @@ describe("RequestMetricsRecorder", () => {
 		expect(recorder.snapshot()).toEqual([]);
 		expect(warnSpy).toHaveBeenCalledWith(
 			`[metrics] Ignoring metric recorded after flush: ${METRIC_NAMES.httpRequestsTotal}`,
+		);
+	});
+
+	it("includes event identity in the flush payload when present", async () => {
+		const flushSpy = vi.fn().mockResolvedValue(undefined);
+		const recorder = new RequestMetricsRecorder({
+			sink: { flush: flushSpy },
+		});
+
+		recorder.setEventIdentity({
+			tenantId: "tenant-123",
+		});
+		recorder.count(METRIC_NAMES.httpRequestsTotal);
+		await recorder.flush();
+
+		expect(flushSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventIdentity: {
+					tenantId: "tenant-123",
+				},
+			}),
 		);
 	});
 });

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -271,7 +271,7 @@ describe("withRequestMetrics", () => {
 
 		expect(result).toBe("handler-result");
 		expect(errorSpy).toHaveBeenCalledWith(
-			"[metrics] Failed to schedule request metrics flush",
+			"[metrics] Failed to schedule metrics flush",
 			expect.any(Error),
 		);
 	});

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -416,21 +416,25 @@ describe("withRequestMetrics", () => {
 		const ctx = {
 			props: {
 				apiVersion: "backwards-compatibility-default",
+				apiVersionMode: "implicit_legacy",
 			},
 		} as unknown as ExecutionContext;
 		const request = new Request(
 			"https://example.com/bearer/mcp?api-version=beta",
 		);
 
-		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe(
+			"backwards-compatibility-default",
+		);
 	});
 
-	it("labels legacy OAuth routes as implicit default when no selector is provided", () => {
+	it("labels legacy OAuth routes as implicit legacy when no selector is provided", () => {
 		const request = new Request("https://example.com/mcp");
 
 		expect(resolveApiVersionLabels(request, {} as ExecutionContext)).toEqual({
-			apiVersion: "default",
-			apiVersionMode: "implicit_default",
+			apiReleaseDate: "2025-01-01",
+			apiVersion: "backwards-compatibility-default",
+			apiVersionMode: "implicit_legacy",
 		});
 	});
 
@@ -438,8 +442,9 @@ describe("withRequestMetrics", () => {
 		const request = new Request("https://example.com/token/mcp");
 
 		expect(resolveApiVersionLabels(request, {} as ExecutionContext)).toEqual({
+			apiReleaseDate: "2026-05-01",
 			apiVersion: "latest",
-			apiVersionMode: "latest",
+			apiVersionMode: "implicit_latest",
 		});
 	});
 
@@ -449,8 +454,23 @@ describe("withRequestMetrics", () => {
 		);
 
 		expect(resolveApiVersionLabels(request, {} as ExecutionContext)).toEqual({
+			apiRequestedVersion: "2026-05-01",
+			apiReleaseDate: "2026-05-01",
 			apiVersion: "latest",
 			apiVersionMode: "pinned",
+		});
+	});
+
+	it("labels explicit latest selectors separately from implicit latest", () => {
+		const request = new Request(
+			"https://example.com/token/mcp?api-version=latest",
+		);
+
+		expect(resolveApiVersionLabels(request, {} as ExecutionContext)).toEqual({
+			apiRequestedVersion: "latest",
+			apiReleaseDate: "2026-05-01",
+			apiVersion: "latest",
+			apiVersionMode: "explicit_latest",
 		});
 	});
 
@@ -469,13 +489,16 @@ describe("withRequestMetrics", () => {
 			"https://example.com/token/mcp?api-version=2025-12-01",
 		);
 
-		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe(
+			"backwards-compatibility-default",
+		);
 	});
 
 	it("labels unresolved api-version values as unknown", () => {
 		const ctx = {
 			props: {
 				apiVersion: "garbage",
+				apiRequestedVersion: "invalid",
 			},
 		} as unknown as ExecutionContext;
 		const request = new Request(
@@ -483,6 +506,26 @@ describe("withRequestMetrics", () => {
 		);
 
 		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("unknown");
+	});
+
+	it("keeps the normalized requested selector even when the served release resolves differently", () => {
+		const request = new Request(
+			"https://example.com/bearer/mcp?api-version=beta",
+		);
+		const ctx = {
+			props: {
+				apiVersion: "backwards-compatibility-default",
+				apiRequestedVersion: "beta",
+				apiVersionMode: "implicit_legacy",
+			},
+		} as unknown as ExecutionContext;
+
+		expect(resolveApiVersionLabels(request, ctx)).toEqual({
+			apiRequestedVersion: "beta",
+			apiReleaseDate: "2025-01-01",
+			apiVersion: "backwards-compatibility-default",
+			apiVersionMode: "implicit_legacy",
+		});
 	});
 
 	it("records auth outcome counters from response status", () => {
@@ -520,5 +563,27 @@ describe("withRequestMetrics", () => {
 				},
 			}),
 		]);
+	});
+
+	it("preserves the requested selector for bearer auth traffic in analytics context", async () => {
+		const analyticsEngineSink = { flush: vi.fn().mockResolvedValue(undefined) };
+		const recorder = createRequestMetricsRecorder(
+			{ METRICS_SINK_MODE: "analytics_engine" },
+			{ analyticsEngineSink },
+		);
+		const request = new Request(
+			"https://example.com/bearer/mcp?api-version=beta",
+		);
+
+		recordBearerAuthRequestMetric(recorder, request, 401);
+		await recorder.flush();
+
+		expect(analyticsEngineSink.flush).toHaveBeenCalledWith(
+			expect.objectContaining({
+				analyticsContext: {
+					apiRequestedVersion: "beta",
+				},
+			}),
+		);
 	});
 });

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -7,6 +7,7 @@ import {
 	recordBearerAuthRequestMetric,
 	recordHttpRequestMetrics,
 	recordStatusMetric,
+	resolveApiVersionLabels,
 	resolveCanonicalApiVersionLabel,
 	setMetricsRecorderOnExecutionContext,
 	withRequestMetrics,
@@ -379,6 +380,7 @@ describe("withRequestMetrics", () => {
 				labels: {
 					api_surface: "mcp",
 					api_version: "beta",
+					api_version_mode: "beta",
 					auth_mode: "oauth",
 					outcome: "success",
 					route_group: "mcp",
@@ -393,6 +395,7 @@ describe("withRequestMetrics", () => {
 				labels: {
 					api_surface: "mcp",
 					api_version: "beta",
+					api_version_mode: "beta",
 					auth_mode: "oauth",
 					outcome: "success",
 					route_group: "mcp",
@@ -402,11 +405,11 @@ describe("withRequestMetrics", () => {
 		]);
 	});
 
-	it("labels versioned MCP routes as default when no explicit API version is requested", () => {
+	it("labels unversioned token routes as latest when no explicit API version is requested", () => {
 		const ctx = {} as ExecutionContext;
 		const request = new Request("https://example.com/token/mcp");
 
-		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
+		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("latest");
 	});
 
 	it("uses the effective default surface when bearer routes ignore an api-version query", () => {
@@ -420,6 +423,35 @@ describe("withRequestMetrics", () => {
 		);
 
 		expect(resolveCanonicalApiVersionLabel(request, ctx)).toBe("default");
+	});
+
+	it("labels legacy OAuth routes as implicit default when no selector is provided", () => {
+		const request = new Request("https://example.com/mcp");
+
+		expect(resolveApiVersionLabels(request, {} as ExecutionContext)).toEqual({
+			apiVersion: "default",
+			apiVersionMode: "implicit_default",
+		});
+	});
+
+	it("labels unversioned token routes as following latest", () => {
+		const request = new Request("https://example.com/token/mcp");
+
+		expect(resolveApiVersionLabels(request, {} as ExecutionContext)).toEqual({
+			apiVersion: "latest",
+			apiVersionMode: "latest",
+		});
+	});
+
+	it("labels date-based token routes as pinned even when they currently resolve to latest", () => {
+		const request = new Request(
+			"https://example.com/token/mcp?api-version=2026-05-01",
+		);
+
+		expect(resolveApiVersionLabels(request, {} as ExecutionContext)).toEqual({
+			apiVersion: "latest",
+			apiVersionMode: "pinned",
+		});
 	});
 
 	it("maps stable date-based versions onto the latest label", () => {

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { connect } from "mcp-testing-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MixpanelTracker } from "../../src/metrics/mixpanel/mixpanel";
+import { ANALYTICS_ENGINE_SCHEMA_VERSION } from "../../src/metrics/runtime/analytics-engine-sink";
+import { METRIC_NAMES } from "../../src/metrics/runtime/metric-types";
 import { MCPServer } from "../../src/servers/mcp-server";
+import { StreamingMessagesStorageWithTtl } from "../../src/streaming-message-storage-with-ttl/streaming-message-storage-with-ttl";
 import * as thoughtspotClient from "../../src/thoughtspot/thoughtspot-client";
 import { ThoughtSpotService } from "../../src/thoughtspot/thoughtspot-service";
-import { MixpanelTracker } from "../../src/metrics/mixpanel/mixpanel";
-import { StreamingMessagesStorageWithTtl } from "../../src/streaming-message-storage-with-ttl/streaming-message-storage-with-ttl";
 
 // Mock the MixpanelTracker
 vi.mock("../../src/metrics/mixpanel/mixpanel", () => ({
@@ -298,6 +300,71 @@ describe("MCP Server", () => {
 
 			expect(result.isError).toBeUndefined();
 			expect((result.content as any[])[0].text).toBe("Pong");
+		});
+
+		it("writes tenant-scoped tool metrics without blocking the tool response", async () => {
+			const analyticsDataset = {
+				writeDataPoint: vi.fn(),
+			};
+			const waitUntilPromises: Promise<void>[] = [];
+			const metricsServer = new MCPServer(
+				{
+					props: mockProps,
+					env: {
+						METRICS_SINK_MODE: "analytics_engine",
+						ANALYTICS: analyticsDataset,
+					} as any,
+					ctx: {
+						waitUntil(promise: Promise<void>) {
+							waitUntilPromises.push(promise);
+						},
+					} as any,
+				},
+				new StreamingMessagesStorageWithTtl(null as any, vi.fn(), vi.fn()),
+			);
+			await metricsServer.init();
+
+			const { callTool } = connect(metricsServer);
+			const result = await callTool("ping", {});
+
+			expect(result.isError).toBeUndefined();
+			expect(waitUntilPromises).toHaveLength(1);
+
+			await Promise.all(waitUntilPromises);
+
+			const dataPoints = analyticsDataset.writeDataPoint.mock.calls.map(
+				([dataPoint]) => dataPoint,
+			);
+			const toolCallCounter = dataPoints.find(
+				(dataPoint) => dataPoint.indexes?.[2] === METRIC_NAMES.toolCallsTotal,
+			);
+			const toolDuration = dataPoints.find(
+				(dataPoint) => dataPoint.indexes?.[2] === METRIC_NAMES.toolDurationMs,
+			);
+
+			expect(toolCallCounter).toEqual(
+				expect.objectContaining({
+					indexes: [
+						ANALYTICS_ENGINE_SCHEMA_VERSION,
+						"tool",
+						METRIC_NAMES.toolCallsTotal,
+						"test-org",
+						"test-user-123",
+					],
+					blobs: expect.arrayContaining(["ping", "success", "mcp"]),
+				}),
+			);
+			expect(toolDuration).toEqual(
+				expect.objectContaining({
+					indexes: [
+						ANALYTICS_ENGINE_SCHEMA_VERSION,
+						"tool",
+						METRIC_NAMES.toolDurationMs,
+						"test-org",
+						"test-user-123",
+					],
+				}),
+			);
 		});
 	});
 

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -309,7 +309,12 @@ describe("MCP Server", () => {
 			const waitUntilPromises: Promise<void>[] = [];
 			const metricsServer = new MCPServer(
 				{
-					props: mockProps,
+					props: {
+						...mockProps,
+						apiVersion: "2025-03-01",
+						apiRequestedVersion: "2025-03-01",
+						apiVersionMode: "pinned",
+					},
 					env: {
 						METRICS_SINK_MODE: "analytics_engine",
 						ANALYTICS: analyticsDataset,
@@ -351,7 +356,15 @@ describe("MCP Server", () => {
 						"test-org",
 						"test-user-123",
 					],
-					blobs: expect.arrayContaining(["ping", "success", "mcp"]),
+					blobs: expect.arrayContaining([
+						"ping",
+						"success",
+						"mcp",
+						"backwards-compatibility-default",
+						"pinned",
+						"2025-01-01",
+						"2025-03-01",
+					]),
 				}),
 			);
 			expect(toolDuration).toEqual(

--- a/test/servers/version-registry.spec.ts
+++ b/test/servers/version-registry.spec.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-	resolveApiVersion,
 	VERSION_REGISTRY,
+	YYYY_MM_DD_DATE_REGEX,
+	getReleaseDateIdentifier,
+	resolveApiVersion,
+	resolveApiVersionMetrics,
 } from "../../src/servers/version-registry";
 
 // Helper: Validates if a given API version string is valid
@@ -113,6 +116,35 @@ describe("Version Registry", () => {
 			expect(versions).toContain("latest");
 			expect(versions).toContain("2025-01-01");
 			expect(versions.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe("metrics helpers", () => {
+		it("exposes the shared YYYY-MM-DD regex", () => {
+			expect(YYYY_MM_DD_DATE_REGEX.test("2026-05-01")).toBe(true);
+			expect(YYYY_MM_DD_DATE_REGEX.test("2026-5-1")).toBe(false);
+		});
+
+		it("returns the resolved release date identifier when present", () => {
+			expect(getReleaseDateIdentifier(["latest", "2026-05-01"])).toBe(
+				"2026-05-01",
+			);
+			expect(getReleaseDateIdentifier(["beta"])).toBeUndefined();
+		});
+
+		it("maps requested selectors onto canonical metrics labels and release dates", () => {
+			expect(resolveApiVersionMetrics("latest")).toEqual({
+				apiVersion: "latest",
+				apiReleaseDate: "2026-05-01",
+			});
+			expect(resolveApiVersionMetrics("2025-03-15")).toEqual({
+				apiVersion: "backwards-compatibility-default",
+				apiReleaseDate: "2025-01-01",
+			});
+			expect(resolveApiVersionMetrics("beta")).toEqual({
+				apiVersion: "beta",
+				apiReleaseDate: undefined,
+			});
 		});
 	});
 

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -21,6 +21,11 @@ vi.mock("../src/metrics/tracing/tracing-utils", () => ({
 	},
 }));
 
+import { METRIC_NAMES } from "../src/metrics/runtime/metric-types";
+import {
+	type MetricsRecorder,
+	NOOP_METRICS_RECORDER,
+} from "../src/metrics/runtime/metrics-recorder";
 import { processSendAgentConversationMessageStreamingResponse } from "../src/streaming-utils";
 
 // Helper to build a ReadableStreamDefaultReader from an array of string chunks
@@ -105,6 +110,34 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			CONV_ID,
 			[],
 			true,
+		);
+	});
+
+	it("records upstream operation on stream message metrics", async () => {
+		const storage = makeMockStorage();
+		const recorder: MetricsRecorder = {
+			...NOOP_METRICS_RECORDER,
+			count: vi.fn(),
+		};
+		const line = `data: ${JSON.stringify([{ type: "text", content: "Hello world", metadata: {} }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+			recorder,
+		);
+
+		expect(recorder.count).toHaveBeenCalledWith(
+			METRIC_NAMES.upstreamStreamMessagesTotal,
+			1,
+			expect.objectContaining({
+				upstream_operation: "send_agent_conversation_message_streaming",
+				message_type: "text",
+				is_thinking: false,
+			}),
 		);
 	});
 

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -1,4 +1,26 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+const tracingState = vi.hoisted(() => ({
+	span: undefined as
+		| {
+				setAttribute: ReturnType<typeof vi.fn>;
+				setAttributes: ReturnType<typeof vi.fn>;
+				setStatus: ReturnType<typeof vi.fn>;
+		  }
+		| undefined,
+}));
+
+vi.mock("../src/metrics/tracing/tracing-utils", () => ({
+	withSpan: async (_name: string, fn: (span: any) => Promise<unknown>) => {
+		const span = {
+			setAttribute: vi.fn(),
+			setAttributes: vi.fn(),
+			setStatus: vi.fn(),
+		};
+		tracingState.span = span;
+		return fn(span);
+	},
+}));
+
 import { processSendAgentConversationMessageStreamingResponse } from "../src/streaming-utils";
 
 // Helper to build a ReadableStreamDefaultReader from an array of string chunks
@@ -35,6 +57,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		tracingState.span = undefined;
 		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 	});
@@ -235,6 +258,26 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
 			{ is_thinking: false, type: "text", text: "Something went wrong" },
 		]);
+	});
+
+	it("does not count error events as parsed text messages", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "error", display_message: "Something went wrong" }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 0,
+		});
 	});
 
 	it("ignores ack, notification, search_datasets, file, and conv_title events", async () => {

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -1,13 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { METRIC_NAMES } from "../../src/metrics/runtime/metric-types";
+import { createRequestMetricsRecorder } from "../../src/metrics/runtime/request-metrics";
 import {
-	getRelevantQuestions,
-	getAnswerForQuestion,
-	fetchTMLAndCreateLiveboard,
-	createLiveboard,
-	getDataSources,
-	getSessionInfo,
-	getDataSourceSuggestions,
 	ThoughtSpotService,
+	createLiveboard,
+	fetchTMLAndCreateLiveboard,
+	getAnswerForQuestion,
+	getDataSourceSuggestions,
+	getDataSources,
+	getRelevantQuestions,
+	getSessionInfo,
 } from "../../src/thoughtspot/thoughtspot-service";
 
 // Mock the ThoughtSpot REST API client
@@ -234,6 +236,108 @@ describe("thoughtspot-service", () => {
 	});
 
 	describe("sendAgentConversationMessageStreaming", () => {
+		it("records upstream streaming metrics and flushes stream message metrics in the background", async () => {
+			vi.useFakeTimers();
+
+			const analyticsDataset = {
+				writeDataPoint: vi.fn(),
+			};
+			const waitUntilPromises: Promise<void>[] = [];
+			const recorder = createRequestMetricsRecorder({
+				METRICS_SINK_MODE: "analytics_engine",
+				ANALYTICS: analyticsDataset,
+			});
+			recorder.setEventIdentity({
+				tenantId: "org-123",
+				userId: "user-123",
+			});
+
+			const encoder = new TextEncoder();
+			const reader = {
+				read: vi
+					.fn()
+					.mockResolvedValueOnce({
+						done: false,
+						value: encoder.encode(
+							'data: [{"type":"text","content":"Hello","metadata":{}}]\n',
+						),
+					})
+					.mockResolvedValueOnce({ done: true, value: undefined }),
+			};
+
+			mockClient.sendAgentConversationMessageStreaming = vi
+				.fn()
+				.mockResolvedValue({
+					body: { getReader: vi.fn().mockReturnValue(reader) },
+				});
+
+			const appendMessages = vi.fn().mockResolvedValue(undefined);
+
+			const service = new ThoughtSpotService(mockClient, {
+				recorder,
+				metricsEnv: {
+					METRICS_SINK_MODE: "analytics_engine",
+					ANALYTICS: analyticsDataset,
+				},
+				waitUntil(promise: Promise<void>) {
+					waitUntilPromises.push(promise);
+				},
+				eventIdentity: {
+					tenantId: "org-123",
+					userId: "user-123",
+				},
+			});
+
+			await service.sendAgentConversationMessageStreaming(
+				"conv-123",
+				"Show me revenue",
+				appendMessages,
+			);
+			await recorder.flush();
+			await vi.runAllTimersAsync();
+
+			for (let index = 0; index < waitUntilPromises.length; index++) {
+				await waitUntilPromises[index];
+			}
+
+			const dataPoints = analyticsDataset.writeDataPoint.mock.calls.map(
+				([dataPoint]) => dataPoint,
+			);
+
+			expect(
+				dataPoints.some(
+					(dataPoint) =>
+						dataPoint.indexes?.[2] === METRIC_NAMES.upstreamCallsTotal &&
+						dataPoint.blobs?.includes(
+							"send_agent_conversation_message_streaming",
+						) &&
+						dataPoint.indexes?.[3] === "org-123" &&
+						dataPoint.indexes?.[4] === "user-123",
+				),
+			).toBe(true);
+			expect(
+				dataPoints.some(
+					(dataPoint) =>
+						dataPoint.indexes?.[2] ===
+							METRIC_NAMES.upstreamStreamsStartedTotal &&
+						dataPoint.blobs?.includes(
+							"send_agent_conversation_message_streaming",
+						),
+				),
+			).toBe(true);
+			expect(
+				dataPoints.some(
+					(dataPoint) =>
+						dataPoint.indexes?.[2] ===
+							METRIC_NAMES.upstreamStreamMessagesTotal &&
+						dataPoint.blobs?.includes("text") &&
+						dataPoint.blobs?.includes("false"),
+				),
+			).toBe(true);
+
+			vi.useRealTimers();
+		});
+
 		it("should throw when the response body reader is unavailable", async () => {
 			mockClient.sendAgentConversationMessageStreaming = vi
 				.fn()

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -247,6 +247,9 @@ describe("thoughtspot-service", () => {
 				METRICS_SINK_MODE: "analytics_engine",
 				ANALYTICS: analyticsDataset,
 			});
+			recorder.setAnalyticsContext({
+				apiRequestedVersion: "latest",
+			});
 			recorder.setEventIdentity({
 				tenantId: "org-123",
 				userId: "user-123",
@@ -282,6 +285,9 @@ describe("thoughtspot-service", () => {
 				waitUntil(promise: Promise<void>) {
 					waitUntilPromises.push(promise);
 				},
+				analyticsContext: {
+					apiRequestedVersion: "latest",
+				},
 				eventIdentity: {
 					tenantId: "org-123",
 					userId: "user-123",
@@ -311,6 +317,7 @@ describe("thoughtspot-service", () => {
 						dataPoint.blobs?.includes(
 							"send_agent_conversation_message_streaming",
 						) &&
+						dataPoint.blobs?.includes("latest") &&
 						dataPoint.indexes?.[3] === "org-123" &&
 						dataPoint.indexes?.[4] === "user-123",
 				),

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -330,6 +330,9 @@ describe("thoughtspot-service", () => {
 					(dataPoint) =>
 						dataPoint.indexes?.[2] ===
 							METRIC_NAMES.upstreamStreamMessagesTotal &&
+						dataPoint.blobs?.includes(
+							"send_agent_conversation_message_streaming",
+						) &&
 						dataPoint.blobs?.includes("text") &&
 						dataPoint.blobs?.includes("false"),
 				),
@@ -339,13 +342,26 @@ describe("thoughtspot-service", () => {
 		});
 
 		it("should throw when the response body reader is unavailable", async () => {
+			const analyticsDataset = {
+				writeDataPoint: vi.fn(),
+			};
+			const recorder = createRequestMetricsRecorder({
+				METRICS_SINK_MODE: "analytics_engine",
+				ANALYTICS: analyticsDataset,
+			});
 			mockClient.sendAgentConversationMessageStreaming = vi
 				.fn()
 				.mockResolvedValue({
 					body: undefined,
 				});
 
-			const service = new ThoughtSpotService(mockClient);
+			const service = new ThoughtSpotService(mockClient, {
+				recorder,
+				metricsEnv: {
+					METRICS_SINK_MODE: "analytics_engine",
+					ANALYTICS: analyticsDataset,
+				},
+			});
 
 			await expect(
 				service.sendAgentConversationMessageStreaming(
@@ -356,6 +372,28 @@ describe("thoughtspot-service", () => {
 					} as any,
 				),
 			).rejects.toThrow("Failed to get reader from response body");
+
+			await recorder.flush();
+
+			const dataPoints = analyticsDataset.writeDataPoint.mock.calls.map(
+				([dataPoint]) => dataPoint,
+			);
+			expect(
+				dataPoints.some(
+					(dataPoint) =>
+						dataPoint.indexes?.[2] === METRIC_NAMES.upstreamCallsTotal &&
+						dataPoint.blobs?.includes(
+							"send_agent_conversation_message_streaming",
+						) &&
+						dataPoint.blobs?.includes("upstream_error"),
+				),
+			).toBe(true);
+			expect(
+				dataPoints.some(
+					(dataPoint) =>
+						dataPoint.indexes?.[2] === METRIC_NAMES.upstreamStreamsStartedTotal,
+				),
+			).toBe(false);
 		});
 
 		it("should throw when sending the streaming message fails", async () => {


### PR DESCRIPTION
## Summary

Add MCP tool-level metrics and ThoughtSpot upstream health metrics with tenant-scoped Analytics Engine identity.

## What Changed

- wrap MCP tool handling in a per-tool recorder that records tool call counts and latency
- attach trusted `tenantId` from ThoughtSpot session info to Analytics Engine events
- instrument ThoughtSpot API calls for upstream count and latency metrics
- track streaming upstream starts and parsed stream messages with a dedicated background recorder
- add focused tests for recorder identity, tool flush behavior, and streaming metrics

## Semantics

- tool metrics stay low-cardinality through `tool_name`, `api_surface`, `api_version`, and `outcome`
- tenant identity flows only through Analytics Engine `eventIdentity`, not metric labels
- background metrics flush via `waitUntil(...)` when available and never block MCP responses