### PR TITLE
SCAL-310982 Fix Analytics Engine single-index writes

### DIFF
--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -1,11 +1,11 @@
 import {
-	APPROVED_METRIC_LABEL_KEYS,
 	METRIC_NAMES,
 	type MetricLabels,
 	type MetricName,
 } from "./metric-types";
 import type {
 	MetricAnalyticsContext,
+	MetricEventIdentity,
 	MetricObservation,
 	MetricResourceAttributes,
 	MetricsFlushPayload,
@@ -23,28 +23,42 @@ export type AnalyticsEngineDatasetLike = {
 };
 
 export const ANALYTICS_ENGINE_SCHEMA_VERSION = "mcp_metrics_v2";
+const ANALYTICS_ENGINE_FALLBACK_INDEX = "shared";
 
-export const ANALYTICS_ENGINE_INDEX_FIELDS = [
-	"schema_version",
-	"event_family",
-	"metric_name",
-	"tenant_id",
-	"user_id",
+// Cloudflare Analytics Engine allows one sampling index and up to 20 blobs. This
+// schema is intentionally AE-specific instead of mirroring every approved metric
+// label, so we can keep tenant/user + version + tool/upstream context together
+// without exceeding those limits.
+export const ANALYTICS_ENGINE_INDEX_FIELDS = ["tenant_id"] as const;
+
+export const ANALYTICS_ENGINE_IDENTITY_BLOB_FIELDS = [
+	["tenant_id", "tenantId"],
+	["user_id", "userId"],
+] as const satisfies readonly (readonly [string, keyof MetricEventIdentity])[];
+
+export const ANALYTICS_ENGINE_LABEL_FIELDS = [
+	"route_group",
+	"auth_mode",
+	"api_version",
+	"api_version_mode",
+	"api_release_date",
+	"outcome",
+	"status_class",
+	"tool_name",
+	"upstream_operation",
+	"message_type",
+	"is_done",
 ] as const;
-
-export const ANALYTICS_ENGINE_LABEL_FIELDS = APPROVED_METRIC_LABEL_KEYS;
 
 export const ANALYTICS_ENGINE_CONTEXT_FIELDS = [
 	["api_requested_version", "apiRequestedVersion"],
+	["analytical_session_id", "analyticalSessionId"],
 ] as const satisfies readonly (readonly [
 	string,
 	keyof MetricAnalyticsContext,
 ])[];
 
 export const ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS = [
-	["deployment_environment", "deployment.environment"],
-	["service_name", "service.name"],
-	["service_namespace", "service.namespace"],
 	["service_version", "service.version"],
 ] as const satisfies readonly (readonly [
 	string,
@@ -52,7 +66,11 @@ export const ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS = [
 ])[];
 
 export const ANALYTICS_ENGINE_BLOB_FIELDS = [
+	"schema_version",
+	"event_family",
+	"metric_name",
 	"metric_kind",
+	...ANALYTICS_ENGINE_IDENTITY_BLOB_FIELDS.map(([field]) => field),
 	...ANALYTICS_ENGINE_LABEL_FIELDS,
 	...ANALYTICS_ENGINE_CONTEXT_FIELDS.map(([field]) => field),
 	...ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS.map(([field]) => field),
@@ -62,11 +80,6 @@ export const ANALYTICS_ENGINE_DOUBLE_FIELDS = [
 	"metric_value",
 	"timestamp_ms",
 ] as const;
-
-type AnalyticsEngineIdentity = {
-	tenantId?: string;
-	userId?: string;
-};
 
 type AnalyticsEngineMetricFamily =
 	| "analysis"
@@ -94,6 +107,13 @@ function getResourceAttribute(
 	key: keyof MetricResourceAttributes,
 ): string | null {
 	return nullableString(resourceAttributes[key]);
+}
+
+function getEventIdentityField(
+	identity: MetricEventIdentity,
+	key: keyof MetricEventIdentity,
+): string | null {
+	return nullableString(identity[key]);
 }
 
 function getAnalyticsContextField(
@@ -155,18 +175,20 @@ export function toAnalyticsEngineDataPoint(
 	observation: MetricObservation,
 	resourceAttributes: MetricResourceAttributes,
 	analyticsContext: MetricAnalyticsContext = {},
-	identity: AnalyticsEngineIdentity = {},
+	identity: MetricEventIdentity = {},
 ): AnalyticsEngineDataPointLike {
 	return {
 		indexes: [
+			nullableString(identity.tenantId) ?? ANALYTICS_ENGINE_FALLBACK_INDEX,
+		],
+		blobs: [
 			ANALYTICS_ENGINE_SCHEMA_VERSION,
 			getAnalyticsEngineMetricFamily(observation.name),
 			observation.name,
-			nullableString(identity.tenantId),
-			nullableString(identity.userId),
-		],
-		blobs: [
 			observation.kind,
+			...ANALYTICS_ENGINE_IDENTITY_BLOB_FIELDS.map(([, key]) =>
+				getEventIdentityField(identity, key),
+			),
 			...ANALYTICS_ENGINE_LABEL_FIELDS.map((key) =>
 				getLabel(observation.labels, key),
 			),

--- a/src/metrics/runtime/metrics-recorder.ts
+++ b/src/metrics/runtime/metrics-recorder.ts
@@ -78,6 +78,9 @@ export class RequestMetricsRecorder implements MetricsRecorder {
 		if (context.apiRequestedVersion) {
 			nextContext.apiRequestedVersion = context.apiRequestedVersion;
 		}
+		if (context.analyticalSessionId) {
+			nextContext.analyticalSessionId = context.analyticalSessionId;
+		}
 		this.analyticsContext = nextContext;
 	}
 

--- a/src/metrics/runtime/metrics-sink.ts
+++ b/src/metrics/runtime/metrics-sink.ts
@@ -28,10 +28,11 @@ export type MetricEventIdentity = {
 // Sink-specific context for dimensions that should not become generic metric labels.
 // `api_version`, `api_version_mode`, and `api_release_date` stay in `MetricObservation.labels`
 // because both Grafana and Analytics Engine should receive them as low-cardinality dimensions.
-// `apiRequestedVersion` lives here instead because we only want it in Analytics Engine as
-// request-debug context, not as an extra Grafana label.
+// `apiRequestedVersion` and `analyticalSessionId` live here instead because they are
+// Analytics-Engine-only debug/context fields and should not widen Grafana label cardinality.
 export type MetricAnalyticsContext = {
 	apiRequestedVersion?: string;
+	analyticalSessionId?: string;
 };
 
 export type MetricsFlushPayload = {

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -198,7 +198,10 @@ export abstract class BaseMCPServer extends Server {
 		);
 	}
 
-	protected getThoughtSpotService(recorder?: MetricsRecorder) {
+	protected getThoughtSpotService(
+		recorder?: MetricsRecorder,
+		analyticsContextOverride?: MetricAnalyticsContext,
+	) {
 		return new ThoughtSpotService(
 			getThoughtSpotClient(
 				this.ctx.props.instanceUrl,
@@ -208,7 +211,9 @@ export abstract class BaseMCPServer extends Server {
 				recorder,
 				metricsEnv: this.ctx.env as unknown as Record<string, unknown>,
 				waitUntil: this.getMetricsWaitUntil(),
-				analyticsContext: this.getMetricAnalyticsContext(),
+				analyticsContext: this.mergeMetricAnalyticsContext(
+					analyticsContextOverride,
+				),
 				eventIdentity: this.getMetricEventIdentity(),
 			},
 		);
@@ -239,6 +244,20 @@ export abstract class BaseMCPServer extends Server {
 
 		return {
 			apiRequestedVersion,
+		};
+	}
+
+	protected mergeMetricAnalyticsContext(
+		override?: MetricAnalyticsContext,
+	): MetricAnalyticsContext | undefined {
+		const baseContext = this.getMetricAnalyticsContext();
+		if (!baseContext && !override) {
+			return undefined;
+		}
+
+		return {
+			...baseContext,
+			...override,
 		};
 	}
 

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -386,6 +386,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			await this.getThoughtSpotService(recorder).createAgentConversation(
 				data_source_id,
 			);
+		recorder.setAnalyticsContext({
+			analyticalSessionId: response.conversation_id,
+		});
 		span?.setAttribute("analytical_session_id", response.conversation_id);
 
 		// Conversation is initialized in streamingMessageStorage from callSendSessionMessage,
@@ -405,6 +408,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		const span = trace.getSpan(context.active());
 		const { analytical_session_id, message, additional_context } =
 			SendSessionMessageInputSchema.parse(request.params.arguments);
+		recorder.setAnalyticsContext({
+			analyticalSessionId: analytical_session_id,
+		});
 		span?.setAttributes({
 			analytical_session_id,
 			has_additional_context: !!additional_context,
@@ -424,9 +430,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			);
 		}
 
-		await this.getThoughtSpotService(
-			recorder,
-		).sendAgentConversationMessageStreaming(
+		await this.getThoughtSpotService(recorder, {
+			analyticalSessionId: analytical_session_id,
+		}).sendAgentConversationMessageStreaming(
 			analytical_session_id,
 			message,
 			storageService.appendMessages.bind(storageService),

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -3,6 +3,7 @@ import {
 	ANALYTICS_ENGINE_BLOB_FIELDS,
 	ANALYTICS_ENGINE_CONTEXT_FIELDS,
 	ANALYTICS_ENGINE_DOUBLE_FIELDS,
+	ANALYTICS_ENGINE_IDENTITY_BLOB_FIELDS,
 	ANALYTICS_ENGINE_INDEX_FIELDS,
 	ANALYTICS_ENGINE_LABEL_FIELDS,
 	ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS,
@@ -12,10 +13,7 @@ import {
 	getAnalyticsEngineMetricFamily,
 	toAnalyticsEngineDataPoint,
 } from "../../../src/metrics/runtime/analytics-engine-sink";
-import {
-	APPROVED_METRIC_LABEL_KEYS,
-	METRIC_NAMES,
-} from "../../../src/metrics/runtime/metric-types";
+import { METRIC_NAMES } from "../../../src/metrics/runtime/metric-types";
 import type { MetricObservation } from "../../../src/metrics/runtime/metrics-sink";
 
 describe("AnalyticsEngineMetricsSink", () => {
@@ -46,19 +44,16 @@ describe("AnalyticsEngineMetricsSink", () => {
 			"service.version": "0.5.0",
 		});
 
-		expect(dataPoint.indexes).toEqual([
+		expect(dataPoint.indexes).toEqual(["shared"]);
+		expect(dataPoint.blobs).toEqual([
 			ANALYTICS_ENGINE_SCHEMA_VERSION,
 			"tool",
 			METRIC_NAMES.toolCallsTotal,
-			null,
-			null,
-		]);
-		expect(dataPoint.blobs).toEqual([
 			"counter",
-			"mcp",
+			null,
+			null,
 			"mcp",
 			"oauth",
-			"mcp",
 			null,
 			null,
 			null,
@@ -70,10 +65,6 @@ describe("AnalyticsEngineMetricsSink", () => {
 			null,
 			null,
 			null,
-			null,
-			"production",
-			"thoughtspot-mcp-server",
-			"thoughtspot",
 			"0.5.0",
 		]);
 		expect(dataPoint.doubles).toEqual([2, 1_714_000_000_000]);
@@ -99,37 +90,49 @@ describe("AnalyticsEngineMetricsSink", () => {
 		).toBe("auth");
 	});
 
-	it("keeps the Analytics Engine schema aligned with approved labels and resource attributes", () => {
-		expect(ANALYTICS_ENGINE_LABEL_FIELDS).toEqual(APPROVED_METRIC_LABEL_KEYS);
+	it("keeps the Analytics Engine schema aligned with the compact single-index layout", () => {
+		expect(ANALYTICS_ENGINE_INDEX_FIELDS).toEqual(["tenant_id"]);
+		expect(ANALYTICS_ENGINE_IDENTITY_BLOB_FIELDS).toEqual([
+			["tenant_id", "tenantId"],
+			["user_id", "userId"],
+		]);
+		expect(ANALYTICS_ENGINE_LABEL_FIELDS).toEqual([
+			"route_group",
+			"auth_mode",
+			"api_version",
+			"api_version_mode",
+			"api_release_date",
+			"outcome",
+			"status_class",
+			"tool_name",
+			"upstream_operation",
+			"message_type",
+			"is_done",
+		]);
 		expect(ANALYTICS_ENGINE_CONTEXT_FIELDS).toEqual([
 			["api_requested_version", "apiRequestedVersion"],
+			["analytical_session_id", "analyticalSessionId"],
 		]);
 		expect(ANALYTICS_ENGINE_RESOURCE_ATTRIBUTE_FIELDS).toEqual([
-			["deployment_environment", "deployment.environment"],
-			["service_name", "service.name"],
-			["service_namespace", "service.namespace"],
 			["service_version", "service.version"],
 		]);
-		expect(ANALYTICS_ENGINE_INDEX_FIELDS).toEqual([
+		expect(ANALYTICS_ENGINE_BLOB_FIELDS).toEqual([
 			"schema_version",
 			"event_family",
 			"metric_name",
+			"metric_kind",
 			"tenant_id",
 			"user_id",
-		]);
-		expect(ANALYTICS_ENGINE_BLOB_FIELDS).toEqual([
-			"metric_kind",
-			...APPROVED_METRIC_LABEL_KEYS,
+			...ANALYTICS_ENGINE_LABEL_FIELDS,
 			"api_requested_version",
-			"deployment_environment",
-			"service_name",
-			"service_namespace",
+			"analytical_session_id",
 			"service_version",
 		]);
 		expect(ANALYTICS_ENGINE_DOUBLE_FIELDS).toEqual([
 			"metric_value",
 			"timestamp_ms",
 		]);
+		expect(ANALYTICS_ENGINE_BLOB_FIELDS).toHaveLength(20);
 	});
 
 	it("writes one data point per observation", async () => {
@@ -146,19 +149,13 @@ describe("AnalyticsEngineMetricsSink", () => {
 		expect(dataset.writeDataPoint).toHaveBeenCalledTimes(1);
 		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
 			expect.objectContaining({
-				indexes: [
-					ANALYTICS_ENGINE_SCHEMA_VERSION,
-					"tool",
-					METRIC_NAMES.toolCallsTotal,
-					null,
-					null,
-				],
+				indexes: ["shared"],
 				doubles: [2, 1_714_000_000_000],
 			}),
 		);
 	});
 
-	it("maps request-scoped event identity into Analytics Engine indexes", async () => {
+	it("maps request-scoped event identity into the Analytics Engine index and blobs", async () => {
 		const dataset = { writeDataPoint: vi.fn() };
 		const sink = new AnalyticsEngineMetricsSink(dataset);
 
@@ -173,13 +170,8 @@ describe("AnalyticsEngineMetricsSink", () => {
 
 		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
 			expect.objectContaining({
-				indexes: [
-					ANALYTICS_ENGINE_SCHEMA_VERSION,
-					"tool",
-					METRIC_NAMES.toolCallsTotal,
-					"tenant-123",
-					"user-456",
-				],
+				indexes: ["tenant-123"],
+				blobs: expect.arrayContaining(["tenant-123", "user-456"]),
 			}),
 		);
 	});
@@ -193,12 +185,13 @@ describe("AnalyticsEngineMetricsSink", () => {
 			resourceAttributes: {},
 			analyticsContext: {
 				apiRequestedVersion: "2026-10-01",
+				analyticalSessionId: "conv-123",
 			},
 		});
 
 		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
 			expect.objectContaining({
-				blobs: expect.arrayContaining(["2026-10-01"]),
+				blobs: expect.arrayContaining(["2026-10-01", "conv-123"]),
 			}),
 		);
 	});
@@ -211,7 +204,7 @@ describe("AnalyticsEngineMetricsSink", () => {
 		} satisfies MetricObservation;
 		const dataset = {
 			writeDataPoint: vi.fn((dataPoint) => {
-				if (dataPoint?.indexes?.[2] === METRIC_NAMES.toolCallsTotal) {
+				if (dataPoint?.blobs?.[2] === METRIC_NAMES.toolCallsTotal) {
 					throw new Error("write failed");
 				}
 			}),

--- a/test/metrics/runtime/metrics-recorder.spec.ts
+++ b/test/metrics/runtime/metrics-recorder.spec.ts
@@ -240,6 +240,7 @@ describe("RequestMetricsRecorder", () => {
 
 		recorder.setAnalyticsContext({
 			apiRequestedVersion: "2026-10-01",
+			analyticalSessionId: "conv-123",
 		});
 		recorder.count(METRIC_NAMES.httpRequestsTotal);
 		await recorder.flush();
@@ -248,6 +249,7 @@ describe("RequestMetricsRecorder", () => {
 			expect.objectContaining({
 				analyticsContext: {
 					apiRequestedVersion: "2026-10-01",
+					analyticalSessionId: "conv-123",
 				},
 			}),
 		);

--- a/test/metrics/runtime/request-metrics.spec.ts
+++ b/test/metrics/runtime/request-metrics.spec.ts
@@ -242,7 +242,8 @@ describe("withRequestMetrics", () => {
 		expect(analyticsDataset.writeDataPoint).toHaveBeenCalledTimes(1);
 		expect(analyticsDataset.writeDataPoint).toHaveBeenCalledWith(
 			expect.objectContaining({
-				indexes: expect.arrayContaining([METRIC_NAMES.httpRequestsTotal]),
+				indexes: ["shared"],
+				blobs: expect.arrayContaining([METRIC_NAMES.httpRequestsTotal]),
 			}),
 		);
 	});

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -341,25 +341,23 @@ describe("MCP Server", () => {
 				([dataPoint]) => dataPoint,
 			);
 			const toolCallCounter = dataPoints.find(
-				(dataPoint) => dataPoint.indexes?.[2] === METRIC_NAMES.toolCallsTotal,
+				(dataPoint) => dataPoint.blobs?.[2] === METRIC_NAMES.toolCallsTotal,
 			);
 			const toolDuration = dataPoints.find(
-				(dataPoint) => dataPoint.indexes?.[2] === METRIC_NAMES.toolDurationMs,
+				(dataPoint) => dataPoint.blobs?.[2] === METRIC_NAMES.toolDurationMs,
 			);
 
 			expect(toolCallCounter).toEqual(
 				expect.objectContaining({
-					indexes: [
+					indexes: ["test-org"],
+					blobs: expect.arrayContaining([
 						ANALYTICS_ENGINE_SCHEMA_VERSION,
 						"tool",
 						METRIC_NAMES.toolCallsTotal,
 						"test-org",
 						"test-user-123",
-					],
-					blobs: expect.arrayContaining([
 						"ping",
 						"success",
-						"mcp",
 						"backwards-compatibility-default",
 						"pinned",
 						"2025-01-01",
@@ -369,13 +367,14 @@ describe("MCP Server", () => {
 			);
 			expect(toolDuration).toEqual(
 				expect.objectContaining({
-					indexes: [
+					indexes: ["test-org"],
+					blobs: expect.arrayContaining([
 						ANALYTICS_ENGINE_SCHEMA_VERSION,
 						"tool",
 						METRIC_NAMES.toolDurationMs,
 						"test-org",
 						"test-user-123",
-					],
+					]),
 				}),
 			);
 		});

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -249,6 +249,7 @@ describe("thoughtspot-service", () => {
 			});
 			recorder.setAnalyticsContext({
 				apiRequestedVersion: "latest",
+				analyticalSessionId: "conv-123",
 			});
 			recorder.setEventIdentity({
 				tenantId: "org-123",
@@ -287,6 +288,7 @@ describe("thoughtspot-service", () => {
 				},
 				analyticsContext: {
 					apiRequestedVersion: "latest",
+					analyticalSessionId: "conv-123",
 				},
 				eventIdentity: {
 					tenantId: "org-123",
@@ -313,20 +315,20 @@ describe("thoughtspot-service", () => {
 			expect(
 				dataPoints.some(
 					(dataPoint) =>
-						dataPoint.indexes?.[2] === METRIC_NAMES.upstreamCallsTotal &&
+						dataPoint.blobs?.[2] === METRIC_NAMES.upstreamCallsTotal &&
 						dataPoint.blobs?.includes(
 							"send_agent_conversation_message_streaming",
 						) &&
 						dataPoint.blobs?.includes("latest") &&
-						dataPoint.indexes?.[3] === "org-123" &&
-						dataPoint.indexes?.[4] === "user-123",
+						dataPoint.blobs?.includes("conv-123") &&
+						dataPoint.indexes?.[0] === "org-123" &&
+						dataPoint.blobs?.includes("user-123"),
 				),
 			).toBe(true);
 			expect(
 				dataPoints.some(
 					(dataPoint) =>
-						dataPoint.indexes?.[2] ===
-							METRIC_NAMES.upstreamStreamsStartedTotal &&
+						dataPoint.blobs?.[2] === METRIC_NAMES.upstreamStreamsStartedTotal &&
 						dataPoint.blobs?.includes(
 							"send_agent_conversation_message_streaming",
 						),
@@ -335,13 +337,12 @@ describe("thoughtspot-service", () => {
 			expect(
 				dataPoints.some(
 					(dataPoint) =>
-						dataPoint.indexes?.[2] ===
-							METRIC_NAMES.upstreamStreamMessagesTotal &&
+						dataPoint.blobs?.[2] === METRIC_NAMES.upstreamStreamMessagesTotal &&
 						dataPoint.blobs?.includes(
 							"send_agent_conversation_message_streaming",
 						) &&
 						dataPoint.blobs?.includes("text") &&
-						dataPoint.blobs?.includes("false"),
+						dataPoint.blobs?.includes("conv-123"),
 				),
 			).toBe(true);
 
@@ -388,7 +389,7 @@ describe("thoughtspot-service", () => {
 			expect(
 				dataPoints.some(
 					(dataPoint) =>
-						dataPoint.indexes?.[2] === METRIC_NAMES.upstreamCallsTotal &&
+						dataPoint.blobs?.[2] === METRIC_NAMES.upstreamCallsTotal &&
 						dataPoint.blobs?.includes(
 							"send_agent_conversation_message_streaming",
 						) &&
@@ -398,7 +399,7 @@ describe("thoughtspot-service", () => {
 			expect(
 				dataPoints.some(
 					(dataPoint) =>
-						dataPoint.indexes?.[2] === METRIC_NAMES.upstreamStreamsStartedTotal,
+						dataPoint.blobs?.[2] === METRIC_NAMES.upstreamStreamsStartedTotal,
 				),
 			).toBe(false);
 		});


### PR DESCRIPTION
## Summary

Fix the Workers Analytics Engine payload so production writes succeed again.

Cloudflare only accepts a single index per data point. The current sink writes five indexes, which causes every Analytics Engine write to fail in production.

## What Changed

- switch the Analytics Engine sink to a compact AE-specific row layout with one tenant-scoped index and a bounded blob set
- keep is_done, drop is_thinking, and add analytical_session_id as Analytics-Engine-only context for session debugging
- propagate analyticalSessionId through the metrics context and attach it to the session creation and send-session-message tool flows
- update sink, recorder, request, MCP server, and ThoughtSpot service tests to lock the new schema

## Notes

- keep mcp_metrics_v2; production writes were failing, so this becomes the first valid persisted layout rather than a new version bump
- local design docs were updated for reference only and are not part of this repo commit