### PR TITLE
SCAL-308282 Track polling and first response latency

### DIFF
--- a/src/metrics/runtime/analysis-metrics.ts
+++ b/src/metrics/runtime/analysis-metrics.ts
@@ -1,0 +1,163 @@
+import {
+	METRIC_NAMES,
+	type MetricLabelInput,
+	type MetricOutcome,
+} from "./metric-types";
+import type { MetricsRecorder } from "./metrics-recorder";
+
+export const STREAM_STORAGE_OPERATIONS = {
+	initialize: "initialize",
+	append: "append",
+	messages: "messages",
+	alarm: "alarm",
+	unknown: "unknown",
+} as const;
+
+export type StreamStorageOperation =
+	(typeof STREAM_STORAGE_OPERATIONS)[keyof typeof STREAM_STORAGE_OPERATIONS];
+
+function recordCountAnalysisMetric(
+	recorder: MetricsRecorder | undefined,
+	metricName: string,
+	outcome: MetricOutcome,
+	extraLabels?: MetricLabelInput,
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	recorder.count(metricName, 1, {
+		outcome,
+		...extraLabels,
+	});
+}
+
+function recordHistogramAnalysisMetric(
+	recorder: MetricsRecorder | undefined,
+	metricName: string,
+	durationMs: number,
+	outcome: MetricOutcome,
+	extraLabels?: MetricLabelInput,
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	recorder.histogram(metricName, durationMs, {
+		outcome,
+		...extraLabels,
+	});
+}
+
+export function recordAnalysisSessionCreatedMetric(
+	recorder: MetricsRecorder | undefined,
+	outcome: MetricOutcome,
+): void {
+	recordCountAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisSessionsCreatedTotal,
+		outcome,
+	);
+}
+
+export function recordAnalysisMessageSentMetric(
+	recorder: MetricsRecorder | undefined,
+	outcome: MetricOutcome,
+): void {
+	recordCountAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisMessagesSentTotal,
+		outcome,
+	);
+}
+
+export function recordAnalysisUpdatesPolledMetric(
+	recorder: MetricsRecorder | undefined,
+	outcome: MetricOutcome,
+): void {
+	recordCountAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisUpdatesPolledTotal,
+		outcome,
+	);
+}
+
+export function recordAnalysisPollWaitMetric(
+	recorder: MetricsRecorder | undefined,
+	durationMs: number,
+	outcome: MetricOutcome,
+	isDone: boolean,
+): void {
+	recordHistogramAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisPollWaitMs,
+		durationMs,
+		outcome,
+		{
+			is_done: isDone,
+		},
+	);
+}
+
+export function recordAnalysisFirstBufferedUpdateMetric(
+	recorder: MetricsRecorder | undefined,
+	durationMs: number,
+	outcome: MetricOutcome,
+): void {
+	recordHistogramAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisFirstBufferedUpdateMs,
+		durationMs,
+		outcome,
+	);
+}
+
+export function recordAnalysisFirstPollDelayMetric(
+	recorder: MetricsRecorder | undefined,
+	durationMs: number,
+	outcome: MetricOutcome,
+): void {
+	recordHistogramAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisFirstPollDelayMs,
+		durationMs,
+		outcome,
+	);
+}
+
+export function recordAnalysisFirstNonEmptyResponseMetric(
+	recorder: MetricsRecorder | undefined,
+	durationMs: number,
+	outcome: MetricOutcome,
+): void {
+	recordHistogramAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisFirstNonEmptyResponseMs,
+		durationMs,
+		outcome,
+	);
+}
+
+export function recordAnalysisSessionNeverPolledMetric(
+	recorder: MetricsRecorder | undefined,
+	outcome: MetricOutcome = "client_error",
+): void {
+	recordCountAnalysisMetric(
+		recorder,
+		METRIC_NAMES.analysisSessionsNeverPolledTotal,
+		outcome,
+	);
+}
+
+export function recordStreamStorageErrorMetric(
+	recorder: MetricsRecorder | undefined,
+	operation: StreamStorageOperation,
+): void {
+	if (!recorder) {
+		return;
+	}
+
+	recorder.count(METRIC_NAMES.streamStorageErrorsTotal, 1, {
+		operation,
+	});
+}

--- a/src/servers/conversation-storage-server.ts
+++ b/src/servers/conversation-storage-server.ts
@@ -1,5 +1,29 @@
 import { isBoolean } from "lodash";
-import type { Message, StreamingMessagesState } from "../thoughtspot/types";
+import {
+	STREAM_STORAGE_OPERATIONS,
+	type StreamStorageOperation,
+	recordAnalysisFirstBufferedUpdateMetric,
+	recordAnalysisFirstNonEmptyResponseMetric,
+	recordAnalysisFirstPollDelayMetric,
+	recordAnalysisSessionNeverPolledMetric,
+	recordStreamStorageErrorMetric,
+} from "../metrics/runtime/analysis-metrics";
+import {
+	type MetricsRecorder,
+	scheduleMetricsFlush,
+} from "../metrics/runtime/metrics-recorder";
+import type {
+	MetricAnalyticsContext,
+	MetricEventIdentity,
+} from "../metrics/runtime/metrics-sink";
+import { createRequestMetricsRecorder } from "../metrics/runtime/request-metrics";
+import type { MetricsEnvLike } from "../metrics/runtime/runtime-config";
+import type {
+	Message,
+	StreamingConversationMetricsContext,
+	StreamingConversationTimingState,
+	StreamingMessagesState,
+} from "../thoughtspot/types";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const STORAGE_BATCH_SIZE = 127; // Cloudflare DO bulk get/put limit is 128, we use 127 to be safe
@@ -8,6 +32,10 @@ const MESSAGE_KEY_PREFIX = "message-";
 const IS_DONE_KEY = "is-done";
 const WRITE_BOOKMARK_KEY = "write-bookmark";
 const READ_BOOKMARK_KEY = "read-bookmark";
+const METRICS_STATE_KEY = "metrics-state";
+
+type ConversationMetricsState = StreamingConversationTimingState &
+	StreamingConversationMetricsContext;
 
 /**
  * A Durable Object that stores streaming conversation messages and exposes them over HTTP.
@@ -41,7 +69,11 @@ export class ConversationStorageServerSQLite {
 		try {
 			switch (`${request.method} /${operation}`) {
 				case "POST /initialize": {
-					await this.initializeConversation();
+					const body =
+						((await request
+							.json()
+							.catch(() => ({}))) as Partial<ConversationMetricsState>) ?? {};
+					await this.initializeConversation(body);
 					return Response.json({ ok: true });
 				}
 
@@ -60,6 +92,7 @@ export class ConversationStorageServerSQLite {
 					return new Response("Not Found", { status: 404 });
 			}
 		} catch (err) {
+			await this.recordStorageErrorMetric(this.toStorageOperation(operation));
 			const message = err instanceof Error ? err.message : String(err);
 			console.error(
 				`Error handling conversation storage request for conversation ${this.conversationId}:`,
@@ -74,7 +107,9 @@ export class ConversationStorageServerSQLite {
 	 * existing conversation which is already marked done for a followup message. We never delete
 	 * messages in the conversation, instead the next messages begin at the existing bookmark.
 	 */
-	private async initializeConversation(): Promise<void> {
+	private async initializeConversation(
+		metricsContext: Partial<ConversationMetricsState>,
+	): Promise<void> {
 		const existingIsDone = await this.state.storage.get<boolean>(IS_DONE_KEY);
 		if (isBoolean(existingIsDone) && !existingIsDone) {
 			throw new Error(
@@ -82,7 +117,19 @@ export class ConversationStorageServerSQLite {
 			);
 		}
 
-		await this.state.storage.put<boolean>(IS_DONE_KEY, false);
+		const metricsState: ConversationMetricsState = {
+			responseStartedAtMs: metricsContext.responseStartedAtMs,
+			apiRequestedVersion: metricsContext.apiRequestedVersion,
+			analyticalSessionId:
+				metricsContext.analyticalSessionId ?? this.conversationId,
+			tenantId: metricsContext.tenantId,
+			userId: metricsContext.userId,
+		};
+
+		await this.state.storage.put({
+			[IS_DONE_KEY]: false,
+			[METRICS_STATE_KEY]: metricsState,
+		});
 		await this.restartTtl();
 	}
 
@@ -96,7 +143,10 @@ export class ConversationStorageServerSQLite {
 		newMessages: Message[],
 		isDone = false,
 	): Promise<void> {
-		const existingIsDone = await this.state.storage.get<boolean>(IS_DONE_KEY);
+		const [existingIsDone, metricsState] = await Promise.all([
+			this.state.storage.get<boolean>(IS_DONE_KEY),
+			this.getConversationMetricsState(),
+		]);
 		if (!isBoolean(existingIsDone)) {
 			throw new Error(`Conversation ${this.conversationId} not found`);
 		}
@@ -107,7 +157,7 @@ export class ConversationStorageServerSQLite {
 		}
 
 		let idx = (await this.state.storage.get<number>(WRITE_BOOKMARK_KEY)) ?? 0;
-		const entriesToStore = {} as Record<string, Message | number | boolean>;
+		const entriesToStore = {} as Record<string, unknown>;
 		for (const message of newMessages) {
 			entriesToStore[`${MESSAGE_KEY_PREFIX}${idx}`] = message;
 			idx++;
@@ -117,10 +167,31 @@ export class ConversationStorageServerSQLite {
 		if (isDone) {
 			entriesToStore[IS_DONE_KEY] = true;
 		}
+		const shouldRecordFirstBufferedUpdate =
+			newMessages.length > 0 && !metricsState?.firstBufferedUpdateAtMs;
+		if (metricsState && shouldRecordFirstBufferedUpdate) {
+			metricsState.firstBufferedUpdateAtMs = Date.now();
+			entriesToStore[METRICS_STATE_KEY] = metricsState;
+		}
 
 		// Perform all writes in batches, then restart TTL
 		await this.putInBatches(entriesToStore);
 		await this.restartTtl();
+
+		if (
+			shouldRecordFirstBufferedUpdate &&
+			metricsState?.responseStartedAtMs !== undefined &&
+			metricsState.firstBufferedUpdateAtMs !== undefined
+		) {
+			this.recordMetricsSafe(metricsState, (recorder) => {
+				recordAnalysisFirstBufferedUpdateMetric(
+					recorder,
+					metricsState.firstBufferedUpdateAtMs! -
+						metricsState.responseStartedAtMs!,
+					"success",
+				);
+			});
+		}
 	}
 
 	/*
@@ -129,29 +200,49 @@ export class ConversationStorageServerSQLite {
 	 * use WRITE_BOOKMARK to know up to which index new messages have been written.
 	 */
 	private async getNewMessagesAndUpdateBookmark(): Promise<StreamingMessagesState> {
-		const [isDone, readBookmark, writeBookmark] =
-			await this.getIsDoneAndReadWriteBookmarks();
+		const [isDone, readBookmark, writeBookmark, metricsState] =
+			await this.getConversationStateSnapshot();
 		if (!isBoolean(isDone)) {
 			throw new Error(`Conversation ${this.conversationId} not found`);
 		}
-
-		const keys = [];
-		for (let i = readBookmark; i < writeBookmark; i++) {
-			keys.push(MESSAGE_KEY_PREFIX + i);
+		const shouldRecordFirstPoll = !metricsState?.firstPollAtMs;
+		if (metricsState && shouldRecordFirstPoll) {
+			metricsState.firstPollAtMs = Date.now();
+			await this.state.storage.put(METRICS_STATE_KEY, metricsState);
+			if (metricsState.responseStartedAtMs !== undefined) {
+				this.recordMetricsSafe(metricsState, (recorder) => {
+					recordAnalysisFirstPollDelayMetric(
+						recorder,
+						metricsState.firstPollAtMs! - metricsState.responseStartedAtMs!,
+						"success",
+					);
+				});
+			}
 		}
 
-		const newMessages: Message[] = [];
-		const messagesMap = await this.getInBatches<Message>(keys);
-		for (let i = readBookmark; i < writeBookmark; i++) {
-			const message = messagesMap.get(MESSAGE_KEY_PREFIX + i);
-			if (!message) {
-				console.warn(
-					`Expected message at index ${i} for conversation ${this.conversationId} not found`,
-					{ readBookmark, writeBookmark },
-				);
-				continue;
+		const newMessages = await this.getMessagesInRange(
+			readBookmark,
+			writeBookmark,
+			true,
+		);
+
+		const shouldRecordFirstNonEmptyResponse =
+			metricsState &&
+			newMessages.length > 0 &&
+			!metricsState.firstNonEmptyResponseAtMs;
+		if (shouldRecordFirstNonEmptyResponse) {
+			metricsState.firstNonEmptyResponseAtMs = Date.now();
+			await this.state.storage.put(METRICS_STATE_KEY, metricsState);
+			if (metricsState.responseStartedAtMs !== undefined) {
+				this.recordMetricsSafe(metricsState, (recorder) => {
+					recordAnalysisFirstNonEmptyResponseMetric(
+						recorder,
+						metricsState.firstNonEmptyResponseAtMs! -
+							metricsState.responseStartedAtMs!,
+						"success",
+					);
+				});
 			}
-			newMessages.push(message);
 		}
 
 		await this.state.storage.put<number>(READ_BOOKMARK_KEY, writeBookmark);
@@ -199,8 +290,8 @@ export class ConversationStorageServerSQLite {
 
 	async alarm(): Promise<void> {
 		// Check for any abnormalities in the state prior to deleting
-		const [isDone, readBookmark, writeBookmark] =
-			await this.getIsDoneAndReadWriteBookmarks();
+		const [isDone, readBookmark, writeBookmark, metricsState] =
+			await this.getConversationStateSnapshot();
 		if (!isBoolean(isDone) || !isDone) {
 			console.warn(
 				`Conversation ${this.conversationId} expired without being marked done`,
@@ -221,26 +312,142 @@ export class ConversationStorageServerSQLite {
 				},
 			);
 		}
+		if (!metricsState?.firstPollAtMs) {
+			this.recordMetricsSafe(metricsState, (recorder) => {
+				recordAnalysisSessionNeverPolledMetric(recorder);
+			});
+		}
 
 		// Delete everything in storage
 		await this.state.storage.deleteAll();
 	}
 
 	/*
-	 * Retrieve 3 fields from storage in one transaction: isDone, readBookmark, and writeBookmark
+	 * Retrieve the core conversation state and metrics metadata in one transaction.
 	 */
-	async getIsDoneAndReadWriteBookmarks(): Promise<
-		[boolean | undefined, number, number]
+	async getConversationStateSnapshot(): Promise<
+		[boolean | undefined, number, number, ConversationMetricsState | undefined]
 	> {
-		const result = await this.state.storage.get<boolean | number>([
-			IS_DONE_KEY,
-			READ_BOOKMARK_KEY,
-			WRITE_BOOKMARK_KEY,
-		]);
+		const result = await this.state.storage.get<
+			boolean | number | ConversationMetricsState
+		>([IS_DONE_KEY, READ_BOOKMARK_KEY, WRITE_BOOKMARK_KEY, METRICS_STATE_KEY]);
 		return [
 			result.get(IS_DONE_KEY) as boolean,
 			(result.get(READ_BOOKMARK_KEY) as number) ?? 0,
 			(result.get(WRITE_BOOKMARK_KEY) as number) ?? 0,
+			result.get(METRICS_STATE_KEY) as ConversationMetricsState | undefined,
 		];
+	}
+
+	private async getConversationMetricsState(): Promise<
+		ConversationMetricsState | undefined
+	> {
+		return this.state.storage.get<ConversationMetricsState>(METRICS_STATE_KEY);
+	}
+
+	private async getMessagesInRange(
+		readBookmark: number,
+		writeBookmark: number,
+		warnOnMissing = false,
+	): Promise<Message[]> {
+		const keys = [];
+		for (let i = readBookmark; i < writeBookmark; i++) {
+			keys.push(MESSAGE_KEY_PREFIX + i);
+		}
+
+		const messages: Message[] = [];
+		const messagesMap = await this.getInBatches<Message>(keys);
+		for (let i = readBookmark; i < writeBookmark; i++) {
+			const message = messagesMap.get(MESSAGE_KEY_PREFIX + i);
+			if (!message) {
+				if (warnOnMissing) {
+					console.warn(
+						`Expected message at index ${i} for conversation ${this.conversationId} not found`,
+						{ readBookmark, writeBookmark },
+					);
+				}
+				continue;
+			}
+			messages.push(message);
+		}
+
+		return messages;
+	}
+
+	private createMetricsRecorder(
+		metricsState?: ConversationMetricsState,
+	): MetricsRecorder {
+		const recorder = createRequestMetricsRecorder(
+			this.env as unknown as MetricsEnvLike,
+		);
+
+		const analyticsContext: MetricAnalyticsContext = {};
+		if (metricsState?.apiRequestedVersion) {
+			analyticsContext.apiRequestedVersion = metricsState.apiRequestedVersion;
+		}
+		if (metricsState?.analyticalSessionId) {
+			analyticsContext.analyticalSessionId = metricsState.analyticalSessionId;
+		}
+		if (Object.keys(analyticsContext).length > 0) {
+			recorder.setAnalyticsContext(analyticsContext);
+		}
+
+		const eventIdentity: MetricEventIdentity = {};
+		if (metricsState?.tenantId) {
+			eventIdentity.tenantId = metricsState.tenantId;
+		}
+		if (metricsState?.userId) {
+			eventIdentity.userId = metricsState.userId;
+		}
+		if (Object.keys(eventIdentity).length > 0) {
+			recorder.setEventIdentity(eventIdentity);
+		}
+
+		return recorder;
+	}
+
+	private recordMetricsSafe(
+		metricsState: ConversationMetricsState | undefined,
+		record: (recorder: MetricsRecorder) => void,
+	): void {
+		try {
+			const recorder = this.createMetricsRecorder(metricsState);
+			record(recorder);
+			scheduleMetricsFlush(recorder);
+		} catch (error) {
+			console.error(
+				`[metrics] Failed to record conversation storage metrics for ${this.conversationId}`,
+				error,
+			);
+		}
+	}
+
+	private async recordStorageErrorMetric(
+		operation: StreamStorageOperation,
+	): Promise<void> {
+		try {
+			const metricsState = await this.getConversationMetricsState();
+			this.recordMetricsSafe(metricsState, (recorder) => {
+				recordStreamStorageErrorMetric(recorder, operation);
+			});
+		} catch (error) {
+			console.error(
+				`[metrics] Failed to record conversation storage error metric for ${this.conversationId}`,
+				error,
+			);
+		}
+	}
+
+	private toStorageOperation(operation: string): StreamStorageOperation {
+		switch (operation) {
+			case "initialize":
+				return STREAM_STORAGE_OPERATIONS.initialize;
+			case "append":
+				return STREAM_STORAGE_OPERATIONS.append;
+			case "messages":
+				return STREAM_STORAGE_OPERATIONS.messages;
+			default:
+				return STREAM_STORAGE_OPERATIONS.unknown;
+		}
 	}
 }

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -5,12 +5,22 @@ import type {
 import { SpanStatusCode, context, trace } from "@opentelemetry/api";
 import type { z } from "zod";
 import { TrackEvent } from "../metrics";
+import {
+	recordAnalysisMessageSentMetric,
+	recordAnalysisPollWaitMetric,
+	recordAnalysisSessionCreatedMetric,
+	recordAnalysisUpdatesPolledMetric,
+} from "../metrics/runtime/analysis-metrics";
 import type { ApiVersionMode } from "../metrics/runtime/metric-types";
 import {
 	type MetricsRecorder,
 	NOOP_METRICS_RECORDER,
 } from "../metrics/runtime/metrics-recorder";
-import type { ToolMetricApiSurface } from "../metrics/runtime/tool-metrics";
+import {
+	type ToolMetricApiSurface,
+	getToolMetricOutcomeFromError,
+	getToolMetricOutcomeFromResult,
+} from "../metrics/runtime/tool-metrics";
 import { WithSpan } from "../metrics/tracing/tracing-utils";
 import type { DataSource } from "../thoughtspot/thoughtspot-service";
 import type { Answer, StreamingMessagesState } from "../thoughtspot/types";
@@ -93,6 +103,29 @@ export class MCPServer extends BaseMCPServer {
 			return resolveApiVersionMetrics(apiVersion).apiReleaseDate;
 		} catch {
 			return undefined;
+		}
+	}
+
+	private async withAnalysisOutcomeMetric<T>(
+		recorder: MetricsRecorder,
+		recordOutcome: (
+			outcome: ReturnType<typeof getToolMetricOutcomeFromError>,
+		) => void,
+		handler: () => Promise<T>,
+	): Promise<T> {
+		let outcome: ReturnType<typeof getToolMetricOutcomeFromError> | undefined;
+
+		try {
+			const result = await handler();
+			outcome = getToolMetricOutcomeFromResult(result);
+			return result;
+		} catch (error) {
+			outcome = getToolMetricOutcomeFromError(error);
+			throw error;
+		} finally {
+			if (outcome) {
+				recordOutcome(outcome);
+			}
 		}
 	}
 
@@ -375,27 +408,35 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		request: z.infer<typeof CallToolRequestSchema>,
 		recorder: MetricsRecorder,
 	) {
-		const span = trace.getSpan(context.active());
-		const { data_source_id } = CreateAnalysisSessionInputSchema.parse(
-			request.params.arguments,
-		);
-		span?.setAttribute("data_source_id", data_source_id ?? "(none)");
+		return this.withAnalysisOutcomeMetric(
+			recorder,
+			(outcome) => {
+				recordAnalysisSessionCreatedMetric(recorder, outcome);
+			},
+			async () => {
+				const span = trace.getSpan(context.active());
+				const { data_source_id } = CreateAnalysisSessionInputSchema.parse(
+					request.params.arguments,
+				);
+				span?.setAttribute("data_source_id", data_source_id ?? "(none)");
 
-		const response =
-			await this.getThoughtSpotService(recorder).createAgentConversation(
-				data_source_id,
-			);
-		recorder.setAnalyticsContext({
-			analyticalSessionId: response.conversation_id,
-		});
-		span?.setAttribute("analytical_session_id", response.conversation_id);
+				const response =
+					await this.getThoughtSpotService(recorder).createAgentConversation(
+						data_source_id,
+					);
+				recorder.setAnalyticsContext({
+					analyticalSessionId: response.conversation_id,
+				});
+				span?.setAttribute("analytical_session_id", response.conversation_id);
 
-		// Conversation is initialized in Storage Server from callSendSessionMessage, since that is
-		// the common entrypoint for both initial messages and followup messages.
+				// Conversation is initialized in streamingMessageStorage from callSendSessionMessage,
+				// since that is the common entrypoint for both initial messages and followup messages.
 
-		return this.createStructuredContentSuccessResponse(
-			{ analytical_session_id: response.conversation_id },
-			"Conversation created successfully",
+				return this.createStructuredContentSuccessResponse(
+					{ analytical_session_id: response.conversation_id },
+					"Conversation created successfully",
+				);
+			},
 		);
 	}
 
@@ -404,55 +445,80 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		request: z.infer<typeof CallToolRequestSchema>,
 		recorder: MetricsRecorder = NOOP_METRICS_RECORDER,
 	) {
-		const span = trace.getSpan(context.active());
-		const { analytical_session_id, message, additional_context } =
-			SendSessionMessageInputSchema.parse(request.params.arguments);
-		recorder.setAnalyticsContext({
-			analyticalSessionId: analytical_session_id,
-		});
-		span?.setAttributes({
-			analytical_session_id,
-			has_additional_context: !!additional_context,
-		});
+		return this.withAnalysisOutcomeMetric(
+			recorder,
+			(outcome) => {
+				recordAnalysisMessageSentMetric(recorder, outcome);
+			},
+			async () => {
+				const span = trace.getSpan(context.active());
+				const { analytical_session_id, message, additional_context } =
+					SendSessionMessageInputSchema.parse(request.params.arguments);
+				const responseStartedAtMs = Date.now();
+				const analyticsContext = this.mergeMetricAnalyticsContext({
+					analyticalSessionId: analytical_session_id,
+				});
+				const eventIdentity = this.getMetricEventIdentity();
+				recorder.setAnalyticsContext({
+					analyticalSessionId: analytical_session_id,
+				});
+				span?.setAttributes({
+					analytical_session_id,
+					has_additional_context: !!additional_context,
+				});
 
-		const storageService = await this.getStorageService();
-		try {
-			await storageService.initializeConversation(analytical_session_id);
-		} catch (error) {
-			console.error(
-				"Error initializing conversation in storage service:",
-				error,
-			);
-			return this.createErrorResponse(
-				"The analytical session has an ongoing response to the previous message. Please continue to call `get_session_updates` until `is_done` is true before sending a followup message.",
-				`Error sending message to conversation ${analytical_session_id}: ${error}`,
-			);
-		}
+				const storageService = await this.getStorageService();
+				try {
+					await storageService.initializeConversation(analytical_session_id, {
+						responseStartedAtMs,
+						apiRequestedVersion: analyticsContext?.apiRequestedVersion,
+						analyticalSessionId: analytical_session_id,
+						tenantId: eventIdentity?.tenantId,
+						userId: eventIdentity?.userId,
+					});
+				} catch (error) {
+					console.error(
+						"Error initializing conversation in storage service:",
+						error,
+					);
+					return this.createErrorResponse(
+						"The analytical session has an ongoing response to the previous message. Please continue to call `get_session_updates` until `is_done` is true before sending a followup message.",
+						`Error sending message to conversation ${analytical_session_id}: ${error}`,
+					);
+				}
 
-		await this.getThoughtSpotService(recorder, {
-			analyticalSessionId: analytical_session_id,
-		}).sendAgentConversationMessageStreaming(
-			analytical_session_id,
-			message,
-			storageService.appendMessages.bind(storageService),
-			additional_context,
-		);
+				await this.getThoughtSpotService(recorder, {
+					analyticalSessionId: analytical_session_id,
+				}).sendAgentConversationMessageStreaming(
+					analytical_session_id,
+					message,
+					storageService.appendMessages.bind(storageService),
+					additional_context,
+				);
 
-		return this.createStructuredContentSuccessResponse(
-			{ success: true },
-			"Conversation message sent successfully",
+				return this.createStructuredContentSuccessResponse(
+					{ success: true },
+					"Conversation message sent successfully",
+				);
+			},
 		);
 	}
 
 	@WithSpan("call-get-session-updates")
 	async callGetSessionUpdates(
 		request: z.infer<typeof CallToolRequestSchema>,
-		_recorder: MetricsRecorder = NOOP_METRICS_RECORDER,
+		recorder: MetricsRecorder = NOOP_METRICS_RECORDER,
 	) {
 		const span = trace.getSpan(context.active());
+		const pollStartedAt = Date.now();
+		let outcome: ReturnType<typeof getToolMetricOutcomeFromError> | undefined;
+		let isDone = false;
 		const { analytical_session_id } = GetSessionUpdatesInputSchema.parse(
 			request.params.arguments,
 		);
+		recorder.setAnalyticsContext({
+			analyticalSessionId: analytical_session_id,
+		});
 		span?.setAttribute("analytical_session_id", analytical_session_id);
 
 		// Rules when fetching conversation updates:
@@ -462,46 +528,64 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		//    returning too quickly, which leads to too many get updates tool calls.
 		// 4. If there are no updates after waiting for 10 seconds, return an empty response. We
 		//    want to avoid waiting indefinitely in case of errors or unexpected problems.
-		const storageService = await this.getStorageService();
-		const messagesState: StreamingMessagesState = {
-			messages: [],
-			isDone: false,
-		};
-		let i = 0;
-		for (; i < 20; i++) {
-			// Get latest updates
-			const newMessagesState = await storageService.getNewMessages(
-				analytical_session_id,
-			);
-			messagesState.messages.push(...newMessagesState.messages);
-			messagesState.isDone = newMessagesState.isDone;
+		try {
+			const storageService = await this.getStorageService();
+			const messagesState: StreamingMessagesState = {
+				messages: [],
+				isDone: false,
+			};
+			let i = 0;
+			for (; i < 20; i++) {
+				// Get latest updates
+				const newMessagesState = await storageService.getNewMessages(
+					analytical_session_id,
+				);
+				messagesState.messages.push(...newMessagesState.messages);
+				messagesState.isDone = newMessagesState.isDone;
 
-			// If conversation is marked done, return immediately
-			if (messagesState.isDone) {
-				break;
+				// If conversation is marked done, return immediately
+				if (messagesState.isDone) {
+					break;
+				}
+
+				// If we have new messages and waited for at least 3 seconds, return the updates
+				if (messagesState.messages.length > 0 && i >= 6) {
+					break;
+				}
+
+				// Wait 500 ms before polling for updates again
+				await new Promise((resolve) => setTimeout(resolve, 500));
 			}
 
-			// If we have new messages and waited for at least 3 seconds, return the updates
-			if (messagesState.messages.length > 0 && i >= 6) {
-				break;
-			}
-
-			// Wait 500 ms before polling for updates again
-			await new Promise((resolve) => setTimeout(resolve, 500));
-		}
-		span?.setAttributes({
-			total_wait_time_ms: i * 500,
-			total_session_updates: messagesState.messages.length,
-			is_done: messagesState.isDone,
-		});
-
-		return this.createStructuredContentSuccessResponse(
-			{
-				session_updates: messagesState.messages,
+			isDone = messagesState.isDone;
+			outcome = "success";
+			span?.setAttributes({
+				total_wait_time_ms: i * 500,
+				total_session_updates: messagesState.messages.length,
 				is_done: messagesState.isDone,
-			},
-			"Conversation updates retrieved successfully",
-		);
+			});
+
+			return this.createStructuredContentSuccessResponse(
+				{
+					session_updates: messagesState.messages,
+					is_done: messagesState.isDone,
+				},
+				"Conversation updates retrieved successfully",
+			);
+		} catch (error) {
+			outcome = getToolMetricOutcomeFromError(error);
+			throw error;
+		} finally {
+			if (outcome) {
+				recordAnalysisUpdatesPolledMetric(recorder, outcome);
+				recordAnalysisPollWaitMetric(
+					recorder,
+					Date.now() - pollStartedAt,
+					outcome,
+					isDone,
+				);
+			}
+		}
 	}
 
 	@WithSpan("call-create-dashboard")

--- a/src/storage-service/storage-service.ts
+++ b/src/storage-service/storage-service.ts
@@ -1,16 +1,22 @@
-import type { Message, StreamingMessagesState } from "../thoughtspot/types";
+import type {
+	Message,
+	StreamingConversationMetricsContext,
+	StreamingConversationTimingState,
+	StreamingMessagesState,
+} from "../thoughtspot/types";
 
 /**
  * Client for the ConversationStorageServer Durable Object.
  *
  * Communicates directly with the DO via its stub (bypassing the OAuth layer), mapping to the
  * following HTTP endpoints exposed by the server:
- *   POST  /storage/<storageId>/initialize —> initializeConversation
- *   POST  /storage/<storageId>/append     —> appendMessagesAndRestartTtl
- *   GET   /storage/<storageId>/messages   —> getNewMessagesAndUpdateBookmark
+ *   POST  /storage/<conversationId>/initialize —> initializeConversation
+ *   POST  /storage/<conversationId>/append     —> appendMessagesAndRestartTtl
+ *   GET   /storage/<conversationId>/messages   —> getNewMessagesAndUpdateBookmark
  *
- * The storageId is derived by taking a hash of the user's access token and combining it with the
- * conversationId, to ensure no users can access each other's conversations.
+ * The route path uses the conversation id. Isolation between users happens at the
+ * Durable Object id level by hashing the access token and combining it with the
+ * conversation id when constructing the stub name.
  */
 export class StorageServiceClient {
 	constructor(
@@ -42,10 +48,18 @@ export class StorageServiceClient {
 	 * Can also be called on an existing conversation that is already marked done,
 	 * to prime it for a follow-up message.
 	 */
-	async initializeConversation(conversationId: string): Promise<void> {
+	async initializeConversation(
+		conversationId: string,
+		metricsContext?: StreamingConversationMetricsContext &
+			Required<Pick<StreamingConversationTimingState, "responseStartedAtMs">>,
+	): Promise<void> {
 		const response = await this.stubFor(conversationId).fetch(
 			this.url(conversationId, "initialize"),
-			{ method: "POST", headers: this.headers() },
+			{
+				method: "POST",
+				headers: this.headers(),
+				body: JSON.stringify(metricsContext ?? {}),
+			},
 		);
 
 		if (!response.ok) {

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -49,6 +49,20 @@ export interface AnswerMessage extends BaseMessage {
 
 export type Message = TextMessage | AnswerMessage;
 
+export interface StreamingConversationTimingState {
+	responseStartedAtMs?: number;
+	firstBufferedUpdateAtMs?: number;
+	firstPollAtMs?: number;
+	firstNonEmptyResponseAtMs?: number;
+}
+
+export interface StreamingConversationMetricsContext {
+	apiRequestedVersion?: string;
+	analyticalSessionId?: string;
+	tenantId?: string;
+	userId?: string;
+}
+
 export interface StreamingMessagesState {
 	messages: Message[];
 	isDone: boolean;

--- a/test/servers/conversation-storage-server.spec.ts
+++ b/test/servers/conversation-storage-server.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { METRIC_NAMES } from "../../src/metrics/runtime/metric-types";
 import { ConversationStorageServerSQLite } from "../../src/servers/conversation-storage-server";
 import type {
 	Message,
@@ -67,9 +68,12 @@ function createMockStorage() {
 	};
 }
 
-function createServer(mock: ReturnType<typeof createMockStorage>) {
+function createServer(
+	mock: ReturnType<typeof createMockStorage>,
+	env: Partial<Env> = {},
+) {
 	const state = { storage: mock.storage } as unknown as DurableObjectState;
-	return new ConversationStorageServerSQLite(state, {} as Env);
+	return new ConversationStorageServerSQLite(state, env as Env);
 }
 
 function makeRequest(
@@ -83,6 +87,20 @@ function makeRequest(
 		headers: body ? { "Content-Type": "application/json" } : {},
 		body: body ? JSON.stringify(body) : undefined,
 	});
+}
+
+function dataPointsFor(
+	analyticsDataset: { writeDataPoint: ReturnType<typeof vi.fn> },
+	metricName: string,
+) {
+	return analyticsDataset.writeDataPoint.mock.calls
+		.map(([dataPoint]) => dataPoint)
+		.filter((dataPoint) => dataPoint.blobs?.[2] === metricName);
+}
+
+async function flushScheduledMetrics() {
+	await Promise.resolve();
+	await Promise.resolve();
 }
 
 // Sample messages
@@ -143,6 +161,12 @@ describe("ConversationStorageServerSQLite", () => {
 		it("returns 404 for a valid operation with the wrong HTTP method", async () => {
 			const res = await server.fetch(makeRequest("GET", "initialize"));
 			expect(res.status).toBe(404);
+		});
+
+		it("maps unmapped operation names to unknown storage metrics", () => {
+			expect((server as any).toStorageOperation("future-operation")).toBe(
+				"unknown",
+			);
 		});
 	});
 
@@ -294,11 +318,12 @@ describe("ConversationStorageServerSQLite", () => {
 		// -------------------------------------------------------------------
 
 		it("stores exactly STORAGE_BATCH_SIZE messages in a single put call", async () => {
-			// STORAGE_BATCH_SIZE - 1 messages + write-bookmark = STORAGE_BATCH_SIZE entries → 1 batch
+			// STORAGE_BATCH_SIZE - 1 messages + write-bookmark + metrics-state = STORAGE_BATCH_SIZE + 1
+			// entries → 2 batches on the first append.
 			const messages = generateMessages(STORAGE_BATCH_SIZE - 1);
 			await server.fetch(makeRequest("POST", "append", { messages }));
 
-			expect(mock.storage.put).toHaveBeenCalledOnce();
+			expect(mock.storage.put).toHaveBeenCalledTimes(2);
 			expect(mock.store.get("write-bookmark")).toBe(STORAGE_BATCH_SIZE - 1);
 			expect(mock.store.get("message-0")).toEqual(messages[0]);
 			expect(mock.store.get(`message-${STORAGE_BATCH_SIZE - 2}`)).toEqual(
@@ -357,7 +382,10 @@ describe("ConversationStorageServerSQLite", () => {
 		it("returns empty messages and isDone=false on a fresh conversation", async () => {
 			const res = await server.fetch(makeRequest("GET", "messages"));
 			expect(res.status).toBe(200);
-			expect(await res.json()).toEqual({ messages: [], isDone: false });
+			expect(await res.json()).toMatchObject({
+				messages: [],
+				isDone: false,
+			});
 		});
 
 		it("returns all messages appended since the last call", async () => {
@@ -433,7 +461,7 @@ describe("ConversationStorageServerSQLite", () => {
 			const res = await server.fetch(makeRequest("GET", "messages"));
 			const body = (await res.json()) as StreamingMessagesState;
 
-			// 1 get for getIsDoneAndReadWriteBookmarks + 1 get for the STORAGE_BATCH_SIZE message keys
+			// 1 get for getConversationStateSnapshot + 1 get for the STORAGE_BATCH_SIZE message keys
 			expect(mock.storage.get).toHaveBeenCalledTimes(2);
 			expect(body.messages).toHaveLength(STORAGE_BATCH_SIZE);
 			expect(body.messages).toEqual(messages);
@@ -448,7 +476,7 @@ describe("ConversationStorageServerSQLite", () => {
 			const res = await server.fetch(makeRequest("GET", "messages"));
 			const body = (await res.json()) as StreamingMessagesState;
 
-			// 1 get for getIsDoneAndReadWriteBookmarks + 2 get batches for the message keys
+			// 1 get for getConversationStateSnapshot + 2 get batches for the message keys
 			expect(mock.storage.get).toHaveBeenCalledTimes(3);
 			expect(body.messages).toHaveLength(count);
 			expect(body.messages).toEqual(messages);
@@ -532,5 +560,138 @@ describe("ConversationStorageServerSQLite", () => {
 			const res = await server.fetch(makeRequest("POST", "initialize"));
 			expect(res.status).toBe(200);
 		});
+	});
+});
+
+describe("ConversationStorageServerSQLite metrics", () => {
+	let analyticsDataset: { writeDataPoint: ReturnType<typeof vi.fn> };
+	let mock: ReturnType<typeof createMockStorage>;
+	let server: ConversationStorageServerSQLite;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		analyticsDataset = {
+			writeDataPoint: vi.fn(),
+		};
+		mock = createMockStorage();
+		server = createServer(mock, {
+			METRICS_SINK_MODE: "analytics_engine",
+			ANALYTICS: analyticsDataset,
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("records first-buffered, first-poll, and first-non-empty-response metrics once", async () => {
+		vi.setSystemTime(1_000);
+		await server.fetch(
+			makeRequest("POST", "initialize", {
+				responseStartedAtMs: 1_000,
+				apiRequestedVersion: "latest",
+				analyticalSessionId: "conv-1",
+				tenantId: "org-123",
+				userId: "user-123",
+			}),
+		);
+
+		vi.setSystemTime(1_500);
+		await server.fetch(
+			makeRequest("POST", "append", {
+				messages: [{ type: "text", text: "hello", is_thinking: false }],
+				isDone: false,
+			}),
+		);
+
+		await flushScheduledMetrics();
+		expect(
+			dataPointsFor(
+				analyticsDataset,
+				METRIC_NAMES.analysisFirstBufferedUpdateMs,
+			),
+		).toHaveLength(1);
+
+		vi.setSystemTime(2_000);
+		const firstPollResponse = await server.fetch(
+			makeRequest("GET", "messages"),
+		);
+		expect(firstPollResponse.status).toBe(200);
+		expect(await firstPollResponse.json()).toMatchObject({
+			messages: [{ type: "text", text: "hello", is_thinking: false }],
+			isDone: false,
+		});
+
+		await flushScheduledMetrics();
+		expect(
+			dataPointsFor(analyticsDataset, METRIC_NAMES.analysisFirstPollDelayMs),
+		).toHaveLength(1);
+		expect(
+			dataPointsFor(
+				analyticsDataset,
+				METRIC_NAMES.analysisFirstNonEmptyResponseMs,
+			),
+		).toHaveLength(1);
+
+		vi.setSystemTime(5_000);
+		await server.fetch(
+			makeRequest("POST", "append", {
+				messages: [{ type: "text", text: "again", is_thinking: false }],
+				isDone: false,
+			}),
+		);
+		await server.fetch(makeRequest("GET", "messages"));
+
+		expect(
+			dataPointsFor(
+				analyticsDataset,
+				METRIC_NAMES.analysisFirstBufferedUpdateMs,
+			),
+		).toHaveLength(1);
+		expect(
+			dataPointsFor(analyticsDataset, METRIC_NAMES.analysisFirstPollDelayMs),
+		).toHaveLength(1);
+		expect(
+			dataPointsFor(
+				analyticsDataset,
+				METRIC_NAMES.analysisFirstNonEmptyResponseMs,
+			),
+		).toHaveLength(1);
+	});
+
+	it("records never-polled sessions during cleanup", async () => {
+		vi.setSystemTime(1_000);
+		await server.fetch(
+			makeRequest("POST", "initialize", {
+				responseStartedAtMs: 1_000,
+				tenantId: "org-123",
+			}),
+		);
+
+		await server.alarm();
+
+		await flushScheduledMetrics();
+		expect(
+			dataPointsFor(
+				analyticsDataset,
+				METRIC_NAMES.analysisSessionsNeverPolledTotal,
+			),
+		).toHaveLength(1);
+	});
+
+	it("records storage error metrics when an operation fails", async () => {
+		const response = await server.fetch(
+			makeRequest("POST", "append", {
+				messages: [{ type: "text", text: "hello", is_thinking: false }],
+				isDone: false,
+			}),
+		);
+
+		expect(response.status).toBe(500);
+		await flushScheduledMetrics();
+		expect(
+			dataPointsFor(analyticsDataset, METRIC_NAMES.streamStorageErrorsTotal),
+		).toHaveLength(1);
 	});
 });

--- a/test/servers/mcp-server-analysis-metrics.spec.ts
+++ b/test/servers/mcp-server-analysis-metrics.spec.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { METRIC_NAMES } from "../../src/metrics/runtime/metric-types";
+import { createRequestMetricsRecorder } from "../../src/metrics/runtime/request-metrics";
+import { MCPServer } from "../../src/servers/mcp-server";
+
+function metricDataPoints(
+	analyticsDataset: { writeDataPoint: ReturnType<typeof vi.fn> },
+	metricName: string,
+) {
+	return analyticsDataset.writeDataPoint.mock.calls
+		.map(([dataPoint]) => dataPoint)
+		.filter((dataPoint) => dataPoint.blobs?.[2] === metricName);
+}
+
+function createServerAndRecorder() {
+	const analyticsDataset = {
+		writeDataPoint: vi.fn(),
+	};
+	const server = new MCPServer(
+		{
+			props: {
+				instanceUrl: "https://test.thoughtspot.cloud",
+				accessToken: "test-access-token",
+				apiVersion: "latest",
+				apiRequestedVersion: "latest",
+				apiVersionMode: "explicit_latest",
+			},
+			env: {
+				METRICS_SINK_MODE: "analytics_engine",
+				ANALYTICS: analyticsDataset,
+			} as any,
+		} as any,
+		{} as any,
+	);
+	(server as any).sessionInfo = {
+		clusterId: "cluster-123",
+		currentOrgId: "org-123",
+		userGUID: "user-123",
+	};
+
+	const recorder = createRequestMetricsRecorder({
+		METRICS_SINK_MODE: "analytics_engine",
+		ANALYTICS: analyticsDataset,
+	});
+	recorder.setAnalyticsContext({
+		apiRequestedVersion: "latest",
+	});
+	recorder.setEventIdentity({
+		tenantId: "cluster-123",
+		userId: "user-123",
+	});
+
+	return { analyticsDataset, server, recorder };
+}
+
+describe("MCPServer analysis metrics", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("records analysis session creation metrics with the resolved session id", async () => {
+		const { analyticsDataset, recorder, server } = createServerAndRecorder();
+		vi.spyOn(server as any, "getThoughtSpotService").mockReturnValue({
+			createAgentConversation: vi.fn().mockResolvedValue({
+				conversation_id: "conv-123",
+			}),
+		});
+
+		await server.callCreateAnalysisSession(
+			{
+				method: "tools/call",
+				params: { name: "create_analysis_session", arguments: {} },
+			} as any,
+			recorder,
+		);
+		await recorder.flush();
+
+		expect(
+			metricDataPoints(
+				analyticsDataset,
+				METRIC_NAMES.analysisSessionsCreatedTotal,
+			),
+		).toEqual([
+			expect.objectContaining({
+				indexes: ["cluster-123"],
+				blobs: expect.arrayContaining([
+					METRIC_NAMES.analysisSessionsCreatedTotal,
+					"conv-123",
+				]),
+			}),
+		]);
+	});
+
+	it("records send-session metrics and initializes storage with timing context", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000);
+
+		const { analyticsDataset, recorder, server } = createServerAndRecorder();
+		const storageService = {
+			initializeConversation: vi.fn().mockResolvedValue(undefined),
+			appendMessages: vi.fn().mockResolvedValue(undefined),
+		};
+		vi.spyOn(server as any, "getStorageService").mockReturnValue(
+			storageService,
+		);
+		vi.spyOn(server as any, "getThoughtSpotService").mockReturnValue({
+			sendAgentConversationMessageStreaming: vi
+				.fn()
+				.mockResolvedValue(undefined),
+		});
+
+		await server.callSendSessionMessage(
+			{
+				method: "tools/call",
+				params: {
+					name: "send_session_message",
+					arguments: {
+						analytical_session_id: "conv-123",
+						message: "Show me revenue",
+					},
+				},
+			} as any,
+			recorder,
+		);
+		await recorder.flush();
+
+		expect(storageService.initializeConversation).toHaveBeenCalledWith(
+			"conv-123",
+			expect.objectContaining({
+				responseStartedAtMs: 1_000,
+				apiRequestedVersion: "latest",
+				analyticalSessionId: "conv-123",
+				tenantId: "cluster-123",
+				userId: "user-123",
+			}),
+		);
+		expect(
+			metricDataPoints(
+				analyticsDataset,
+				METRIC_NAMES.analysisMessagesSentTotal,
+			),
+		).toEqual([
+			expect.objectContaining({
+				indexes: ["cluster-123"],
+				blobs: expect.arrayContaining([
+					METRIC_NAMES.analysisMessagesSentTotal,
+					"conv-123",
+				]),
+			}),
+		]);
+
+		vi.useRealTimers();
+	});
+
+	it("records polling counters and poll wait while marking first non-empty delivery", async () => {
+		const { analyticsDataset, recorder, server } = createServerAndRecorder();
+		const storageService = {
+			getNewMessages: vi.fn().mockResolvedValue({
+				messages: [{ type: "text", text: "hello", is_thinking: false }],
+				isDone: true,
+			}),
+		};
+		vi.spyOn(server as any, "getStorageService").mockReturnValue(
+			storageService,
+		);
+
+		const result = await server.callGetSessionUpdates(
+			{
+				method: "tools/call",
+				params: {
+					name: "get_session_updates",
+					arguments: {
+						analytical_session_id: "conv-123",
+					},
+				},
+			} as any,
+			recorder,
+		);
+		await recorder.flush();
+
+		expect(result.structuredContent).toEqual({
+			session_updates: [{ type: "text", text: "hello", is_thinking: false }],
+			is_done: true,
+		});
+		expect(
+			metricDataPoints(
+				analyticsDataset,
+				METRIC_NAMES.analysisUpdatesPolledTotal,
+			),
+		).toEqual([
+			expect.objectContaining({
+				indexes: ["cluster-123"],
+				blobs: expect.arrayContaining([
+					METRIC_NAMES.analysisUpdatesPolledTotal,
+					"conv-123",
+				]),
+			}),
+		]);
+		expect(
+			metricDataPoints(analyticsDataset, METRIC_NAMES.analysisPollWaitMs),
+		).toHaveLength(1);
+	});
+});

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -1338,6 +1338,13 @@ describe("MCP Server", () => {
 			expect((result.structuredContent as any).success).toBe(true);
 			expect(mockStorageService.initializeConversation).toHaveBeenCalledWith(
 				"conv-abc-123",
+				expect.objectContaining({
+					analyticalSessionId: "conv-abc-123",
+					apiRequestedVersion: undefined,
+					responseStartedAtMs: expect.any(Number),
+					tenantId: "test-cluster-123",
+					userId: "test-user-123",
+				}),
 			);
 			expect(mockSendAgentConversationMessageStreaming).toHaveBeenCalledWith(
 				"conv-abc-123",


### PR DESCRIPTION
## Summary

Instrument the analysis polling bridge so we can measure backend readiness, client polling behavior, and sessions that never get polled.

## What Changed

- add shared analysis metric helpers for session counters, poll wait, first buffered update, first poll delay, first non-empty response, never-polled sessions, and storage errors
- persist timing metadata in the ConversationStorageServer Durable Object and expose it through the storage client so one-shot lifecycle metrics are emitted once per response
- record request-scoped analysis counters and poll-wait histograms in the MCP server analysis tool methods
- add focused specs for the conversation storage timing state and the analysis tool metrics flow

## Notes

- first-buffered, first-poll, first-non-empty, and never-polled metrics are emitted from the storage Durable Object because it owns the cross-request conversation state
- local design docs were updated for our internal reference but are not part of this commit