### PR TITLE
Add access token hash to Storage Server DO routing

### DIFF
--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -33,9 +33,6 @@ import { getThoughtSpotClient } from "../thoughtspot/thoughtspot-client";
 import { ThoughtSpotService } from "../thoughtspot/thoughtspot-service";
 import type { Props } from "../utils";
 
-const ToolInputSchema = ToolSchema.shape.inputSchema;
-type ToolInput = z.infer<typeof ToolInputSchema>;
-
 // Response utility types
 export type ContentItem = {
 	type: "text";
@@ -191,10 +188,23 @@ export abstract class BaseMCPServer extends Server {
 		};
 	}
 
-	protected getStorageService(): StorageServiceClient {
+	protected async getStorageService(): Promise<StorageServiceClient> {
+		const accessToken = this.ctx.props.accessToken;
+		if (!accessToken || accessToken.length === 0) {
+			throw new Error("Access token is required to use Storage Service");
+		}
+		const encodedAccessToken = new TextEncoder().encode(accessToken);
+		const hashBuffer = await crypto.subtle.digest(
+			"SHA-256",
+			encodedAccessToken,
+		);
+		const hashUrlSafe = Buffer.from(new Uint8Array(hashBuffer)).toString(
+			"base64url",
+		);
 		return new StorageServiceClient(
 			this.ctx.env
 				.CONVERSATION_STORAGE_OBJECT as unknown as DurableObjectNamespace,
+			hashUrlSafe,
 		);
 	}
 

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -416,7 +416,7 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			has_additional_context: !!additional_context,
 		});
 
-		const storageService = this.getStorageService();
+		const storageService = await this.getStorageService();
 		try {
 			await storageService.initializeConversation(analytical_session_id);
 		} catch (error) {
@@ -463,7 +463,7 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		//    returning too quickly, which leads to too many get updates tool calls.
 		// 4. If there are no updates after waiting for 10 seconds, return an empty response. We
 		//    want to avoid waiting indefinitely in case of errors or unexpected problems.
-		const storageService = this.getStorageService();
+		const storageService = await this.getStorageService();
 		const messagesState: StreamingMessagesState = {
 			messages: [],
 			isDone: false,

--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -408,6 +408,7 @@ export const toolDefinitionsV2 = [
 			title: "Create Dashboard",
 			readOnlyHint: false,
 			destructiveHint: false,
+			openWorldHint: false,
 		},
 	},
 ];

--- a/src/storage-service/storage-service.ts
+++ b/src/storage-service/storage-service.ts
@@ -5,12 +5,18 @@ import type { Message, StreamingMessagesState } from "../thoughtspot/types";
  *
  * Communicates directly with the DO via its stub (bypassing the OAuth layer), mapping to the
  * following HTTP endpoints exposed by the server:
- *   POST  /storage/<conversationId>/initialize —> initializeConversation
- *   POST  /storage/<conversationId>/append     —> appendMessagesAndRestartTtl
- *   GET   /storage/<conversationId>/messages   —> getNewMessagesAndUpdateBookmark
+ *   POST  /storage/<storageId>/initialize —> initializeConversation
+ *   POST  /storage/<storageId>/append     —> appendMessagesAndRestartTtl
+ *   GET   /storage/<storageId>/messages   —> getNewMessagesAndUpdateBookmark
+ *
+ * The storageId is derived by taking a hash of the user's access token and combining it with the
+ * conversationId, to ensure no users can access each other's conversations.
  */
 export class StorageServiceClient {
-	constructor(private readonly namespace: DurableObjectNamespace) {}
+	constructor(
+		private readonly namespace: DurableObjectNamespace,
+		private readonly accessTokenHashUrlSafe: string,
+	) {}
 
 	private headers(): HeadersInit {
 		return {
@@ -20,7 +26,9 @@ export class StorageServiceClient {
 	}
 
 	private stubFor(conversationId: string): DurableObjectStub {
-		const id = this.namespace.idFromName(conversationId);
+		const id = this.namespace.idFromName(
+			`${this.accessTokenHashUrlSafe}:${conversationId}`,
+		);
 		return this.namespace.get(id);
 	}
 

--- a/test/servers/mcp-server-base.spec.ts
+++ b/test/servers/mcp-server-base.spec.ts
@@ -70,6 +70,10 @@ class TestMCPServer extends MCPServer {
 	public testGetMetricEventIdentity() {
 		return this.getMetricEventIdentity();
 	}
+
+	public async testGetStorageService() {
+		return this.getStorageService();
+	}
 }
 
 describe("MCP Server Base", () => {
@@ -411,11 +415,118 @@ describe("MCP Server Base", () => {
 	});
 
 	describe("getStorageService", () => {
-		it("should throw when env.CONVERSATION_STORAGE_OBJECT is not set", () => {
-			// env is an empty object — accessing CONVERSATION_STORAGE_OBJECT is undefined,
-			// and StorageServiceClient construction should fail or return an unusable instance.
-			// We just assert it doesn't throw at construction time (the error surfaces on use).
-			expect(() => (server as any).getStorageService()).not.toThrow();
+		// Pre-computed SHA-256 base64url values for known inputs (full 32-byte digest):
+		//   "test-token"  -> SHA-256 -> base64url
+		//   "other-token" -> SHA-256 -> base64url
+		// These can be verified independently with:
+		//   node -e "crypto.subtle.digest('SHA-256', new TextEncoder().encode('test-token'))
+		//     .then(b => console.log(Buffer.from(b).toString('base64url')))"
+
+		async function computeExpectedHash(token: string): Promise<string> {
+			const buf = await crypto.subtle.digest(
+				"SHA-256",
+				new TextEncoder().encode(token),
+			);
+			return Buffer.from(buf).toString("base64url");
+		}
+
+		it("returns a StorageServiceClient without throwing", async () => {
+			await expect(server.testGetStorageService()).resolves.toBeDefined();
+		});
+
+		it("throws an error when access token is missing", async () => {
+			const serverWithNoToken = new TestMCPServer(
+				{ props: { ...mockProps, accessToken: "" }, env: mockEnv },
+				mockStreamingStorage,
+			);
+			await expect(serverWithNoToken.testGetStorageService()).rejects.toThrow(
+				"Access token is required to use Storage Service",
+			);
+		});
+
+		it("throws an error when access token is undefined", async () => {
+			const serverWithNoToken = new TestMCPServer(
+				{ props: { ...mockProps, accessToken: undefined }, env: mockEnv },
+				mockStreamingStorage,
+			);
+			await expect(serverWithNoToken.testGetStorageService()).rejects.toThrow(
+				"Access token is required to use Storage Service",
+			);
+		});
+
+		it("uses the full SHA-256 base64url hash of the access token", async () => {
+			const storageService = await server.testGetStorageService();
+			const expectedHash = await computeExpectedHash(mockProps.accessToken);
+
+			// The hash is used as the DO name prefix — verify via idFromName spy
+			const namespaceMock: DurableObjectNamespace = {
+				idFromName: vi.fn(
+					() => ({ toString: () => "stub-id" }) as DurableObjectId,
+				),
+				get: vi.fn(
+					() =>
+						({
+							fetch: vi
+								.fn()
+								.mockResolvedValue(new Response(JSON.stringify({ ok: true }))),
+						}) as unknown as DurableObjectStub,
+				),
+			} as unknown as DurableObjectNamespace;
+
+			// Rebuild with a traceable namespace
+			(storageService as any).namespace = namespaceMock;
+			await storageService.initializeConversation("conv-123");
+
+			expect(namespaceMock.idFromName).toHaveBeenCalledWith(
+				`${expectedHash}:conv-123`,
+			);
+		});
+
+		it("produces a valid base64url string (no +, /, or = characters)", async () => {
+			const storageService = await server.testGetStorageService();
+			const hash: string = (storageService as any).accessTokenHashUrlSafe;
+
+			expect(hash).toMatch(/^[A-Za-z0-9\-_]+$/);
+		});
+
+		it("produces a 43-character hash (32 bytes base64url-encoded without padding)", async () => {
+			const storageService = await server.testGetStorageService();
+			const hash: string = (storageService as any).accessTokenHashUrlSafe;
+
+			// SHA-256 produces 32 bytes; base64url without padding is ceil(32 * 4/3) = 43 chars
+			expect(hash).toHaveLength(43);
+		});
+
+		it("produces different hashes for different access tokens", async () => {
+			const serverA = new TestMCPServer(
+				{ props: { ...mockProps, accessToken: "token-alice" }, env: mockEnv },
+				mockStreamingStorage,
+			);
+			const serverB = new TestMCPServer(
+				{ props: { ...mockProps, accessToken: "token-bob" }, env: mockEnv },
+				mockStreamingStorage,
+			);
+
+			const [serviceA, serviceB] = await Promise.all([
+				serverA.testGetStorageService(),
+				serverB.testGetStorageService(),
+			]);
+
+			const hashA: string = (serviceA as any).accessTokenHashUrlSafe;
+			const hashB: string = (serviceB as any).accessTokenHashUrlSafe;
+
+			expect(hashA).not.toBe(hashB);
+		});
+
+		it("produces the same hash for the same access token across calls", async () => {
+			const [service1, service2] = await Promise.all([
+				server.testGetStorageService(),
+				server.testGetStorageService(),
+			]);
+
+			expect((service1 as any).accessTokenHashUrlSafe).toBe(
+				(service2 as any).accessTokenHashUrlSafe,
+			);
 		});
 	});
 

--- a/test/storage-service/storage-service.spec.ts
+++ b/test/storage-service/storage-service.spec.ts
@@ -10,15 +10,25 @@ import type {
 // ---------------------------------------------------------------------------
 
 const CONVERSATION_ID = "conv-abc123";
+const TOKEN_HASH = "abc12345";
 
-const textMessage: Message = { type: "text", text: "Hello" };
-const chunkMessage: Message = { type: "text_chunk", text: " world" };
+const textMessage: Message = {
+	type: "text",
+	text: "Hello",
+	is_thinking: false,
+};
+const chunkMessage: Message = {
+	type: "text_chunk",
+	text: " world",
+	is_thinking: false,
+};
 const answerMessage: Message = {
 	type: "answer",
 	answer_id: "ans-1",
 	answer_title: "My Answer",
 	answer_query: "SELECT 1",
 	iframe_url: "https://example.com/answer/1",
+	is_thinking: false,
 };
 
 // Captured request from the stub's last fetch call
@@ -65,7 +75,7 @@ describe("StorageServiceClient", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		namespaceMock = makeNamespaceMock();
-		client = new StorageServiceClient(namespaceMock);
+		client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 	});
 
 	// -------------------------------------------------------------------------
@@ -100,7 +110,7 @@ describe("StorageServiceClient", () => {
 
 		it("throws when the server returns a non-ok status", async () => {
 			namespaceMock = makeNamespaceMock("Something went wrong", 500);
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			await expect(
 				client.initializeConversation(CONVERSATION_ID),
@@ -112,7 +122,7 @@ describe("StorageServiceClient", () => {
 				"Conversation already exists and is not marked done",
 				400,
 			);
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			await expect(
 				client.initializeConversation(CONVERSATION_ID),
@@ -166,7 +176,7 @@ describe("StorageServiceClient", () => {
 
 		it("throws when the server returns a non-ok status", async () => {
 			namespaceMock = makeNamespaceMock("Conversation not found", 500);
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			await expect(
 				client.appendMessages(CONVERSATION_ID, [textMessage]),
@@ -178,7 +188,7 @@ describe("StorageServiceClient", () => {
 				"Cannot append messages to a conversation marked done",
 				400,
 			);
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			await expect(
 				client.appendMessages(CONVERSATION_ID, [textMessage]),
@@ -192,8 +202,11 @@ describe("StorageServiceClient", () => {
 
 	describe("getNewMessages", () => {
 		it("sends GET to /storage/<id>/messages", async () => {
-			namespaceMock = makeNamespaceMock({ messages: [textMessage], isDone: false });
-			client = new StorageServiceClient(namespaceMock);
+			namespaceMock = makeNamespaceMock({
+				messages: [textMessage],
+				isDone: false,
+			});
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			await client.getNewMessages(CONVERSATION_ID);
 
@@ -210,7 +223,7 @@ describe("StorageServiceClient", () => {
 				isDone: true,
 			};
 			namespaceMock = makeNamespaceMock(state);
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			const result = await client.getNewMessages(CONVERSATION_ID);
 
@@ -219,7 +232,7 @@ describe("StorageServiceClient", () => {
 
 		it("returns an empty messages array when there are no new messages", async () => {
 			namespaceMock = makeNamespaceMock({ messages: [], isDone: false });
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			const result = await client.getNewMessages(CONVERSATION_ID);
 
@@ -229,7 +242,7 @@ describe("StorageServiceClient", () => {
 
 		it("throws when the server returns a non-ok status", async () => {
 			namespaceMock = makeNamespaceMock("Conversation not found", 404);
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			await expect(client.getNewMessages(CONVERSATION_ID)).rejects.toThrow(
 				"Failed to get messages (404)",
@@ -238,10 +251,60 @@ describe("StorageServiceClient", () => {
 
 		it("includes the error body in the thrown error message", async () => {
 			namespaceMock = makeNamespaceMock("Internal error", 500);
-			client = new StorageServiceClient(namespaceMock);
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
 
 			await expect(client.getNewMessages(CONVERSATION_ID)).rejects.toThrow(
 				"Internal error",
+			);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// DO instance keying — accessTokenHashUrlSafe isolation
+	// -------------------------------------------------------------------------
+
+	describe("DO instance keying", () => {
+		it("keys the DO on <tokenHash>:<conversationId>", async () => {
+			await client.initializeConversation(CONVERSATION_ID);
+
+			expect(namespaceMock.idFromName).toHaveBeenCalledWith(
+				`${TOKEN_HASH}:${CONVERSATION_ID}`,
+			);
+		});
+
+		it("two clients with different token hashes produce different DO keys for the same conversationId", async () => {
+			const namespaceA = makeNamespaceMock();
+			const namespaceB = makeNamespaceMock();
+			const clientA = new StorageServiceClient(namespaceA, "hash-user-a");
+			const clientB = new StorageServiceClient(namespaceB, "hash-user-b");
+
+			await clientA.initializeConversation(CONVERSATION_ID);
+			await clientB.initializeConversation(CONVERSATION_ID);
+
+			expect(namespaceA.idFromName).toHaveBeenCalledWith(
+				`hash-user-a:${CONVERSATION_ID}`,
+			);
+			expect(namespaceB.idFromName).toHaveBeenCalledWith(
+				`hash-user-b:${CONVERSATION_ID}`,
+			);
+			// The two resulting keys must differ
+			const keyA = (namespaceA.idFromName as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as string;
+			const keyB = (namespaceB.idFromName as ReturnType<typeof vi.fn>).mock
+				.calls[0][0] as string;
+			expect(keyA).not.toBe(keyB);
+		});
+
+		it("uses the same DO key across all operations for a given client", async () => {
+			await client.initializeConversation(CONVERSATION_ID);
+			await client.appendMessages(CONVERSATION_ID, [textMessage]);
+
+			namespaceMock = makeNamespaceMock({ messages: [], isDone: false });
+			client = new StorageServiceClient(namespaceMock, TOKEN_HASH);
+			await client.getNewMessages(CONVERSATION_ID);
+
+			expect(namespaceMock.idFromName).toHaveBeenCalledWith(
+				`${TOKEN_HASH}:${CONVERSATION_ID}`,
 			);
 		});
 	});

--- a/test/thoughtspot/thoughtspot-client.spec.ts
+++ b/test/thoughtspot/thoughtspot-client.spec.ts
@@ -33,6 +33,11 @@ describe("ThoughtSpot Client", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
+		// Re-assign fetch as a fresh vi.fn() so mockResolvedValue/mockRejectedValue
+		// are always available (vi.restoreAllMocks in afterEach would otherwise strip
+		// the mock methods from the plain vi.fn() assigned at module load time).
+		global.fetch = vi.fn();
+
 		// Setup mock config
 		mockConfig = {
 			middleware: [],


### PR DESCRIPTION
- Ensure each conversation can only be accessed by the user that created it, instead of anyone with the conversationId
- Fix a missing field with tool definitions
- Add coverage and fix tests