### PR TITLE
SCAL-311395 Fix Analytics Engine tenant identity

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -6,6 +6,10 @@ import { type Span, SpanStatusCode, context, trace } from "@opentelemetry/api";
 import { Hono } from "hono";
 import { decodeBase64Url, encodeBase64Url } from "hono/utils/encode";
 import { any } from "zod";
+import {
+	getStatusClass,
+	resolveRequestMetricContext,
+} from "./metrics/runtime/metric-context";
 import { METRIC_NAMES } from "./metrics/runtime/metric-types";
 import {
 	getMetricsRecorderFromExecutionContext,
@@ -35,7 +39,7 @@ function getExecutionContextOrUndefined(context: {
 }
 
 function recordAuthFlowMetric(
-	context: { executionCtx: ExecutionContext },
+	context: { executionCtx: ExecutionContext; req: { raw: Request } },
 	name:
 		| typeof METRIC_NAMES.oauthAuthorizeRequestsTotal
 		| typeof METRIC_NAMES.oauthAuthorizeSubmitTotal
@@ -48,10 +52,18 @@ function recordAuthFlowMetric(
 		return;
 	}
 
+	const requestContext = resolveRequestMetricContext(context.req.raw);
 	recordStatusMetric(
 		getMetricsRecorderFromExecutionContext(executionContext),
 		name,
 		status,
+		{
+			route_group: requestContext.routeGroup,
+			transport: requestContext.transport,
+			auth_mode: requestContext.authMode,
+			api_surface: requestContext.apiSurface,
+			status_class: getStatusClass(status),
+		},
 	);
 }
 

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -266,8 +266,8 @@ export abstract class BaseMCPServer extends Server {
 			return undefined;
 		}
 
-		const tenantId = this.sessionInfo.currentOrgId
-			? String(this.sessionInfo.currentOrgId)
+		const tenantId = this.sessionInfo.clusterId
+			? String(this.sessionInfo.clusterId)
 			: undefined;
 		const userId = this.sessionInfo.userGUID
 			? String(this.sessionInfo.userGUID)

--- a/test/handlers.spec.ts
+++ b/test/handlers.spec.ts
@@ -169,9 +169,14 @@ describe("Handlers", () => {
 					kind: "counter",
 					name: METRIC_NAMES.oauthAuthorizeSubmitTotal,
 					value: 1,
-					labels: {
+					labels: expect.objectContaining({
+						api_surface: "oauth",
+						auth_mode: "none",
 						outcome: "client_error",
-					},
+						route_group: "authorize",
+						status_class: "4xx",
+						transport: "http",
+					}),
 				}),
 			);
 		});
@@ -704,6 +709,37 @@ describe("Handlers", () => {
 	});
 
 	describe("GET /callback", () => {
+		it("records callback metrics with request context labels", async () => {
+			const recorder = createRequestMetricsRecorder();
+			setMetricsRecorderOnExecutionContext(
+				mockCtx as ExecutionContext,
+				recorder,
+			);
+
+			const result = await app.fetch(
+				new Request("https://example.com/callback"),
+				mockEnv,
+				mockCtx,
+			);
+
+			expect(result.status).toBe(400);
+			expect(recorder.snapshot()).toContainEqual(
+				expect.objectContaining({
+					kind: "counter",
+					name: METRIC_NAMES.oauthCallbackTotal,
+					value: 1,
+					labels: expect.objectContaining({
+						api_surface: "oauth",
+						auth_mode: "none",
+						outcome: "client_error",
+						route_group: "callback",
+						status_class: "4xx",
+						transport: "http",
+					}),
+				}),
+			);
+		});
+
 		it("should return 400 for missing instance URL", async () => {
 			const id = env.MCP_OBJECT.idFromName("test");
 			const object = env.MCP_OBJECT.get(id);
@@ -792,6 +828,44 @@ describe("Handlers", () => {
 	});
 
 	describe("POST /store-token", () => {
+		it("records store-token metrics with request context labels", async () => {
+			const recorder = createRequestMetricsRecorder();
+			setMetricsRecorderOnExecutionContext(
+				mockCtx as ExecutionContext,
+				recorder,
+			);
+
+			const result = await app.fetch(
+				new Request("https://example.com/store-token", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						oauthReqInfo: { clientId: "test" },
+						instanceUrl: "https://test.thoughtspot.cloud",
+					}),
+				}),
+				mockEnv,
+				mockCtx,
+			);
+
+			expect(result.status).toBe(400);
+			expect(recorder.snapshot()).toContainEqual(
+				expect.objectContaining({
+					kind: "counter",
+					name: METRIC_NAMES.oauthStoreTokenTotal,
+					value: 1,
+					labels: expect.objectContaining({
+						api_surface: "oauth",
+						auth_mode: "none",
+						outcome: "client_error",
+						route_group: "store_token",
+						status_class: "4xx",
+						transport: "http",
+					}),
+				}),
+			);
+		});
+
 		it("should return 400 for missing token", async () => {
 			const id = env.MCP_OBJECT.idFromName("test");
 			const object = env.MCP_OBJECT.get(id);

--- a/test/servers/mcp-server-base.spec.ts
+++ b/test/servers/mcp-server-base.spec.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MCPServer } from "../../src/servers/mcp-server";
-import * as thoughtspotClient from "../../src/thoughtspot/thoughtspot-client";
-import { MixpanelTracker } from "../../src/metrics/mixpanel/mixpanel";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TrackEvent, type Tracker } from "../../src/metrics";
+import { MixpanelTracker } from "../../src/metrics/mixpanel/mixpanel";
+import { MCPServer } from "../../src/servers/mcp-server";
 import { StreamingMessagesStorageWithTtl } from "../../src/streaming-message-storage-with-ttl/streaming-message-storage-with-ttl";
+import * as thoughtspotClient from "../../src/thoughtspot/thoughtspot-client";
 
 // Mock the MixpanelTracker
 vi.mock("../../src/metrics/mixpanel/mixpanel", () => ({
@@ -65,6 +65,10 @@ class TestMCPServer extends MCPServer {
 
 	public getSessionInfo() {
 		return this.sessionInfo;
+	}
+
+	public testGetMetricEventIdentity() {
+		return this.getMetricEventIdentity();
 	}
 }
 
@@ -260,13 +264,11 @@ describe("MCP Server Base", () => {
 
 		it("should return false when enableSpotterDataSourceDiscovery is disabled", async () => {
 			vi.spyOn(thoughtspotClient, "getThoughtSpotClient").mockReturnValue({
-				getSessionInfo: vi
-					.fn()
-					.mockResolvedValue(
-						makeSessionInfo({
-							configInfo: { enableSpotterDataSourceDiscovery: false },
-						}),
-					),
+				getSessionInfo: vi.fn().mockResolvedValue(
+					makeSessionInfo({
+						configInfo: { enableSpotterDataSourceDiscovery: false },
+					}),
+				),
 				searchMetadata: vi.fn().mockResolvedValue([]),
 				instanceUrl: "https://test.thoughtspot.cloud",
 			} as any);
@@ -281,13 +283,11 @@ describe("MCP Server Base", () => {
 
 		it("should return false when enableSpotterDataSourceDiscovery is undefined", async () => {
 			vi.spyOn(thoughtspotClient, "getThoughtSpotClient").mockReturnValue({
-				getSessionInfo: vi
-					.fn()
-					.mockResolvedValue(
-						makeSessionInfo({
-							configInfo: { enableSpotterDataSourceDiscovery: undefined },
-						}),
-					),
+				getSessionInfo: vi.fn().mockResolvedValue(
+					makeSessionInfo({
+						configInfo: { enableSpotterDataSourceDiscovery: undefined },
+					}),
+				),
 				searchMetadata: vi.fn().mockResolvedValue([]),
 				instanceUrl: "https://test.thoughtspot.cloud",
 			} as any);
@@ -298,6 +298,17 @@ describe("MCP Server Base", () => {
 			);
 			await testServer.init();
 			expect(testServer.testIsDatasourceDiscoveryAvailable()).toBe(false);
+		});
+	});
+
+	describe("Metric Identity", () => {
+		it("uses clusterId rather than currentOrgId for metrics identity", async () => {
+			await server.init();
+
+			expect(server.testGetMetricEventIdentity()).toEqual({
+				tenantId: "test-cluster-123",
+				userId: "test-user-123",
+			});
 		});
 	});
 

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -349,12 +349,12 @@ describe("MCP Server", () => {
 
 			expect(toolCallCounter).toEqual(
 				expect.objectContaining({
-					indexes: ["test-org"],
+					indexes: ["test-cluster-123"],
 					blobs: expect.arrayContaining([
 						ANALYTICS_ENGINE_SCHEMA_VERSION,
 						"tool",
 						METRIC_NAMES.toolCallsTotal,
-						"test-org",
+						"test-cluster-123",
 						"test-user-123",
 						"ping",
 						"success",
@@ -367,12 +367,12 @@ describe("MCP Server", () => {
 			);
 			expect(toolDuration).toEqual(
 				expect.objectContaining({
-					indexes: ["test-org"],
+					indexes: ["test-cluster-123"],
 					blobs: expect.arrayContaining([
 						ANALYTICS_ENGINE_SCHEMA_VERSION,
 						"tool",
 						METRIC_NAMES.toolDurationMs,
-						"test-org",
+						"test-cluster-123",
 						"test-user-123",
 					]),
 				}),

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -252,7 +252,7 @@ describe("thoughtspot-service", () => {
 				analyticalSessionId: "conv-123",
 			});
 			recorder.setEventIdentity({
-				tenantId: "org-123",
+				tenantId: "tenant-123",
 				userId: "user-123",
 			});
 
@@ -291,7 +291,7 @@ describe("thoughtspot-service", () => {
 					analyticalSessionId: "conv-123",
 				},
 				eventIdentity: {
-					tenantId: "org-123",
+					tenantId: "tenant-123",
 					userId: "user-123",
 				},
 			});
@@ -321,7 +321,7 @@ describe("thoughtspot-service", () => {
 						) &&
 						dataPoint.blobs?.includes("latest") &&
 						dataPoint.blobs?.includes("conv-123") &&
-						dataPoint.indexes?.[0] === "org-123" &&
+						dataPoint.indexes?.[0] === "tenant-123" &&
 						dataPoint.blobs?.includes("user-123"),
 				),
 			).toBe(true);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -70,7 +70,7 @@
 		"head_sampling_rate": 1
 	},
 	"analytics_engine_datasets": [
-        { "binding": "ANALYTICS", "dataset": "mcp_events" }
+        { "binding": "ANALYTICS", "dataset": "mcp_events_v2" }
     ],
 	"assets": { "directory": "./static/", "binding": "ASSETS" },
 }


### PR DESCRIPTION
## Summary

Fix Analytics Engine tenant identity so `tenant_id` stores the canonical ThoughtSpot `clusterId` instead of `currentOrgId`, cut Analytics Engine over to a clean dataset, and fill in the missing request-context labels on OAuth auth-flow counters.

## What Changed

- source Analytics Engine `tenant_id` from `SessionInfo.clusterId` in `BaseMCPServer.getMetricEventIdentity()`
- keep `currentOrgId` separate so org-level state is not mislabeled as tenant identity
- remove the temporary separate `tenantId` field from `SessionInfo` and update service/server tests to use `clusterId`
- switch the `ANALYTICS` binding target in `wrangler.jsonc` from `mcp_events` to `mcp_events_v2`
- attach `route_group`, `transport`, `auth_mode`, `api_surface`, and `status_class` to OAuth authorize/callback/store-token counters in `handlers.ts`

## Semantics

Analytics Engine `tenant_id` now represents the actual ThoughtSpot cluster/tenant identifier (`clusterId`). Historical rows in `mcp_events` may still contain org ids, so the new deployment writes to `mcp_events_v2` as the clean source of truth for tenant-level analysis. OAuth auth-flow counters now carry the same request-context labels as the rest of the HTTP/auth metrics.