### PR TITLE
Ignore non-markdown text messages from Spotter

### DIFF
--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -79,6 +79,12 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 						// Loop through the items in the line and convert to messages if applicable
 						for (const item of data) {
 							if (item.type === "text") {
+								// Ignore non-markdown text messages
+								if (item.metadata?.format !== "markdown") {
+									nMessagesIgnored++;
+									continue;
+								}
+
 								nTextMessagesParsed++;
 								recordUpstreamStreamMessageMetric(
 									recorder,
@@ -92,6 +98,12 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 									text: item.content,
 								});
 							} else if (item.type === "text-chunk") {
+								// Ignore non-markdown text-chunk messages
+								if (item.metadata?.format !== "markdown") {
+									nMessagesIgnored++;
+									continue;
+								}
+
 								nTextMessagesParsed++;
 								recordUpstreamStreamMessageMetric(
 									recorder,

--- a/test/servers/mcp-server-v2.integration.spec.ts
+++ b/test/servers/mcp-server-v2.integration.spec.ts
@@ -451,7 +451,7 @@ describe("V2 Streaming Parser + Real Storage Integration", () => {
 		await client.initializeConversation("stream-conv-1");
 
 		const reader = makeReader([
-			`data: [{"type":"text","content":"Revenue is $5M","metadata":{}}]\n`,
+			`data: [{"type":"text","content":"Revenue is $5M","metadata":{"format":"markdown"}}]\n`,
 		]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -512,9 +512,9 @@ describe("V2 Streaming Parser + Real Storage Integration", () => {
 		const client = createRealStorageClient();
 		await client.initializeConversation("stream-conv-3");
 
-		const thinkingLine = `data: [{"type":"text","content":"Let me analyze...","metadata":{"type":"thinking"}}]\n`;
+		const thinkingLine = `data: [{"type":"text","content":"Let me analyze...","metadata":{"type":"thinking","format":"markdown"}}]\n`;
 		const answerLine = `data: [{"type":"answer","metadata":{"session_id":"s1","gen_no":1,"transaction_id":"t1","generation_number":1,"title":"Chart","sage_query":"select *","type":null}}]\n`;
-		const textLine = `data: [{"type":"text","content":"Here is your answer.","metadata":{}}]\n`;
+		const textLine = `data: [{"type":"text","content":"Here is your answer.","metadata":{"format":"markdown"}}]\n`;
 
 		const reader = makeReader([thinkingLine, answerLine, textLine]);
 

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -77,7 +77,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 	it("parses a text event and stores a text message", async () => {
 		const storage = makeMockStorage();
-		const line = `data: ${JSON.stringify([{ type: "text", content: "Hello world", metadata: {} }])}\n`;
+		const line = `data: ${JSON.stringify([{ type: "text", content: "Hello world", metadata: { format: "markdown" } }])}\n`;
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -104,7 +104,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			...NOOP_METRICS_RECORDER,
 			count: vi.fn(),
 		};
-		const line = `data: ${JSON.stringify([{ type: "text", content: "Hello world", metadata: {} }])}\n`;
+		const line = `data: ${JSON.stringify([{ type: "text", content: "Hello world", metadata: { format: "markdown" } }])}\n`;
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -128,7 +128,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 	it("sets is_thinking=true on a text event when metadata.type is 'thinking'", async () => {
 		const storage = makeMockStorage();
-		const line = `data: ${JSON.stringify([{ type: "text", content: "Reasoning...", metadata: { type: "thinking" } }])}\n`;
+		const line = `data: ${JSON.stringify([{ type: "text", content: "Reasoning...", metadata: { type: "thinking", format: "markdown" } }])}\n`;
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -145,7 +145,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 	it("parses a text-chunk event and stores a text_chunk message", async () => {
 		const storage = makeMockStorage();
-		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "chunk content", metadata: {} }])}\n`;
+		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "chunk content", metadata: { format: "markdown" } }])}\n`;
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -162,7 +162,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 	it("sets is_thinking=true on a text-chunk event when metadata.type is 'thinking'", async () => {
 		const storage = makeMockStorage();
-		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "thinking chunk", metadata: { type: "thinking" } }])}\n`;
+		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "thinking chunk", metadata: { type: "thinking", format: "markdown" } }])}\n`;
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -175,6 +175,165 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
 			{ is_thinking: true, type: "text_chunk", text: "thinking chunk" },
 		]);
+	});
+
+	it("ignores a text event whose metadata.format is not 'markdown'", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "text", content: "plain text", metadata: { format: "plaintext" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		// Only the terminal done call should have been made (no message stored)
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 1,
+		});
+	});
+
+	it("ignores a text event with no metadata.format", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "text", content: "no format", metadata: {} }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 1,
+		});
+	});
+
+	it("does not record a metric for a text event whose format is not 'markdown'", async () => {
+		const storage = makeMockStorage();
+		const recorder: MetricsRecorder = {
+			...NOOP_METRICS_RECORDER,
+			count: vi.fn(),
+		};
+		const line = `data: ${JSON.stringify([{ type: "text", content: "plain text", metadata: { format: "plaintext" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+			recorder,
+		);
+
+		expect(recorder.count).not.toHaveBeenCalled();
+	});
+
+	it("ignores a text-chunk event whose metadata.format is not 'markdown'", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "plain chunk", metadata: { format: "plaintext" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 1,
+		});
+	});
+
+	it("ignores a text-chunk event with no metadata.format", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "text-chunk", content: "no format chunk", metadata: {} }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 1,
+		});
+	});
+
+	it("stores only markdown text items when mixed with non-markdown items", async () => {
+		const storage = makeMockStorage();
+		const items = [
+			{ type: "text", content: "keep me", metadata: { format: "markdown" } },
+			{ type: "text", content: "drop me", metadata: { format: "plaintext" } },
+			{
+				type: "text-chunk",
+				content: "keep chunk",
+				metadata: { format: "markdown" },
+			},
+			{ type: "text-chunk", content: "drop chunk", metadata: {} },
+		];
+		const line = `data: ${JSON.stringify(items)}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			{ is_thinking: false, type: "text", text: "keep me" },
+			{ is_thinking: false, type: "text_chunk", text: "keep chunk" },
+		]);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 2,
+			total_text_messages_parsed: 2,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 2,
+		});
 	});
 
 	it("parses an answer event and constructs the correct iframe URL", async () => {
@@ -330,7 +489,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 	it("ignores blank lines and heartbeat lines", async () => {
 		const storage = makeMockStorage();
 		// Blank line and heartbeat, then a real message
-		const chunk = `\n: heartbeat\ndata: ${JSON.stringify([{ type: "text", content: "hi", metadata: {} }])}\n`;
+		const chunk = `\n: heartbeat\ndata: ${JSON.stringify([{ type: "text", content: "hi", metadata: { format: "markdown" } }])}\n`;
 		const reader = makeReader([chunk]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -404,7 +563,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 	it("handles multiple chunks and assembles partial lines across reads correctly", async () => {
 		const storage = makeMockStorage();
 		// Split the data line across two chunks
-		const fullLine = `data: ${JSON.stringify([{ type: "text", content: "split message", metadata: {} }])}`;
+		const fullLine = `data: ${JSON.stringify([{ type: "text", content: "split message", metadata: { format: "markdown" } }])}`;
 		const part1 = fullLine.slice(0, 20);
 		const part2 = `${fullLine.slice(20)}\n`;
 		const reader = makeReader([part1, part2]);
@@ -423,8 +582,8 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 	it("processes multiple messages from multiple chunks and stores them in order", async () => {
 		const storage = makeMockStorage();
-		const chunk1 = `data: ${JSON.stringify([{ type: "text", content: "first", metadata: {} }])}\n`;
-		const chunk2 = `data: ${JSON.stringify([{ type: "text-chunk", content: "second", metadata: {} }])}\n`;
+		const chunk1 = `data: ${JSON.stringify([{ type: "text", content: "first", metadata: { format: "markdown" } }])}\n`;
+		const chunk2 = `data: ${JSON.stringify([{ type: "text-chunk", content: "second", metadata: { format: "markdown" } }])}\n`;
 		const reader = makeReader([chunk1, chunk2]);
 
 		await processSendAgentConversationMessageStreamingResponse(
@@ -455,8 +614,8 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 	it("processes multiple events in the same line as a batch", async () => {
 		const storage = makeMockStorage();
 		const items = [
-			{ type: "text", content: "one", metadata: {} },
-			{ type: "text-chunk", content: "two", metadata: {} },
+			{ type: "text", content: "one", metadata: { format: "markdown" } },
+			{ type: "text-chunk", content: "two", metadata: { format: "markdown" } },
 		];
 		const chunk = `data: ${JSON.stringify(items)}\n`;
 		const reader = makeReader([chunk]);

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -263,7 +263,7 @@ describe("thoughtspot-service", () => {
 					.mockResolvedValueOnce({
 						done: false,
 						value: encoder.encode(
-							'data: [{"type":"text","content":"Hello","metadata":{}}]\n',
+							'data: [{"type":"text","content":"Hello","metadata":{"format":"markdown"}}]\n',
 						),
 					})
 					.mockResolvedValueOnce({ done: true, value: undefined }),
@@ -521,7 +521,7 @@ describe("thoughtspot-service", () => {
 					.mockResolvedValueOnce({
 						done: false,
 						value: encoder.encode(
-							'data: [{"type":"text","content":"The revenue is $1M"}]\n',
+							'data: [{"type":"text","content":"The revenue is $1M","metadata":{"format":"markdown"}}]\n',
 						),
 					})
 					.mockResolvedValueOnce({ done: true, value: undefined }),
@@ -636,7 +636,7 @@ describe("thoughtspot-service", () => {
 					.mockResolvedValueOnce({
 						done: false,
 						value: encoder.encode(
-							': heartbeat\n\ndata: [{"type":"text","content":"Done"}]\n',
+							': heartbeat\n\ndata: [{"type":"text","content":"Done","metadata":{"format":"markdown"}}]\n',
 						),
 					})
 					.mockResolvedValueOnce({ done: true, value: undefined }),
@@ -679,7 +679,7 @@ describe("thoughtspot-service", () => {
 					.mockResolvedValueOnce({
 						done: false,
 						value: encoder.encode(
-							'data: [{"type":"text","content":"Thinking...","metadata":{"type":"thinking"}}]\n',
+							'data: [{"type":"text","content":"Thinking...","metadata":{"type":"thinking","format":"markdown"}}]\n',
 						),
 					})
 					.mockResolvedValueOnce({ done: true, value: undefined }),


### PR DESCRIPTION
- Spotter sends some tool responses as text messages, we should omit these in the updates sent to the host agent
- We already omit the tool call start, so omitting the corresponding result also makes sense
- Update tests