### PR TITLE
Add data source ID to answer objects

### DIFF
--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -152,6 +152,12 @@ export const ConversationUpdateSchema = z.object({
 		.describe(
 			"A human-readable title describing what the answer shows. Only present when `type` is `answer`.",
 		),
+	answer_data_source_id: z
+		.string()
+		.optional()
+		.describe(
+			"The identifier of the data source which the answer is created on. Only present when `type` is `answer`. You can use this to understand which answers were created with the same data source, or to initiate future conversations using the same data source.",
+		),
 	answer_query: z
 		.string()
 		.optional()

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -133,6 +133,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 										gen_no: item.metadata?.gen_no,
 									}),
 									answer_title: item.metadata?.title,
+									answer_data_source_id: item.metadata?.worksheet_id,
 									answer_query: item.metadata?.sage_query,
 									iframe_url: iframeUrl,
 								});

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -43,6 +43,7 @@ export interface AnswerMessage extends BaseMessage {
 	type: "answer";
 	answer_id: string;
 	answer_title: string;
+	answer_data_source_id: string;
 	answer_query: string;
 	iframe_url: string;
 }

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -345,6 +345,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			generation_number: 7,
 			title: "My Answer",
 			sage_query: "show sales",
+			worksheet_id: "ws-123",
 		};
 		const line = `data: ${JSON.stringify([{ type: "answer", metadata }])}\n`;
 		const reader = makeReader([line]);
@@ -363,6 +364,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 				type: "answer",
 				answer_id: JSON.stringify({ session_id: "sess-1", gen_no: 42 }),
 				answer_title: "My Answer",
+				answer_data_source_id: "ws-123",
 				answer_query: "show sales",
 				iframe_url: expectedIframeUrl,
 			},


### PR DESCRIPTION
- Include this information inside answer objects, to have all the required information to recreate the answer if it expired
- Add test coverage