### PR TITLE
SCAL-319970: Multi-org support (list_orgs / switch_org) on shared mcp-auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hono/zod-validator": "^0.7.2",
         "@microlabs/otel-cf-workers": "^1.0.0-rc.52",
         "@modelcontextprotocol/sdk": "^1.20.1",
-        "@thoughtspot/mcp-auth": "1.0.0",
+        "@thoughtspot/mcp-auth": "^2.0.0",
         "@thoughtspot/rest-api-sdk": "^2.22.0",
         "agents": "^0.13.1",
         "hono": "^4.12.21",
@@ -3715,9 +3715,9 @@
       "peer": true
     },
     "node_modules/@thoughtspot/mcp-auth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@thoughtspot/mcp-auth/-/mcp-auth-1.0.0.tgz",
-      "integrity": "sha512-bc6ur5zbeZKyiVzp5v3frr0MKn3tAD439XLHDzxWbKeTgRFi0Mnk4I8LXVZSwVG7CL506Av4OhIeWxlb9ouDhg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@thoughtspot/mcp-auth/-/mcp-auth-2.0.0.tgz",
+      "integrity": "sha512-Q2rGxnBH41IB9Ucrz3+Z1ZVZkcR2QIhR828tuWroCkHuOm2yzymVWOHaGawNRzwJlJ7Gi4Kx7s6UF2MZXAORpA==",
       "license": "ThoughtSpot End user license agreement",
       "peerDependencies": {
         "@cloudflare/workers-oauth-provider": "^0.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1473,7 +1473,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1490,7 +1489,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1507,7 +1505,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1524,7 +1521,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1541,7 +1537,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1558,7 +1553,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1575,7 +1569,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1592,7 +1585,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1609,7 +1601,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,7 +1617,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1643,7 +1633,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1660,7 +1649,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,7 +1665,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,7 +1681,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1711,7 +1697,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1728,7 +1713,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1745,7 +1729,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1762,7 +1745,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1779,7 +1761,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1796,7 +1777,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1813,7 +1793,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1830,7 +1809,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1847,7 +1825,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,7 +1841,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1881,7 +1857,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1898,7 +1873,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3388,7 +3362,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3402,7 +3375,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3416,7 +3388,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3430,7 +3401,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3444,7 +3414,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3458,7 +3427,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3472,7 +3440,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3486,7 +3453,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3500,7 +3466,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3514,7 +3479,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3528,7 +3492,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3542,7 +3505,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3556,7 +3518,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3570,7 +3531,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3584,7 +3544,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3598,7 +3557,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3612,7 +3570,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3626,7 +3583,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3640,7 +3596,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3654,7 +3609,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3668,7 +3622,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3682,7 +3635,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3696,7 +3648,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3710,7 +3661,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3724,7 +3674,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5099,7 +5048,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5516,7 +5465,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7754,7 +7702,7 @@
       "version": "4.22.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -8034,7 +7982,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8051,7 +7998,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8068,7 +8014,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8085,7 +8030,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8102,7 +8046,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8119,7 +8062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8136,7 +8078,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8153,7 +8094,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8170,7 +8110,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8187,7 +8126,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8204,7 +8142,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8221,7 +8158,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8238,7 +8174,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8255,7 +8190,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8272,7 +8206,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8289,7 +8222,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8306,7 +8238,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8323,7 +8254,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8340,7 +8270,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8357,7 +8286,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8374,7 +8302,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8391,7 +8318,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8408,7 +8334,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8425,7 +8350,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8442,7 +8366,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8459,7 +8382,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@hono/zod-validator": "^0.7.2",
     "@microlabs/otel-cf-workers": "^1.0.0-rc.52",
     "@modelcontextprotocol/sdk": "^1.20.1",
-    "@thoughtspot/mcp-auth": "1.0.0",
+    "@thoughtspot/mcp-auth": "^2.0.0",
     "@thoughtspot/rest-api-sdk": "^2.22.0",
     "agents": "^0.13.1",
     "hono": "^4.12.21",

--- a/src/cloudflare-utils.ts
+++ b/src/cloudflare-utils.ts
@@ -1,5 +1,5 @@
+import { type ResolveConfigFn, instrumentDO } from "@microlabs/otel-cf-workers";
 import { McpAgent } from "agents/mcp";
-import { instrumentDO, type ResolveConfigFn } from "@microlabs/otel-cf-workers";
 import type { BaseMCPServer, Context } from "./servers/mcp-server-base";
 import type { Props } from "./utils";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,10 @@ import {
 } from "./metrics/runtime/request-metrics";
 import { ConversationStorageServerSQLite } from "./servers/conversation-storage-server";
 import { MCPServer } from "./servers/mcp-server";
+import { UserTokenStoreSQLite } from "./servers/user-token-store-server";
 import { type Props, normalizeClientName } from "./utils";
 
-export { ConversationStorageServerSQLite };
+export { ConversationStorageServerSQLite, UserTokenStoreSQLite };
 
 // OTEL configuration function
 const config: ResolveConfigFn = (env: Env, _trigger) => {
@@ -75,6 +76,16 @@ const hooks: AuthHooks<Props> = {
 			group,
 		);
 	},
+	// Carry the gettoken fields the keep-warm refresh needs into the OAuth grant,
+	// so they're on every later request (only available at token-exchange time).
+	extendGrantProps(token, base): Props {
+		return {
+			...(base as Props),
+			refreshToken: token?.data?.refreshToken,
+			tokenCreatedTime: token?.data?.tokenCreatedTime,
+			tokenExpiryDuration: token?.data?.tokenExpiryDuration,
+		};
+	},
 	extendProps(req, base): Props {
 		// Bearer/token flow: stamp api-version metadata from query params.
 		// /bearer/* path family uses backwards-compat default; /token/* uses requested/latest.
@@ -85,6 +96,9 @@ const hooks: AuthHooks<Props> = {
 		const props: Props = {
 			...base,
 			clientName: normalizeClientName(base.clientName),
+			// Static-token auth. /bearer/* is legacy "bearer"; /token/* is "token".
+			// Gates OAuth-only tools (e.g. list_orgs) off for these.
+			authMode: isBearerLegacy ? "bearer" : "token",
 		};
 
 		let apiVersion: string | undefined;
@@ -143,6 +157,8 @@ const oauthFetchHandler = createOAuthHandler<Props>({
 				? normalizeRequestedApiVersionForAnalytics(requestedApiVersion)
 				: undefined,
 			apiVersionMode,
+			// OAuth-authenticated flow; enables the OAuth-only org tools.
+			authMode: "oauth",
 		};
 	},
 	// Extra routes mounted on the default handler app (consumer-specific).

--- a/src/metrics/runtime/tool-metrics.ts
+++ b/src/metrics/runtime/tool-metrics.ts
@@ -21,6 +21,8 @@ export const UPSTREAM_OPERATION_NAMES = {
 		"send_agent_conversation_message_streaming",
 	importMetadataTml: "import_metadata_tml",
 	searchMetadata: "search_metadata",
+	listOrgs: "list_orgs",
+	fetchOrgBearerToken: "fetch_org_bearer_token",
 } as const;
 
 export type UpstreamOperation =
@@ -128,6 +130,30 @@ export function recordUpstreamCallMetrics(
 
 	recorder.count(METRIC_NAMES.upstreamCallsTotal, 1, labels);
 	recorder.histogram(METRIC_NAMES.upstreamDurationMs, durationMs, labels);
+}
+
+// Run an upstream call, recording success/error + duration. Shared by the
+// service classes.
+export async function observeUpstreamCall<T>(
+	recorder: MetricsRecorder | undefined,
+	operation: UpstreamOperation,
+	call: () => Promise<T>,
+): Promise<T> {
+	const startedAt = Date.now();
+	let outcome: MetricOutcome = "success";
+	try {
+		return await call();
+	} catch (error) {
+		outcome = "upstream_error";
+		throw error;
+	} finally {
+		recordUpstreamCallMetrics(
+			recorder,
+			operation,
+			outcome,
+			Date.now() - startedAt,
+		);
+	}
 }
 
 export function recordUpstreamStreamStartedMetric(

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -28,6 +28,7 @@ import {
 } from "../metrics/runtime/tool-metrics";
 import { getActiveSpan, withSpan } from "../metrics/tracing/tracing-utils";
 import { StorageServiceClient } from "../storage-service/storage-service";
+import { OrgService } from "../thoughtspot/org-service";
 import { getThoughtSpotClient } from "../thoughtspot/thoughtspot-client";
 import { ThoughtSpotService } from "../thoughtspot/thoughtspot-service";
 import type { Props } from "../utils";
@@ -91,6 +92,18 @@ export abstract class BaseMCPServer extends Server {
 			return false;
 		}
 		return String(this.sessionInfo.enableSpotterDataSourceDiscovery) === "true";
+	}
+
+	/**
+	 * Whether Orgs are enabled on this cluster (from session info). Fails closed:
+	 * if session info is unavailable or the flag is absent, returns false so the
+	 * org tools stay hidden.
+	 */
+	protected isOrgsEnabled(): boolean {
+		if (!this.sessionInfo) {
+			return false;
+		}
+		return this.sessionInfo.orgsEnabled === true;
 	}
 
 	/**
@@ -187,23 +200,60 @@ export abstract class BaseMCPServer extends Server {
 		};
 	}
 
-	protected async getStorageService(): Promise<StorageServiceClient> {
-		const accessToken = this.ctx.props.accessToken;
-		if (!accessToken || accessToken.length === 0) {
-			throw new Error("Access token is required to use Storage Service");
+	/**
+	 * Stable per-login hash used to namespace this user's durable storage (both
+	 * conversation buffers and active-org state), keeping users isolated.
+	 *
+	 * Keyed on the refresh token when present (OAuth): it is stable across the
+	 * access token's 24h rotation and only changes on full reauthentication, so
+	 * storage survives token refresh and resets on reauth. Falls back to the
+	 * access token for static bearer/token connections, which have no refresh
+	 * token (their token is long-lived).
+	 */
+	protected async getStorageKeyHash(): Promise<string> {
+		const keyToken = this.ctx.props.refreshToken ?? this.ctx.props.accessToken;
+		if (!keyToken || keyToken.length === 0) {
+			throw new Error("A token is required to derive the storage key");
 		}
-		const encodedAccessToken = new TextEncoder().encode(accessToken);
 		const hashBuffer = await crypto.subtle.digest(
 			"SHA-256",
-			encodedAccessToken,
+			new TextEncoder().encode(keyToken),
 		);
-		const hashUrlSafe = Buffer.from(new Uint8Array(hashBuffer)).toString(
-			"base64url",
-		);
+		return Buffer.from(new Uint8Array(hashBuffer)).toString("base64url");
+	}
+
+	protected async getStorageService(): Promise<StorageServiceClient> {
+		const hashUrlSafe = await this.getStorageKeyHash();
 		return new StorageServiceClient(
 			this.ctx.env
 				.CONVERSATION_STORAGE_OBJECT as unknown as DurableObjectNamespace,
 			hashUrlSafe,
+			this.ctx.env.USER_TOKEN_OBJECT as unknown as DurableObjectNamespace,
+		);
+	}
+
+	// Active org for ThoughtSpot calls (x-thoughtspot-orgs header); none by default.
+	// Subclasses override to supply per-session org state.
+	protected getActiveOrgId(): string | undefined {
+		return undefined;
+	}
+
+	// Bearer token for ThoughtSpot calls; the session token by default. Subclasses
+	// override to return an org-scoped token.
+	protected getActiveBearerToken(): string {
+		return this.ctx.props.accessToken;
+	}
+
+	// Build an OrgService bound to an explicit (cluster-wide) token for org listing
+	// / org-token minting.
+	protected getOrgService(
+		bearerToken: string,
+		orgId?: string,
+		recorder?: MetricsRecorder,
+	) {
+		return new OrgService(
+			getThoughtSpotClient(this.ctx.props.instanceUrl, bearerToken, orgId),
+			recorder,
 		);
 	}
 
@@ -214,7 +264,8 @@ export abstract class BaseMCPServer extends Server {
 		return new ThoughtSpotService(
 			getThoughtSpotClient(
 				this.ctx.props.instanceUrl,
-				this.ctx.props.accessToken,
+				this.getActiveBearerToken(),
+				this.getActiveOrgId(),
 			),
 			{
 				recorder,
@@ -439,7 +490,21 @@ export abstract class BaseMCPServer extends Server {
 				});
 			},
 		);
+
+		// Subclass post-initialization hook (runs after sessionInfo is available
+		// and handlers are registered). Best-effort: failures must not break the
+		// connection.
+		try {
+			await this.postInit();
+		} catch (error) {
+			console.error("postInit failed:", error);
+		}
 	}
+
+	/**
+	 * Optional hook for subclasses to run setup after init(). Default no-op.
+	 */
+	protected async postInit(): Promise<void> {}
 
 	async addTracker(tracker: Tracker) {
 		this.trackers.add(tracker);

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -75,7 +75,9 @@ export abstract class BaseMCPServer extends Server {
 				capabilities: {
 					tools: {},
 					completion: {},
-					resources: {},
+					// listChanged: the resource set (datasources) changes on switch_org,
+					// so we notify clients to re-list.
+					resources: { listChanged: true },
 				},
 			},
 		);

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -11,10 +11,18 @@ import {
 	type MetricsRecorder,
 	NOOP_METRICS_RECORDER,
 } from "../metrics/runtime/metrics-recorder";
+import type { MetricAnalyticsContext } from "../metrics/runtime/metrics-sink";
 import type { ToolMetricApiSurface } from "../metrics/runtime/tool-metrics";
 import { WithSpan } from "../metrics/tracing/tracing-utils";
-import type { DataSource } from "../thoughtspot/thoughtspot-service";
-import type { Answer, StreamingMessagesState } from "../thoughtspot/types";
+import type {
+	DataSource,
+	ThoughtSpotService,
+} from "../thoughtspot/thoughtspot-service";
+import {
+	type Answer,
+	type StreamingMessagesState,
+	ThoughtSpotApiError,
+} from "../thoughtspot/types";
 import { McpServerError } from "../utils";
 import { BaseMCPServer, type Context } from "./mcp-server-base";
 import {
@@ -26,6 +34,7 @@ import {
 	GetRelevantQuestionsSchema,
 	GetSessionUpdatesInputSchema,
 	SendSessionMessageInputSchema,
+	SwitchOrgInputSchema,
 	ToolName,
 } from "./tool-definitions";
 import {
@@ -35,12 +44,268 @@ import {
 } from "./version-registry";
 
 export class MCPServer extends BaseMCPServer {
+	// Mirrors of the shared per-user store (the durable source of truth, shared so
+	// the token is minted once across the user's fanned-out sessions).
+	private activeOrgId: string | undefined;
+	private activeOrgToken: string | undefined;
+	private warmGlobalToken: string | undefined;
+
 	constructor(ctx: Context) {
 		super(ctx, "ThoughtSpot", "2.0.0");
 	}
 
+	private getGlobalToken(): string {
+		return this.warmGlobalToken ?? this.ctx.props.accessToken;
+	}
+
+	protected getActiveOrgId(): string | undefined {
+		return this.activeOrgId;
+	}
+
+	protected getActiveBearerToken(): string {
+		// An active org must use its org-scoped token — never the global token, which
+		// would break org isolation. ensureActiveOrgToken guarantees it is minted
+		// before any data call, so a missing token here is a bug, not a fallback.
+		if (this.activeOrgId) {
+			if (!this.activeOrgToken) {
+				throw new Error(
+					`Org ${this.activeOrgId} is active but its token is not minted`,
+				);
+			}
+			return this.activeOrgToken;
+		}
+		return this.getGlobalToken();
+	}
+
+	// Re-read on each org-aware call so a switch in another session is reflected.
+	private async loadActiveOrg(): Promise<void> {
+		const storage = await this.getStorageService();
+		const stored = await storage.getActiveOrg();
+		this.activeOrgId = stored.activeOrgId ?? undefined;
+		this.activeOrgToken = stored.orgToken ?? undefined;
+	}
+
+	// Pass orgToken to commit id+token atomically (validated switch); else the
+	// prior token is cleared and re-minted lazily.
+	private async setActiveOrg(orgId: string, orgToken?: string): Promise<void> {
+		this.activeOrgId = orgId;
+		this.activeOrgToken = orgToken;
+		const storage = await this.getStorageService();
+		await storage.setActiveOrg(orgId, orgToken);
+	}
+
+	// Reuse the shared-store token if held, else mint from the global token and
+	// persist it (so the fan-out mints once).
+	private async ensureOrgToken(
+		orgId: string,
+		recorder?: MetricsRecorder,
+	): Promise<string> {
+		if (this.activeOrgId === orgId && this.activeOrgToken) {
+			return this.activeOrgToken;
+		}
+		await this.loadOrSeedWarmToken();
+		const globalToken = this.getGlobalToken();
+		const orgToken = await this.getOrgService(
+			globalToken,
+			undefined,
+			recorder,
+		).fetchOrgBearerToken(globalToken, orgId);
+		this.activeOrgToken = orgToken;
+		const storage = await this.getStorageService();
+		await storage.setActiveOrgToken(orgToken);
+		return orgToken;
+	}
+
+	// HTTP status from a thrown error or `{ error }` result: typed
+	// ThoughtSpotApiError, else parsed from a "status NNN" message.
+	private apiErrorStatus(value: unknown): number | undefined {
+		const err =
+			value instanceof Error
+				? value
+				: ((value as { error?: unknown } | null)?.error ?? value);
+		if (err instanceof ThoughtSpotApiError) {
+			return err.status;
+		}
+		const message =
+			typeof (err as { message?: unknown })?.message === "string"
+				? (err as { message: string }).message
+				: "";
+		const match = message.match(/\bstatus (\d{3})\b/);
+		return match ? Number(match[1]) : undefined;
+	}
+
+	// Re-mint the active org's token, recovering from a stale one. Mint first, then
+	// overwrite atomically — the store never goes tokenless, so a concurrent session
+	// never sees an active org without its token. Abort if a sibling switched org
+	// meanwhile, so we don't clobber the new org's token.
+	private async forceRemintOrgToken(
+		orgId: string,
+		recorder?: MetricsRecorder,
+	): Promise<void> {
+		await this.loadActiveOrg();
+		if (this.activeOrgId !== orgId) {
+			return;
+		}
+		await this.loadOrSeedWarmToken();
+		const globalToken = this.getGlobalToken();
+		const orgToken = await this.getOrgService(
+			globalToken,
+			undefined,
+			recorder,
+		).fetchOrgBearerToken(globalToken, orgId);
+		this.activeOrgToken = orgToken;
+		await this.setActiveOrg(orgId, orgToken);
+	}
+
+	// Single re-mint+retry on a 401, only when an org token is in use (a global-token
+	// 401 passes through). Handles both thrown and `{ error }`-result 401s.
+	protected async withOrgTokenRetry<T>(
+		recorder: MetricsRecorder | undefined,
+		fn: (service: ThoughtSpotService) => Promise<T>,
+		analyticsContextOverride?: MetricAnalyticsContext,
+	): Promise<T> {
+		const orgId = this.activeOrgId;
+
+		const attempt = () =>
+			fn(this.getThoughtSpotService(recorder, analyticsContextOverride));
+
+		if (!orgId) {
+			return attempt();
+		}
+
+		// Org active → the call must use the org-scoped token, never the global one
+		// (a global-token data call would break org isolation). Mint if not cached.
+		if (!this.activeOrgToken) {
+			await this.ensureOrgToken(orgId, recorder);
+		}
+
+		try {
+			const result = await attempt();
+			if (this.apiErrorStatus(result) === 401) {
+				await this.forceRemintOrgToken(orgId, recorder);
+				return attempt();
+			}
+			return result;
+		} catch (error) {
+			if (this.apiErrorStatus(error) === 401) {
+				await this.forceRemintOrgToken(orgId, recorder);
+				return attempt();
+			}
+			throw error;
+		}
+	}
+
+	// validateConnection maps a 401 to `false` (no throw), so withOrgTokenRetry can't
+	// see it. If it fails with an org token in use, re-mint and re-validate.
+	private async validateConnectionWithOrgRetry(
+		recorder?: MetricsRecorder,
+	): Promise<boolean> {
+		const orgId = this.activeOrgId;
+		const usedOrgToken = Boolean(orgId && this.activeOrgToken);
+		const ok = await this.getThoughtSpotService(recorder).validateConnection();
+		if (ok || !usedOrgToken || !orgId) {
+			return ok;
+		}
+		await this.forceRemintOrgToken(orgId, recorder);
+		return this.getThoughtSpotService(recorder).validateConnection();
+	}
+
+	// On connect (OAuth only): keep the cluster token warm, then — when org tools are
+	// available — establish the active org (prior switch wins, else session current)
+	// and mint its token. Best-effort: never break connect.
+	protected async postInit(): Promise<void> {
+		if (!this.isOAuthAuth()) {
+			return;
+		}
+		try {
+			await this.loadOrSeedWarmToken();
+		} catch (error) {
+			console.error("Failed to load/seed keep-warm token on connect:", error);
+		}
+
+		if (!this.areOrgToolsAvailable()) {
+			return;
+		}
+		try {
+			await this.loadActiveOrg();
+			if (!this.activeOrgId) {
+				const currentOrgId =
+					this.sessionInfo?.currentOrgId != null
+						? String(this.sessionInfo.currentOrgId)
+						: undefined;
+				if (currentOrgId) {
+					await this.setActiveOrg(currentOrgId);
+				}
+			}
+			if (this.activeOrgId) {
+				await this.ensureOrgToken(this.activeOrgId);
+			}
+		} catch (error) {
+			console.error("Failed to set/mint active org on connect:", error);
+		}
+	}
+
+	// Load the keep-warm token into memory. Re-seed from props' fresh grant when the
+	// store is unseeded or expired (the refresh chain died); else the store wins.
+	private async loadOrSeedWarmToken(): Promise<void> {
+		const storage = await this.getStorageService();
+		const store = await storage.getTokenStore();
+		const storedExpired =
+			typeof store.expiresAt === "number" && store.expiresAt <= Date.now();
+		if (store.accessToken && !storedExpired) {
+			this.warmGlobalToken = store.accessToken;
+			return;
+		}
+		const { accessToken, refreshToken, tokenExpiryDuration, instanceUrl } =
+			this.ctx.props;
+		if (accessToken && refreshToken) {
+			await storage.seedTokenStore({
+				accessToken,
+				refreshToken,
+				instanceUrl,
+				expiresAt:
+					typeof tokenExpiryDuration === "number"
+						? tokenExpiryDuration
+						: undefined,
+			});
+			this.warmGlobalToken = accessToken;
+			return;
+		}
+		// No refresh token to re-seed with: use whatever we have.
+		this.warmGlobalToken = store.accessToken ?? accessToken;
+	}
+
+	// Fire-and-forget; throttle + idle-delete live in the DO.
+	private touchLastSeen(): void {
+		this.getStorageService()
+			.then((storage) => storage.touchLastSeen())
+			.catch((error) => {
+				console.error("Failed to record last-seen activity:", error);
+			});
+	}
+
 	protected getToolMetricApiSurface(): ToolMetricApiSurface {
 		return "mcp";
+	}
+
+	// Gates OAuth-only tools such as `list_orgs`.
+	protected isOAuthAuth(): boolean {
+		return this.ctx.props.authMode === "oauth";
+	}
+
+	// Org behavior requires OAuth + orgs enabled + the v2 surface (inferred from the
+	// resolved tool set, not a label). Fails closed.
+	protected areOrgToolsAvailable(): boolean {
+		if (!this.isOAuthAuth() || !this.isOrgsEnabled()) {
+			return false;
+		}
+		try {
+			return resolveApiVersion(this.ctx.props.apiVersion).tools.some(
+				(tool) => tool?.name === ToolName.ListOrgs,
+			);
+		} catch {
+			return false;
+		}
 	}
 
 	protected getToolMetricApiVersionLabel(): string | undefined {
@@ -136,6 +401,13 @@ export class MCPServer extends BaseMCPServer {
 			);
 		}
 
+		if (!this.areOrgToolsAvailable()) {
+			tools = tools.filter(
+				(tool) =>
+					tool.name !== ToolName.ListOrgs && tool.name !== ToolName.SwitchOrg,
+			);
+		}
+
 		return { tools };
 	}
 
@@ -189,10 +461,29 @@ export class MCPServer extends BaseMCPServer {
 		const { name } = request.params;
 		this.trackers.track(TrackEvent.CallTool, { toolName: name });
 
+		if (this.isOAuthAuth()) {
+			this.touchLastSeen();
+		}
+
+		if (this.areOrgToolsAvailable()) {
+			await this.loadActiveOrg();
+			// Mint the org token up front so every data path uses it; no call falls
+			// back to the global token while an org is active. list_orgs/switch_org
+			// use the global token on their own (listing / minting) paths.
+			if (
+				this.activeOrgId &&
+				!this.activeOrgToken &&
+				name !== ToolName.ListOrgs &&
+				name !== ToolName.SwitchOrg
+			) {
+				await this.ensureOrgToken(this.activeOrgId, recorder);
+			}
+		}
+
 		switch (name) {
 			case ToolName.Ping: {
 				if (this.ctx.props.accessToken && this.ctx.props.instanceUrl) {
-						if (!this.getThoughtSpotService(recorder).validateConnection()) {
+					if (!this.getThoughtSpotService(recorder).validateConnection()) {
 						return this.createErrorResponse(
 							"Failed to validate connection",
 							"Ping failed",
@@ -226,7 +517,7 @@ export class MCPServer extends BaseMCPServer {
 						"Check connectivity failed",
 					);
 				}
-				if (!this.getThoughtSpotService(recorder).validateConnection()) {
+				if (!(await this.validateConnectionWithOrgRetry(recorder))) {
 					return this.createErrorResponse(
 						"Failed to validate connection",
 						"Check connectivity failed",
@@ -252,6 +543,27 @@ export class MCPServer extends BaseMCPServer {
 
 			case ToolName.CreateDashboard: {
 				return this.callCreateDashboard(request, recorder);
+			}
+
+			case ToolName.ListOrgs: {
+				// Defense in depth: also reject direct invocation when unavailable.
+				if (!this.areOrgToolsAvailable()) {
+					return this.createErrorResponse(
+						"The list_orgs tool is only available when authenticated via OAuth on a cluster with Orgs enabled.",
+						"List orgs rejected: org tools unavailable",
+					);
+				}
+				return this.callListOrgs(recorder);
+			}
+
+			case ToolName.SwitchOrg: {
+				if (!this.areOrgToolsAvailable()) {
+					return this.createErrorResponse(
+						"The switch_org tool is only available when authenticated via OAuth on a cluster with Orgs enabled.",
+						"Switch org rejected: org tools unavailable",
+					);
+				}
+				return this.callSwitchOrg(request, recorder);
 			}
 
 			default:
@@ -396,12 +708,11 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 
 		let response: AgentConversation;
 		try {
-			response =
-				await this.getThoughtSpotService(recorder).createAgentConversation(
-					data_source_id,
-				);
+			response = await this.withOrgTokenRetry(recorder, (svc) =>
+				svc.createAgentConversation(data_source_id),
+			);
 		} catch (error) {
-			if (!(error as any)?.message?.includes("failed with status 401")) {
+			if (this.apiErrorStatus(error) !== 401) {
 				throw error;
 			}
 
@@ -454,13 +765,16 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			);
 		}
 
-		await this.getThoughtSpotService(recorder, {
-			analyticalSessionId: analytical_session_id,
-		}).sendAgentConversationMessageStreaming(
-			analytical_session_id,
-			message,
-			storageService.appendMessages.bind(storageService),
-			additional_context,
+		await this.withOrgTokenRetry(
+			recorder,
+			(svc) =>
+				svc.sendAgentConversationMessageStreaming(
+					analytical_session_id,
+					message,
+					storageService.appendMessages.bind(storageService),
+					additional_context,
+				),
+			{ analyticalSessionId: analytical_session_id },
 		);
 
 		return this.createStructuredContentSuccessResponse(
@@ -519,7 +833,6 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			total_session_updates: messagesState.messages.length,
 			is_done: messagesState.isDone,
 		});
-
 		return this.createStructuredContentSuccessResponse(
 			{
 				session_updates: messagesState.messages,
@@ -560,9 +873,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			);
 		}
 
-		const liveboard = await this.getThoughtSpotService(
-			recorder,
-		).fetchTMLAndCreateLiveboard(title, transformedAnswers, note_tile);
+		const liveboard = await this.withOrgTokenRetry(recorder, (svc) =>
+			svc.fetchTMLAndCreateLiveboard(title, transformedAnswers, note_tile),
+		);
 
 		if (liveboard.error) {
 			return this.createErrorResponse(
@@ -612,19 +925,95 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		);
 	}
 
+	@WithSpan("call-list-orgs")
+	async callListOrgs(recorder: MetricsRecorder) {
+		const span = trace.getSpan(context.active());
+
+		await this.loadOrSeedWarmToken();
+		const orgs = await this.getOrgService(
+			this.getGlobalToken(),
+			undefined,
+			recorder,
+		).listOrgs();
+		span?.setAttribute("total_orgs", orgs.length);
+
+		// May run on a different DO than the switch — re-read the shared store.
+		await this.loadActiveOrg();
+		const activeOrgId = this.getActiveOrgId();
+
+		return this.createStructuredContentSuccessResponse(
+			{
+				orgs: orgs.map((org) => ({
+					...org,
+					is_active:
+						activeOrgId !== undefined && String(org.id) === activeOrgId,
+				})),
+			},
+			`${orgs.length} org(s) found`,
+		);
+	}
+
+	@WithSpan("call-switch-org")
+	async callSwitchOrg(
+		request: z.infer<typeof CallToolRequestSchema>,
+		recorder: MetricsRecorder,
+	) {
+		const span = trace.getSpan(context.active());
+		const { org_id } = SwitchOrgInputSchema.parse(request.params.arguments);
+		const orgId = String(org_id);
+		span?.setAttribute("requested_org_id", orgId);
+
+		// Mint first to validate; commit only on success, so a bad org_id is a no-op.
+		let orgToken: string;
+		try {
+			await this.loadOrSeedWarmToken();
+			const globalToken = this.getGlobalToken();
+			orgToken = await this.getOrgService(
+				globalToken,
+				undefined,
+				recorder,
+			).fetchOrgBearerToken(globalToken, orgId);
+		} catch (error) {
+			const status = this.apiErrorStatus(error);
+			// Any 4xx = org invalid or inaccessible.
+			if (status !== undefined && status >= 400 && status < 500) {
+				return this.createErrorResponse(
+					`You do not have access to org "${orgId}", or it does not exist. Call list_orgs to see the orgs you can access.`,
+					`Switch org failed: org not accessible (status ${status})`,
+				);
+			}
+			return this.createErrorResponse(
+				`Failed to switch to org "${orgId}". Please try again.`,
+				`Error switching org ${(error as Error)?.message ?? ""}`,
+			);
+		}
+
+		await this.setActiveOrg(orgId, orgToken);
+		this._sources = null;
+		span?.setAttribute("active_org_id", orgId);
+
+		return this.createStructuredContentSuccessResponse(
+			{ success: true, active_org_id: org_id },
+			`Switched to org ${orgId}`,
+		);
+	}
+
 	private _sources: {
+		orgId: string | undefined;
 		list: DataSource[];
 		map: Map<string, DataSource>;
 	} | null = null;
 
 	@WithSpan("get-datasources")
 	async getDatasources(recorder?: MetricsRecorder) {
-		if (this._sources) {
+		const orgId = this.getActiveOrgId();
+		if (this._sources && this._sources.orgId === orgId) {
 			return this._sources;
 		}
 
 		const sources = await this.getThoughtSpotService(recorder).getDataSources();
 		this._sources = {
+			orgId,
 			list: sources,
 			map: new Map(sources.map((s) => [s.id, s])),
 		};

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -293,10 +293,21 @@ export class MCPServer extends BaseMCPServer {
 		return this.ctx.props.authMode === "oauth";
 	}
 
+	// A grant minted before multi-org shipped has no refresh token in its props
+	// (extendGrantProps adds it at login). Such sessions keep the pre-multi-org
+	// behavior — no org tools, no overlay — until the user re-authenticates.
+	protected hasMultiOrgGrant(): boolean {
+		return typeof this.ctx.props.refreshToken === "string";
+	}
+
 	// Org behavior requires OAuth + orgs enabled + the v2 surface (inferred from the
-	// resolved tool set, not a label). Fails closed.
+	// resolved tool set, not a label) + a multi-org grant. Fails closed.
 	protected areOrgToolsAvailable(): boolean {
-		if (!this.isOAuthAuth() || !this.isOrgsEnabled()) {
+		if (
+			!this.isOAuthAuth() ||
+			!this.isOrgsEnabled() ||
+			!this.hasMultiOrgGrant()
+		) {
 			return false;
 		}
 		try {

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -271,20 +271,36 @@ export class MCPServer extends BaseMCPServer {
 		}
 	}
 
-	// Load the keep-warm token into memory. Re-seed from props' fresh grant when the
-	// store is unseeded or expired (the refresh chain died); else the store wins.
+	// Load the keep-warm token into memory.
+	// 1. Read the stored token first (the alarm may have refreshed it).
+	// 2. If the stored token is valid and newer than props (different string, not
+	//    expired), use it directly — no re-seed needed.
+	// 3. Otherwise seed from the fresh props grant (re-issued from the OAuth grant
+	//    on every request), then re-read to confirm what was stored.
+	// This read-before-write ensures the mock and DO agree: the stored token wins
+	// without the mock needing to replicate seedTokenStore's merge logic.
 	private async loadOrSeedWarmToken(): Promise<void> {
 		const storage = await this.getStorageService();
-		const store = await storage.getTokenStore();
-		const storedExpired =
-			typeof store.expiresAt === "number" && store.expiresAt <= Date.now();
-		if (store.accessToken && !storedExpired) {
-			this.warmGlobalToken = store.accessToken;
-			return;
-		}
 		const { accessToken, refreshToken, tokenExpiryDuration, instanceUrl } =
 			this.ctx.props;
+
+		// Always read first — the alarm may have refreshed the stored token.
+		const existing = await storage.getTokenStore();
+		const storedToken = existing.accessToken ?? null;
+		const storedExpiresAt = existing.expiresAt ?? null;
+		const storedExpired =
+			typeof storedExpiresAt === "number" && storedExpiresAt <= Date.now();
+		const storedIsNewer =
+			storedToken && storedToken !== accessToken && !storedExpired;
+
+		if (storedIsNewer) {
+			// Stored token was alarm-refreshed and is still valid — use it.
+			this.warmGlobalToken = storedToken;
+			return;
+		}
+
 		if (accessToken && refreshToken) {
+			// Seed/update the store with the fresh props token.
 			await storage.seedTokenStore({
 				accessToken,
 				refreshToken,
@@ -297,10 +313,10 @@ export class MCPServer extends BaseMCPServer {
 			this.warmGlobalToken = accessToken;
 			return;
 		}
-		// No refresh token to re-seed with: prefer the stored token only if it isn't
-		// expired, else fall back to the (possibly fresher) props token.
+
+		// No refresh token (legacy grant): prefer valid stored token, else props.
 		this.warmGlobalToken =
-			store.accessToken && !storedExpired ? store.accessToken : accessToken;
+			storedToken && !storedExpired ? storedToken : accessToken;
 	}
 
 	// Fire-and-forget; throttle + idle-delete live in the DO.

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -49,6 +49,10 @@ export class MCPServer extends BaseMCPServer {
 	private activeOrgId: string | undefined;
 	private activeOrgToken: string | undefined;
 	private warmGlobalToken: string | undefined;
+	// Decided once in postInit: does this connection's grant carry a refresh token?
+	// A pre-multi-org grant does not, so it keeps the old (no-org) behavior until the
+	// user re-authenticates. Everything multi-org keys off this flag.
+	private grantHasRefreshToken = false;
 
 	constructor(ctx: Context) {
 		super(ctx, "ThoughtSpot", "2.0.0");
@@ -217,6 +221,9 @@ export class MCPServer extends BaseMCPServer {
 		if (!this.isOAuthAuth()) {
 			return;
 		}
+		// Single source of truth for multi-org eligibility: only a grant minted by
+		// the multi-org login path carries a refresh token.
+		this.grantHasRefreshToken = typeof this.ctx.props.refreshToken === "string";
 		try {
 			await this.loadOrSeedWarmToken();
 		} catch (error) {
@@ -293,11 +300,11 @@ export class MCPServer extends BaseMCPServer {
 		return this.ctx.props.authMode === "oauth";
 	}
 
-	// A grant minted before multi-org shipped has no refresh token in its props
-	// (extendGrantProps adds it at login). Such sessions keep the pre-multi-org
-	// behavior — no org tools, no overlay — until the user re-authenticates.
+	// A grant minted before multi-org shipped has no refresh token (extendGrantProps
+	// adds it at login). Such sessions keep the pre-multi-org behavior — no org
+	// tools, no overlay — until the user re-authenticates. Decided in postInit.
 	protected hasMultiOrgGrant(): boolean {
-		return typeof this.ctx.props.refreshToken === "string";
+		return this.grantHasRefreshToken;
 	}
 
 	// Org behavior requires OAuth + orgs enabled + the v2 surface (inferred from the

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -214,6 +214,22 @@ export class MCPServer extends BaseMCPServer {
 		return this.getThoughtSpotService(recorder).validateConnection();
 	}
 
+	// Load warm token before initializeService so getSessionInfo uses it instead
+	// of the short-lived props access token.
+	protected async initializeService(): Promise<void> {
+		if (this.isOAuthAuth()) {
+			try {
+				await this.loadOrSeedWarmToken();
+			} catch (error) {
+				console.error(
+					"Failed to load warm token before initializeService:",
+					error,
+				);
+			}
+		}
+		await super.initializeService();
+	}
+
 	// On connect (OAuth only): keep the cluster token warm, then — when org tools are
 	// available — establish the active org (prior switch wins, else session current)
 	// and mint its token. Best-effort: never break connect.
@@ -224,10 +240,13 @@ export class MCPServer extends BaseMCPServer {
 		// Single source of truth for multi-org eligibility: only a grant minted by
 		// the multi-org login path carries a refresh token.
 		this.grantHasRefreshToken = typeof this.ctx.props.refreshToken === "string";
-		try {
-			await this.loadOrSeedWarmToken();
-		} catch (error) {
-			console.error("Failed to load/seed keep-warm token on connect:", error);
+		// Already loaded in initializeService; this is a no-op if the alarm is set.
+		if (!this.warmGlobalToken) {
+			try {
+				await this.loadOrSeedWarmToken();
+			} catch (error) {
+				console.error("Failed to load/seed keep-warm token on connect:", error);
+			}
 		}
 
 		if (!this.areOrgToolsAvailable()) {
@@ -1011,6 +1030,21 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		await this.setActiveOrg(orgId, orgToken);
 		this._sources = null;
 		span?.setAttribute("active_org_id", orgId);
+
+		// Datasources are org-specific — tell the client to re-list resources so it
+		// drops the previous org's datasources. Best-effort: never fail the switch.
+		try {
+			await this.sendResourceListChanged();
+			// TEMP (testing): confirm the notification path fires on switch. Remove.
+			console.log(
+				`[RESOURCE-DEBUG] sendResourceListChanged sent after switch to org ${orgId}`,
+			);
+		} catch (error) {
+			console.error(
+				"Failed to send resource list changed notification:",
+				error,
+			);
+		}
 
 		return this.createStructuredContentSuccessResponse(
 			{ success: true, active_org_id: org_id },

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -214,22 +214,6 @@ export class MCPServer extends BaseMCPServer {
 		return this.getThoughtSpotService(recorder).validateConnection();
 	}
 
-	// Load warm token before initializeService so getSessionInfo uses it instead
-	// of the short-lived props access token.
-	protected async initializeService(): Promise<void> {
-		if (this.isOAuthAuth()) {
-			try {
-				await this.loadOrSeedWarmToken();
-			} catch (error) {
-				console.error(
-					"Failed to load warm token before initializeService:",
-					error,
-				);
-			}
-		}
-		await super.initializeService();
-	}
-
 	// On connect (OAuth only): keep the cluster token warm, then — when org tools are
 	// available — establish the active org (prior switch wins, else session current)
 	// and mint its token. Best-effort: never break connect.
@@ -240,13 +224,10 @@ export class MCPServer extends BaseMCPServer {
 		// Single source of truth for multi-org eligibility: only a grant minted by
 		// the multi-org login path carries a refresh token.
 		this.grantHasRefreshToken = typeof this.ctx.props.refreshToken === "string";
-		// Already loaded in initializeService; this is a no-op if the alarm is set.
-		if (!this.warmGlobalToken) {
-			try {
-				await this.loadOrSeedWarmToken();
-			} catch (error) {
-				console.error("Failed to load/seed keep-warm token on connect:", error);
-			}
+		try {
+			await this.loadOrSeedWarmToken();
+		} catch (error) {
+			console.error("Failed to load/seed keep-warm token on connect:", error);
 		}
 
 		if (!this.areOrgToolsAvailable()) {

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -278,8 +278,10 @@ export class MCPServer extends BaseMCPServer {
 			this.warmGlobalToken = accessToken;
 			return;
 		}
-		// No refresh token to re-seed with: use whatever we have.
-		this.warmGlobalToken = store.accessToken ?? accessToken;
+		// No refresh token to re-seed with: prefer the stored token only if it isn't
+		// expired, else fall back to the (possibly fresher) props token.
+		this.warmGlobalToken =
+			store.accessToken && !storedExpired ? store.accessToken : accessToken;
 	}
 
 	// Fire-and-forget; throttle + idle-delete live in the DO.

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -44,14 +44,10 @@ import {
 } from "./version-registry";
 
 export class MCPServer extends BaseMCPServer {
-	// Mirrors of the shared per-user store (the durable source of truth, shared so
-	// the token is minted once across the user's fanned-out sessions).
 	private activeOrgId: string | undefined;
 	private activeOrgToken: string | undefined;
 	private warmGlobalToken: string | undefined;
-	// Decided once in postInit: does this connection's grant carry a refresh token?
-	// A pre-multi-org grant does not, so it keeps the old (no-org) behavior until the
-	// user re-authenticates. Everything multi-org keys off this flag.
+	// False for pre-multi-org grants (no refresh token) — keeps old behavior until re-auth.
 	private grantHasRefreshToken = false;
 
 	constructor(ctx: Context) {
@@ -67,9 +63,6 @@ export class MCPServer extends BaseMCPServer {
 	}
 
 	protected getActiveBearerToken(): string {
-		// An active org must use its org-scoped token — never the global token, which
-		// would break org isolation. ensureActiveOrgToken guarantees it is minted
-		// before any data call, so a missing token here is a bug, not a fallback.
 		if (this.activeOrgId) {
 			if (!this.activeOrgToken) {
 				throw new Error(
@@ -81,7 +74,6 @@ export class MCPServer extends BaseMCPServer {
 		return this.getGlobalToken();
 	}
 
-	// Re-read on each org-aware call so a switch in another session is reflected.
 	private async loadActiveOrg(): Promise<void> {
 		const storage = await this.getStorageService();
 		const stored = await storage.getActiveOrg();
@@ -89,8 +81,6 @@ export class MCPServer extends BaseMCPServer {
 		this.activeOrgToken = stored.orgToken ?? undefined;
 	}
 
-	// Pass orgToken to commit id+token atomically (validated switch); else the
-	// prior token is cleared and re-minted lazily.
 	private async setActiveOrg(orgId: string, orgToken?: string): Promise<void> {
 		this.activeOrgId = orgId;
 		this.activeOrgToken = orgToken;
@@ -98,8 +88,6 @@ export class MCPServer extends BaseMCPServer {
 		await storage.setActiveOrg(orgId, orgToken);
 	}
 
-	// Reuse the shared-store token if held, else mint from the global token and
-	// persist it (so the fan-out mints once).
 	private async ensureOrgToken(
 		orgId: string,
 		recorder?: MetricsRecorder,
@@ -120,8 +108,6 @@ export class MCPServer extends BaseMCPServer {
 		return orgToken;
 	}
 
-	// HTTP status from a thrown error or `{ error }` result: typed
-	// ThoughtSpotApiError, else parsed from a "status NNN" message.
 	private apiErrorStatus(value: unknown): number | undefined {
 		const err =
 			value instanceof Error
@@ -138,10 +124,6 @@ export class MCPServer extends BaseMCPServer {
 		return match ? Number(match[1]) : undefined;
 	}
 
-	// Re-mint the active org's token, recovering from a stale one. Mint first, then
-	// overwrite atomically — the store never goes tokenless, so a concurrent session
-	// never sees an active org without its token. Abort if a sibling switched org
-	// meanwhile, so we don't clobber the new org's token.
 	private async forceRemintOrgToken(
 		orgId: string,
 		recorder?: MetricsRecorder,
@@ -161,8 +143,6 @@ export class MCPServer extends BaseMCPServer {
 		await this.setActiveOrg(orgId, orgToken);
 	}
 
-	// Single re-mint+retry on a 401, only when an org token is in use (a global-token
-	// 401 passes through). Handles both thrown and `{ error }`-result 401s.
 	protected async withOrgTokenRetry<T>(
 		recorder: MetricsRecorder | undefined,
 		fn: (service: ThoughtSpotService) => Promise<T>,
@@ -177,8 +157,6 @@ export class MCPServer extends BaseMCPServer {
 			return attempt();
 		}
 
-		// Org active → the call must use the org-scoped token, never the global one
-		// (a global-token data call would break org isolation). Mint if not cached.
 		if (!this.activeOrgToken) {
 			await this.ensureOrgToken(orgId, recorder);
 		}
@@ -199,8 +177,6 @@ export class MCPServer extends BaseMCPServer {
 		}
 	}
 
-	// validateConnection maps a 401 to `false` (no throw), so withOrgTokenRetry can't
-	// see it. If it fails with an org token in use, re-mint and re-validate.
 	private async validateConnectionWithOrgRetry(
 		recorder?: MetricsRecorder,
 	): Promise<boolean> {
@@ -214,15 +190,10 @@ export class MCPServer extends BaseMCPServer {
 		return this.getThoughtSpotService(recorder).validateConnection();
 	}
 
-	// On connect (OAuth only): keep the cluster token warm, then — when org tools are
-	// available — establish the active org (prior switch wins, else session current)
-	// and mint its token. Best-effort: never break connect.
 	protected async postInit(): Promise<void> {
 		if (!this.isOAuthAuth()) {
 			return;
 		}
-		// Single source of truth for multi-org eligibility: only a grant minted by
-		// the multi-org login path carries a refresh token.
 		this.grantHasRefreshToken = typeof this.ctx.props.refreshToken === "string";
 		try {
 			await this.loadOrSeedWarmToken();
@@ -252,20 +223,11 @@ export class MCPServer extends BaseMCPServer {
 		}
 	}
 
-	// Load the keep-warm token into memory.
-	// 1. Read the stored token first (the alarm may have refreshed it).
-	// 2. If the stored token is valid and newer than props (different string, not
-	//    expired), use it directly — no re-seed needed.
-	// 3. Otherwise seed from the fresh props grant (re-issued from the OAuth grant
-	//    on every request), then re-read to confirm what was stored.
-	// This read-before-write ensures the mock and DO agree: the stored token wins
-	// without the mock needing to replicate seedTokenStore's merge logic.
 	private async loadOrSeedWarmToken(): Promise<void> {
 		const storage = await this.getStorageService();
 		const { accessToken, refreshToken, tokenExpiryDuration, instanceUrl } =
 			this.ctx.props;
 
-		// Always read first — the alarm may have refreshed the stored token.
 		const existing = await storage.getTokenStore();
 		const storedToken = existing.accessToken ?? null;
 		const storedExpiresAt = existing.expiresAt ?? null;
@@ -275,13 +237,11 @@ export class MCPServer extends BaseMCPServer {
 			storedToken && storedToken !== accessToken && !storedExpired;
 
 		if (storedIsNewer) {
-			// Stored token was alarm-refreshed and is still valid — use it.
 			this.warmGlobalToken = storedToken;
 			return;
 		}
 
 		if (accessToken && refreshToken) {
-			// Seed/update the store with the fresh props token.
 			await storage.seedTokenStore({
 				accessToken,
 				refreshToken,
@@ -295,12 +255,10 @@ export class MCPServer extends BaseMCPServer {
 			return;
 		}
 
-		// No refresh token (legacy grant): prefer valid stored token, else props.
 		this.warmGlobalToken =
 			storedToken && !storedExpired ? storedToken : accessToken;
 	}
 
-	// Fire-and-forget; throttle + idle-delete live in the DO.
 	private touchLastSeen(): void {
 		this.getStorageService()
 			.then((storage) => storage.touchLastSeen())
@@ -313,20 +271,14 @@ export class MCPServer extends BaseMCPServer {
 		return "mcp";
 	}
 
-	// Gates OAuth-only tools such as `list_orgs`.
 	protected isOAuthAuth(): boolean {
 		return this.ctx.props.authMode === "oauth";
 	}
 
-	// A grant minted before multi-org shipped has no refresh token (extendGrantProps
-	// adds it at login). Such sessions keep the pre-multi-org behavior — no org
-	// tools, no overlay — until the user re-authenticates. Decided in postInit.
 	protected hasMultiOrgGrant(): boolean {
 		return this.grantHasRefreshToken;
 	}
 
-	// Org behavior requires OAuth + orgs enabled + the v2 surface (inferred from the
-	// resolved tool set, not a label) + a multi-org grant. Fails closed.
 	protected areOrgToolsAvailable(): boolean {
 		if (
 			!this.isOAuthAuth() ||
@@ -503,9 +455,6 @@ export class MCPServer extends BaseMCPServer {
 
 		if (this.areOrgToolsAvailable()) {
 			await this.loadActiveOrg();
-			// Mint the org token up front so every data path uses it; no call falls
-			// back to the global token while an org is active. list_orgs/switch_org
-			// use the global token on their own (listing / minting) paths.
 			if (
 				this.activeOrgId &&
 				!this.activeOrgToken &&
@@ -582,7 +531,6 @@ export class MCPServer extends BaseMCPServer {
 			}
 
 			case ToolName.ListOrgs: {
-				// Defense in depth: also reject direct invocation when unavailable.
 				if (!this.areOrgToolsAvailable()) {
 					return this.createErrorResponse(
 						"The list_orgs tool is only available when authenticated via OAuth on a cluster with Orgs enabled.",
@@ -973,7 +921,6 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		).listOrgs();
 		span?.setAttribute("total_orgs", orgs.length);
 
-		// May run on a different DO than the switch — re-read the shared store.
 		await this.loadActiveOrg();
 		const activeOrgId = this.getActiveOrgId();
 
@@ -999,7 +946,6 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		const orgId = String(org_id);
 		span?.setAttribute("requested_org_id", orgId);
 
-		// Mint first to validate; commit only on success, so a bad org_id is a no-op.
 		let orgToken: string;
 		try {
 			await this.loadOrSeedWarmToken();
@@ -1011,7 +957,6 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			).fetchOrgBearerToken(globalToken, orgId);
 		} catch (error) {
 			const status = this.apiErrorStatus(error);
-			// Any 4xx = org invalid or inaccessible.
 			if (status !== undefined && status >= 400 && status < 500) {
 				return this.createErrorResponse(
 					`You do not have access to org "${orgId}", or it does not exist. Call list_orgs to see the orgs you can access.`,
@@ -1028,14 +973,8 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 		this._sources = null;
 		span?.setAttribute("active_org_id", orgId);
 
-		// Datasources are org-specific — tell the client to re-list resources so it
-		// drops the previous org's datasources. Best-effort: never fail the switch.
 		try {
 			await this.sendResourceListChanged();
-			// TEMP (testing): confirm the notification path fires on switch. Remove.
-			console.log(
-				`[RESOURCE-DEBUG] sendResourceListChanged sent after switch to org ${orgId}`,
-			);
 		} catch (error) {
 			console.error(
 				"Failed to send resource list changed notification:",

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -979,11 +979,11 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 
 		return this.createStructuredContentSuccessResponse(
 			{
-				orgs: orgs.map((org) => ({
-					...org,
-					is_active:
-						activeOrgId !== undefined && String(org.id) === activeOrgId,
-				})),
+				orgs: orgs.map((org) => {
+					const isActive =
+						activeOrgId !== undefined && String(org.id) === activeOrgId;
+					return isActive ? { ...org, is_active: true } : { ...org };
+				}),
 			},
 			`${orgs.length} org(s) found`,
 		);

--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -263,6 +263,40 @@ export const CreateDashboardOutputSchema = z.object({
 		),
 });
 
+export const ListOrgsInputSchema = z.object({});
+
+export const ListOrgsOutputSchema = z.object({
+	orgs: z
+		.array(
+			z.object({
+				id: z.number().describe("Unique identifier of the Org."),
+				name: z.string().describe("Name of the Org."),
+				description: z.string().optional().describe("Description of the Org."),
+				is_active: z
+					.boolean()
+					.describe(
+						"Whether this is the Org currently active for your account. Tool calls operate against the active Org.",
+					),
+			}),
+		)
+		.describe("The list of Orgs the user can access."),
+});
+
+export const SwitchOrgInputSchema = z.object({
+	org_id: z
+		.number()
+		.describe(
+			"The id of the Org to switch to. Use an `id` returned by `list_orgs`. Subsequent tool calls in this session operate against this Org.",
+		),
+});
+
+export const SwitchOrgOutputSchema = z.object({
+	success: z.boolean().describe("Whether the Org switch was successful."),
+	active_org_id: z
+		.number()
+		.describe("The id of the Org now active for the session."),
+});
+
 export enum ToolName {
 	// V1
 	Ping = "ping",
@@ -276,6 +310,8 @@ export enum ToolName {
 	SendSessionMessage = "send_session_message",
 	GetSessionUpdates = "get_session_updates",
 	CreateDashboard = "create_dashboard",
+	ListOrgs = "list_orgs",
+	SwitchOrg = "switch_org",
 }
 
 export const toolDefinitionsV1 = [
@@ -381,7 +417,7 @@ export const toolDefinitionsV2 = [
 	{
 		name: ToolName.GetSessionUpdates,
 		description:
-			"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true.",
+			"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true. If the completed response indicates that no data or no results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.",
 		inputSchema: z.toJSONSchema(GetSessionUpdatesInputSchema),
 		outputSchema: z.toJSONSchema(GetSessionUpdatesOutputSchema),
 		annotations: {
@@ -399,6 +435,32 @@ export const toolDefinitionsV2 = [
 		outputSchema: z.toJSONSchema(CreateDashboardOutputSchema),
 		annotations: {
 			title: "Create Dashboard",
+			readOnlyHint: false,
+			destructiveHint: false,
+			openWorldHint: false,
+		},
+	},
+	{
+		name: ToolName.ListOrgs,
+		description:
+			"List the Orgs the authenticated user can access on the ThoughtSpot instance, including the ID, name, and description of each Org. The Org marked `is_active: true` is the one currently active for your account, which all tool calls operate against. Use this to tell the user which Org they are in. Only available when authenticated via OAuth.",
+		inputSchema: z.toJSONSchema(ListOrgsInputSchema),
+		outputSchema: z.toJSONSchema(ListOrgsOutputSchema),
+		annotations: {
+			title: "List Orgs",
+			readOnlyHint: true,
+			destructiveHint: false,
+			openWorldHint: false,
+		},
+	},
+	{
+		name: ToolName.SwitchOrg,
+		description:
+			"Switch the active Org. After switching, all subsequent tool calls (analysis sessions, answers, data sources, dashboards) operate against the selected Org. Pass an `org_id` returned by `list_orgs`. If you do not have access to the Org, the switch fails and the active Org is unchanged. The selection is durable and shared across all of your sessions — it persists across reconnects and applies to your other active conversations; it resets only on re-authentication or after prolonged inactivity. Only available when authenticated via OAuth.",
+		inputSchema: z.toJSONSchema(SwitchOrgInputSchema),
+		outputSchema: z.toJSONSchema(SwitchOrgOutputSchema),
+		annotations: {
+			title: "Switch Org",
 			readOnlyHint: false,
 			destructiveHint: false,
 			openWorldHint: false,

--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -274,8 +274,9 @@ export const ListOrgsOutputSchema = z.object({
 				description: z.string().optional().describe("Description of the Org."),
 				is_active: z
 					.boolean()
+					.optional()
 					.describe(
-						"Whether this is the Org currently active for your account. Tool calls operate against the active Org.",
+						"Present and true only for the Org currently active for your account. Absent for all other Orgs. Tool calls operate against the active Org.",
 					),
 			}),
 		)
@@ -417,7 +418,7 @@ export const toolDefinitionsV2 = [
 	{
 		name: ToolName.GetSessionUpdates,
 		description:
-			"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true. If the completed response indicates that no data or no results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.",
+			"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true. If the completed response indicates that no data or no results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org or the user may not have access to it in the current org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.",
 		inputSchema: z.toJSONSchema(GetSessionUpdatesInputSchema),
 		outputSchema: z.toJSONSchema(GetSessionUpdatesOutputSchema),
 		annotations: {
@@ -443,7 +444,7 @@ export const toolDefinitionsV2 = [
 	{
 		name: ToolName.ListOrgs,
 		description:
-			"List the Orgs the authenticated user can access on the ThoughtSpot instance, including the ID, name, and description of each Org. The Org marked `is_active: true` is the one currently active for your account, which all tool calls operate against. Use this to tell the user which Org they are in. Only available when authenticated via OAuth.",
+			"List the Orgs the authenticated user can access on the ThoughtSpot instance, including the ID, name, and description of each Org. The Org marked `is_active: true` is the one currently active for your account, which all tool calls operate against. Use this to tell the user which Org they are in. Only available when authenticated via OAuth. If the list is large , summarize or show only the most relevant orgs (e.g. the active one and a few others) rather than listing all of them, unless the user explicitly asks to see all orgs.",
 		inputSchema: z.toJSONSchema(ListOrgsInputSchema),
 		outputSchema: z.toJSONSchema(ListOrgsOutputSchema),
 		annotations: {

--- a/src/servers/user-token-store-server.ts
+++ b/src/servers/user-token-store-server.ts
@@ -1,0 +1,210 @@
+const ACTIVE_ORG_KEY = "active-org";
+const ORG_TOKEN_KEY = "active-org-token";
+const TOKEN_STORE_KEY = "token-store";
+// 11h refresh on a ~24h token: a failed attempt re-arms at ~22h, still inside the
+// expiry window, giving a second chance before expiry.
+const TOKEN_REFRESH_INTERVAL_MS = 11 * 60 * 60 * 1000;
+const SESSION_IDLE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+export type TokenStore = {
+	accessToken: string;
+	refreshToken: string;
+	instanceUrl: string;
+	expiresAt?: number;
+	lastSeenAt?: number;
+};
+
+// Per-user token/org DO, shared across the user's fanned-out sessions via the
+// storage-key hash. Owns the active org + org token and the keep-warm cluster
+// token (11h refresh alarm, abandoned after 14 idle days).
+export class UserTokenStoreSQLite {
+	constructor(
+		private state: DurableObjectState,
+		private env: Env,
+	) {}
+
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		const parts = url.pathname.split("/");
+		const operation = parts[3] ?? "";
+
+		try {
+			switch (`${request.method} /${operation}`) {
+				case "GET /active-org": {
+					const [activeOrgId, orgToken] = await Promise.all([
+						this.state.storage.get<string>(ACTIVE_ORG_KEY),
+						this.state.storage.get<string>(ORG_TOKEN_KEY),
+					]);
+					return Response.json({
+						activeOrgId: activeOrgId ?? null,
+						orgToken: orgToken ?? null,
+					});
+				}
+
+				// Clear the token only on a real org change; re-setting the same org
+				// (every cold connect) must not delete a token a sibling just minted.
+				case "POST /active-org": {
+					const body = (await request.json()) as {
+						activeOrgId: string;
+						orgToken?: string | null;
+					};
+					if (body.orgToken) {
+						await this.state.storage.put({
+							[ACTIVE_ORG_KEY]: body.activeOrgId,
+							[ORG_TOKEN_KEY]: body.orgToken,
+						});
+						return Response.json({ ok: true });
+					}
+					const previousOrgId =
+						await this.state.storage.get<string>(ACTIVE_ORG_KEY);
+					await this.state.storage.put<string>(
+						ACTIVE_ORG_KEY,
+						body.activeOrgId,
+					);
+					if (previousOrgId !== body.activeOrgId) {
+						await this.state.storage.delete(ORG_TOKEN_KEY);
+					}
+					return Response.json({ ok: true });
+				}
+
+				case "POST /active-org-token": {
+					const body = (await request.json()) as { orgToken?: string | null };
+					if (body.orgToken) {
+						await this.state.storage.put<string>(ORG_TOKEN_KEY, body.orgToken);
+					} else {
+						await this.state.storage.delete(ORG_TOKEN_KEY);
+					}
+					return Response.json({ ok: true });
+				}
+
+				case "GET /token-store": {
+					const store =
+						(await this.state.storage.get<TokenStore>(TOKEN_STORE_KEY)) ?? null;
+					return Response.json({
+						accessToken: store?.accessToken ?? null,
+						expiresAt: store?.expiresAt ?? null,
+					});
+				}
+
+				case "POST /token-store": {
+					const body = (await request.json()) as TokenStore;
+					await this.seedTokenStore(body);
+					return Response.json({ ok: true });
+				}
+
+				case "POST /touch": {
+					await this.touchLastSeen();
+					return Response.json({ ok: true });
+				}
+
+				default:
+					return new Response("Not Found", { status: 404 });
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.error("Error handling user token-store request:", message);
+			return Response.json({ error: message }, { status: 500 });
+		}
+	}
+
+	// Idempotent: re-seeding updates tokens without stacking alarms.
+	private async seedTokenStore(store: TokenStore): Promise<void> {
+		const toStore: TokenStore = {
+			...store,
+			lastSeenAt: store.lastSeenAt ?? Date.now(),
+		};
+		await this.state.storage.put<TokenStore>(TOKEN_STORE_KEY, toStore);
+		const existingAlarm = await this.state.storage.getAlarm();
+		if (existingAlarm == null) {
+			await this.state.storage.setAlarm(Date.now() + TOKEN_REFRESH_INTERVAL_MS);
+		}
+	}
+
+	// Stamp last activity, throttled to ~1/hour so fanned-out calls don't each write.
+	private async touchLastSeen(): Promise<void> {
+		const store = await this.state.storage.get<TokenStore>(TOKEN_STORE_KEY);
+		if (!store) {
+			return;
+		}
+		const now = Date.now();
+		const THROTTLE_MS = 60 * 60 * 1000; // 1 hour
+		if (store.lastSeenAt && now - store.lastSeenAt < THROTTLE_MS) {
+			return;
+		}
+		await this.state.storage.put<TokenStore>(TOKEN_STORE_KEY, {
+			...store,
+			lastSeenAt: now,
+		});
+	}
+
+	// Refresh the keep-warm token and re-arm. Past the idle TTL, abandon instead.
+	private async refreshTokenStore(): Promise<void> {
+		const store = await this.state.storage.get<TokenStore>(TOKEN_STORE_KEY);
+		if (!store) {
+			return;
+		}
+
+		if (
+			store.lastSeenAt != null &&
+			Date.now() - store.lastSeenAt >= SESSION_IDLE_TTL_MS
+		) {
+			console.log("Keep-warm session idle past TTL; abandoning");
+			await this.state.storage.delete([
+				TOKEN_STORE_KEY,
+				ACTIVE_ORG_KEY,
+				ORG_TOKEN_KEY,
+			]);
+			return;
+		}
+
+		try {
+			const response = await fetch(
+				`${store.instanceUrl}/callosum/v1/session/v2/gettoken?refresh=true`,
+				{
+					method: "GET",
+					headers: {
+						"Content-Type": "application/json",
+						Accept: "application/json",
+						"user-agent": "ThoughtSpot-ts-client",
+						Authorization: `Bearer ${store.accessToken}`,
+						"X-Refresh-Token": store.refreshToken,
+					},
+				},
+			);
+			if (!response.ok) {
+				const text = await response.text();
+				throw new Error(`status ${response.status}: ${text}`);
+			}
+			const data = (await response.json()) as any;
+			const accessToken = data?.token ?? data?.data?.token;
+			if (!accessToken || typeof accessToken !== "string") {
+				throw new Error("no token in refresh response");
+			}
+			const refreshToken =
+				data?.refreshToken ?? data?.data?.refreshToken ?? store.refreshToken;
+			const newExpiresAt =
+				data?.tokenExpiryDuration ?? data?.data?.tokenExpiryDuration;
+			await this.state.storage.put<TokenStore>(TOKEN_STORE_KEY, {
+				accessToken,
+				refreshToken,
+				instanceUrl: store.instanceUrl,
+				// Keep the prior expiry if the response omits one.
+				expiresAt:
+					typeof newExpiresAt === "number" ? newExpiresAt : store.expiresAt,
+				lastSeenAt: store.lastSeenAt,
+			});
+			await this.state.storage.setAlarm(Date.now() + TOKEN_REFRESH_INTERVAL_MS);
+		} catch (error) {
+			console.error(
+				"Token keep-warm refresh failed; will retry on next interval:",
+				error instanceof Error ? error.message : String(error),
+			);
+			// Re-arm anyway; the stored token stays intact so reads work until then.
+			await this.state.storage.setAlarm(Date.now() + TOKEN_REFRESH_INTERVAL_MS);
+		}
+	}
+
+	async alarm(): Promise<void> {
+		await this.refreshTokenStore();
+	}
+}

--- a/src/servers/user-token-store-server.ts
+++ b/src/servers/user-token-store-server.ts
@@ -1,8 +1,6 @@
 const ACTIVE_ORG_KEY = "active-org";
 const ORG_TOKEN_KEY = "active-org-token";
 const TOKEN_STORE_KEY = "token-store";
-// 11h refresh on a ~24h token: a failed attempt re-arms at ~22h, still inside the
-// expiry window, giving a second chance before expiry.
 const TOKEN_REFRESH_INTERVAL_MS = 11 * 60 * 60 * 1000;
 const SESSION_IDLE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 
@@ -107,9 +105,11 @@ export class UserTokenStoreSQLite {
 		}
 	}
 
-	// Idempotent: re-seeding updates tokens without stacking alarms.
+	// Idempotent: re-seeding updates the stored token and arms the alarm once.
 	// lastSeenAt is set on first seed (starts the idle clock) and preserved on
-	// re-seeds; only touch() (tool calls) resets it.
+	// re-seeds; only touch() (tool calls) advances it.
+	// The caller (loadOrSeedWarmToken) already decided to use the props token
+	// over the stored one — just write it and arm the alarm.
 	private async seedTokenStore(store: TokenStore): Promise<void> {
 		const existing = await this.state.storage.get<TokenStore>(TOKEN_STORE_KEY);
 		const toStore: TokenStore = {

--- a/src/servers/user-token-store-server.ts
+++ b/src/servers/user-token-store-server.ts
@@ -108,10 +108,13 @@ export class UserTokenStoreSQLite {
 	}
 
 	// Idempotent: re-seeding updates tokens without stacking alarms.
+	// lastSeenAt is set on first seed (starts the idle clock) and preserved on
+	// re-seeds; only touch() (tool calls) resets it.
 	private async seedTokenStore(store: TokenStore): Promise<void> {
+		const existing = await this.state.storage.get<TokenStore>(TOKEN_STORE_KEY);
 		const toStore: TokenStore = {
 			...store,
-			lastSeenAt: store.lastSeenAt ?? Date.now(),
+			lastSeenAt: existing?.lastSeenAt ?? Date.now(),
 		};
 		await this.state.storage.put<TokenStore>(TOKEN_STORE_KEY, toStore);
 		const existingAlarm = await this.state.storage.getAlarm();

--- a/src/storage-service/storage-service.ts
+++ b/src/storage-service/storage-service.ts
@@ -1,21 +1,14 @@
 import type { Message, StreamingMessagesState } from "../thoughtspot/types";
 
-/**
- * Client for the ConversationStorageServer Durable Object.
- *
- * Communicates directly with the DO via its stub (bypassing the OAuth layer), mapping to the
- * following HTTP endpoints exposed by the server:
- *   POST  /storage/<storageId>/initialize —> initializeConversation
- *   POST  /storage/<storageId>/append     —> appendMessagesAndRestartTtl
- *   GET   /storage/<storageId>/messages   —> getNewMessagesAndUpdateBookmark
- *
- * The storageId is derived by taking a hash of the user's access token and combining it with the
- * conversationId, to ensure no users can access each other's conversations.
- */
+// Client for the conversation-storage and per-user token/org Durable Objects,
+// talking to their stubs directly (bypassing the OAuth layer). The storage id is
+// hash(user) + conversationId, so users can't reach each other's conversations.
 export class StorageServiceClient {
 	constructor(
 		private readonly namespace: DurableObjectNamespace,
 		private readonly accessTokenHashUrlSafe: string,
+		// Optional so non-token callers still compile.
+		private readonly userTokenNamespace?: DurableObjectNamespace,
 	) {}
 
 	private headers(): HeadersInit {
@@ -32,16 +25,152 @@ export class StorageServiceClient {
 		return this.namespace.get(id);
 	}
 
-	// DO stubs ignore the hostname; we use a placeholder so the path is parsed correctly.
+	private userStubFor(id: string): DurableObjectStub {
+		const ns = this.userTokenNamespace;
+		if (!ns) {
+			throw new Error(
+				"StorageServiceClient: userTokenNamespace not configured for token/org operation",
+			);
+		}
+		const doId = ns.idFromName(`${this.accessTokenHashUrlSafe}:${id}`);
+		return ns.get(doId);
+	}
+
+	// DO stubs ignore the hostname; a placeholder keeps the path parseable.
 	private url(conversationId: string, operation: string): string {
 		return `https://internal/storage/${encodeURIComponent(conversationId)}/${operation}`;
 	}
 
-	/**
-	 * Initialize a conversation. Must be called before appending messages.
-	 * Can also be called on an existing conversation that is already marked done,
-	 * to prime it for a follow-up message.
-	 */
+	private static readonly ACTIVE_ORG_ID = "__active_org__";
+
+	async getActiveOrg(): Promise<{
+		activeOrgId: string | null;
+		orgToken: string | null;
+	}> {
+		const id = StorageServiceClient.ACTIVE_ORG_ID;
+		const response = await this.userStubFor(id).fetch(
+			this.url(id, "active-org"),
+			{
+				method: "GET",
+				headers: this.headers(),
+			},
+		);
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(`Failed to get active org (${response.status}): ${body}`);
+		}
+		const data = (await response.json()) as {
+			activeOrgId: string | null;
+			orgToken: string | null;
+		};
+		return {
+			activeOrgId: data.activeOrgId ?? null,
+			orgToken: data.orgToken ?? null,
+		};
+	}
+
+	// Pass orgToken to commit id+token atomically (validated switch); omit it on the
+	// postInit default path, where the prior token is cleared and re-minted lazily.
+	async setActiveOrg(activeOrgId: string, orgToken?: string): Promise<void> {
+		const id = StorageServiceClient.ACTIVE_ORG_ID;
+		const response = await this.userStubFor(id).fetch(
+			this.url(id, "active-org"),
+			{
+				method: "POST",
+				headers: this.headers(),
+				body: JSON.stringify({ activeOrgId, orgToken: orgToken ?? null }),
+			},
+		);
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(`Failed to set active org (${response.status}): ${body}`);
+		}
+	}
+
+	// Empty string clears the token (to evict a stale one before re-minting).
+	async setActiveOrgToken(orgToken: string): Promise<void> {
+		const id = StorageServiceClient.ACTIVE_ORG_ID;
+		const response = await this.userStubFor(id).fetch(
+			this.url(id, "active-org-token"),
+			{
+				method: "POST",
+				headers: this.headers(),
+				body: JSON.stringify({ orgToken: orgToken || null }),
+			},
+		);
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(
+				`Failed to set active org token (${response.status}): ${body}`,
+			);
+		}
+	}
+
+	// Read the keep-warm token (alarm-refreshed); accessToken is null if unseeded.
+	async getTokenStore(): Promise<{
+		accessToken: string | null;
+		expiresAt: number | null;
+	}> {
+		const id = StorageServiceClient.ACTIVE_ORG_ID;
+		const response = await this.userStubFor(id).fetch(
+			this.url(id, "token-store"),
+			{
+				method: "GET",
+				headers: this.headers(),
+			},
+		);
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(
+				`Failed to get token store (${response.status}): ${body}`,
+			);
+		}
+		return (await response.json()) as {
+			accessToken: string | null;
+			expiresAt: number | null;
+		};
+	}
+
+	// Seed the keep-warm token store + arm the refresh alarm. Idempotent per connect.
+	async seedTokenStore(store: {
+		accessToken: string;
+		refreshToken: string;
+		instanceUrl: string;
+		expiresAt?: number;
+	}): Promise<void> {
+		const id = StorageServiceClient.ACTIVE_ORG_ID;
+		const response = await this.userStubFor(id).fetch(
+			this.url(id, "token-store"),
+			{
+				method: "POST",
+				headers: this.headers(),
+				body: JSON.stringify(store),
+			},
+		);
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(
+				`Failed to seed token store (${response.status}): ${body}`,
+			);
+		}
+	}
+
+	// Record user activity for idle detection; throttled server-side.
+	async touchLastSeen(): Promise<void> {
+		const id = StorageServiceClient.ACTIVE_ORG_ID;
+		const response = await this.userStubFor(id).fetch(this.url(id, "touch"), {
+			method: "POST",
+			headers: this.headers(),
+		});
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(
+				`Failed to touch last-seen (${response.status}): ${body}`,
+			);
+		}
+	}
+
+	// Call before appending; also re-primes a done conversation for a follow-up.
 	async initializeConversation(conversationId: string): Promise<void> {
 		const response = await this.stubFor(conversationId).fetch(
 			this.url(conversationId, "initialize"),
@@ -56,10 +185,7 @@ export class StorageServiceClient {
 		}
 	}
 
-	/**
-	 * Append new messages to a conversation and restart its TTL.
-	 * Optionally mark the conversation as done.
-	 */
+	// Append messages and restart the TTL; isDone marks the conversation complete.
 	async appendMessages(
 		conversationId: string,
 		messages: Message[],
@@ -80,11 +206,8 @@ export class StorageServiceClient {
 		}
 	}
 
-	/**
-	 * Retrieve all messages that have been added since the last call to this method
-	 * (tracked via a per-conversation bookmark) and advance the bookmark.
-	 * Also returns whether the conversation has been marked done.
-	 */
+	// Return messages added since the last call (advancing a per-conversation
+	// bookmark) plus whether the conversation is done.
 	async getNewMessages(
 		conversationId: string,
 	): Promise<StreamingMessagesState> {

--- a/src/thoughtspot/org-service.ts
+++ b/src/thoughtspot/org-service.ts
@@ -1,0 +1,43 @@
+import type { ThoughtSpotRestApi } from "@thoughtspot/rest-api-sdk";
+import type { MetricsRecorder } from "../metrics/runtime/metrics-recorder";
+import {
+	UPSTREAM_OPERATION_NAMES,
+	observeUpstreamCall,
+} from "../metrics/runtime/tool-metrics";
+import { WithSpan, getActiveSpan } from "../metrics/tracing/tracing-utils";
+import type { Org } from "./types";
+
+// Org/token operations, separate from ThoughtSpotService (Spotter flows): listing
+// the user's orgs and minting org-scoped tokens for the multi-org (v2) tools.
+export class OrgService {
+	constructor(
+		private readonly client: ThoughtSpotRestApi,
+		private readonly recorder?: MetricsRecorder,
+	) {}
+
+	// User-scoped v1 session/orgs — works for any user, unlike the admin-only orgs/search.
+	@WithSpan("list-orgs")
+	async listOrgs(): Promise<Org[]> {
+		const orgs = (await observeUpstreamCall(
+			this.recorder,
+			UPSTREAM_OPERATION_NAMES.listOrgs,
+			() => (this.client as any).listOrgs(),
+		)) as Org[] | undefined;
+		const results = orgs ?? [];
+		getActiveSpan()?.setAttribute("results_count", results.length);
+		return results;
+	}
+
+	@WithSpan("fetch-org-bearer-token")
+	async fetchOrgBearerToken(
+		accessToken: string,
+		orgId: string,
+	): Promise<string> {
+		getActiveSpan()?.setAttribute("org_id", orgId);
+		return (await observeUpstreamCall(
+			this.recorder,
+			UPSTREAM_OPERATION_NAMES.fetchOrgBearerToken,
+			() => (this.client as any).fetchOrgBearerToken({ accessToken, orgId }),
+		)) as string;
+	}
+}

--- a/src/thoughtspot/thoughtspot-client.ts
+++ b/src/thoughtspot/thoughtspot-client.ts
@@ -1,23 +1,27 @@
 import {
-	createBearerAuthenticationConfig,
 	ThoughtSpotRestApi,
+	createBearerAuthenticationConfig,
 } from "@thoughtspot/rest-api-sdk";
 import type {
 	AgentConversation,
 	RequestContext,
 	ResponseContext,
 } from "@thoughtspot/rest-api-sdk";
-import YAML from "yaml";
-import { of } from "rxjs";
-import type { SessionInfo } from "./types";
 import { customAlphabet } from "nanoid";
+import { of } from "rxjs";
+import YAML from "yaml";
+import { type Org, type SessionInfo, ThoughtSpotApiError } from "./types";
 
 /*
  * Inject custom handlers into the ThoughtSpot client
  */
+// Per-request org selector; the access token works across all the user's orgs.
+const ORG_HEADER = "x-thoughtspot-orgs";
+
 export const getThoughtSpotClient = (
 	instanceUrl: string,
 	bearerToken: string,
+	orgId?: string,
 ) => {
 	const config = createBearerAuthenticationConfig(instanceUrl, () =>
 		Promise.resolve(bearerToken),
@@ -29,6 +33,10 @@ export const getThoughtSpotClient = (
 			if (!headers || !headers["Accept-Language"]) {
 				context.setHeaderParam("Accept-Language", "en-US");
 			}
+			// Scope every SDK call to the active org, if one is set.
+			if (orgId) {
+				context.setHeaderParam(ORG_HEADER, orgId);
+			}
 			return of(context) as any;
 		},
 		post: (context: ResponseContext) => {
@@ -37,13 +45,43 @@ export const getThoughtSpotClient = (
 	});
 	const client = new ThoughtSpotRestApi(config);
 	(client as any).instanceUrl = instanceUrl;
-	addExportUnsavedAnswerTML(client, instanceUrl, bearerToken);
-	addGetSessionInfo(client, instanceUrl, bearerToken);
-	addGetAnswerSession(client, instanceUrl, bearerToken);
-	addCreateAgentConversationWithAutoMode(client, instanceUrl, bearerToken);
-	addSendAgentConversationMessageStreaming(client, instanceUrl, bearerToken);
+	addExportUnsavedAnswerTML(client, instanceUrl, bearerToken, orgId);
+	addGetSessionInfo(client, instanceUrl, bearerToken, orgId);
+	addGetAnswerSession(client, instanceUrl, bearerToken, orgId);
+	addCreateAgentConversationWithAutoMode(
+		client,
+		instanceUrl,
+		bearerToken,
+		orgId,
+	);
+	addSendAgentConversationMessageStreaming(
+		client,
+		instanceUrl,
+		bearerToken,
+		orgId,
+	);
+	addFetchOrgBearerToken(client, instanceUrl);
+	addListOrgs(client, instanceUrl, bearerToken);
 	return client;
 };
+
+// Auth/content headers for the raw-fetch handlers, incl. the org header if set.
+function buildHeaders(
+	token: string,
+	orgId?: string,
+	accept = "application/json",
+): Record<string, string> {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		Accept: accept,
+		"user-agent": "ThoughtSpot-ts-client",
+		Authorization: `Bearer ${token}`,
+	};
+	if (orgId) {
+		headers[ORG_HEADER] = orgId;
+	}
+	return headers;
+}
 
 const getAnswerTML = `
 mutation GetUnsavedAnswerTML($session: BachSessionIdInput!, $exportDependencies: Boolean, $formatType:  EDocFormatType, $exportPermissions: Boolean, $exportFqn: Boolean) {
@@ -72,6 +110,7 @@ function addExportUnsavedAnswerTML(
 	client: any,
 	instanceUrl: string,
 	token: string,
+	orgId?: string,
 ) {
 	(client as any).exportUnsavedAnswerTML = async ({
 		session_identifier,
@@ -81,12 +120,7 @@ function addExportUnsavedAnswerTML(
 		// make a graphql request to `ThoughtspotHost/prism endpoint.
 		const response = await fetch(`${instanceUrl}${endpoint}`, {
 			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Accept: "application/json",
-				"user-agent": "ThoughtSpot-ts-client",
-				Authorization: `Bearer ${token}`,
-			},
+			headers: buildHeaders(token, orgId),
 			body: JSON.stringify({
 				operationName: "GetUnsavedAnswerTML",
 				query: getAnswerTML,
@@ -112,18 +146,14 @@ async function addGetSessionInfo(
 	client: any,
 	instanceUrl: string,
 	token: string,
+	orgId?: string,
 ) {
 	(client as any).getSessionInfo = async (): Promise<SessionInfo> => {
 		const endpoint = "/prism/preauth/info";
 		// make a graphql request to `ThoughtspotHost/prism endpoint.
 		const response = await fetch(`${instanceUrl}${endpoint}`, {
 			method: "GET",
-			headers: {
-				"Content-Type": "application/json",
-				Accept: "application/json",
-				"user-agent": "ThoughtSpot-ts-client",
-				Authorization: `Bearer ${token}`,
-			},
+			headers: buildHeaders(token, orgId),
 		});
 
 		const data: any = await response.json();
@@ -158,7 +188,12 @@ export interface AnswerSession {
 /*
  * Using custom handler because we don't have a public API for this
  */
-function addGetAnswerSession(client: any, instanceUrl: string, token: string) {
+function addGetAnswerSession(
+	client: any,
+	instanceUrl: string,
+	token: string,
+	orgId?: string,
+) {
 	(client as any).getAnswerSession = async ({
 		session_identifier,
 		generation_number,
@@ -170,12 +205,7 @@ function addGetAnswerSession(client: any, instanceUrl: string, token: string) {
 		const operationName = "Answer__updateTokens";
 		const fetchOptions = {
 			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Accept: "application/json",
-				"user-agent": "ThoughtSpot-ts-client",
-				Authorization: `Bearer ${token}`,
-			},
+			headers: buildHeaders(token, orgId),
 			body: JSON.stringify({
 				operationName,
 				query: getAnswerSessionQuery,
@@ -191,8 +221,10 @@ function addGetAnswerSession(client: any, instanceUrl: string, token: string) {
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			throw new Error(
-				`getAnswerSession failed with status ${response.status}: ${errorText}`,
+			throw new ThoughtSpotApiError(
+				response.status,
+				"getAnswerSession",
+				errorText,
 			);
 		}
 		const data = (await response.json()) as any;
@@ -211,6 +243,7 @@ function addCreateAgentConversationWithAutoMode(
 	client: any,
 	instanceUrl: string,
 	token: string,
+	orgId?: string,
 ) {
 	(client as any).createAgentConversationWithAutoMode = async ({
 		dataSourceId,
@@ -220,12 +253,7 @@ function addCreateAgentConversationWithAutoMode(
 		const endpoint = "/conversation/v2/";
 		const fetchOptions = {
 			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Accept: "application/json",
-				"user-agent": "ThoughtSpot-ts-client",
-				Authorization: `Bearer ${token}`,
-			},
+			headers: buildHeaders(token, orgId),
 			body: JSON.stringify({
 				context: dataSourceId
 					? {
@@ -251,8 +279,10 @@ function addCreateAgentConversationWithAutoMode(
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			throw new Error(
-				`createAgentConversationWithAutoMode failed with status ${response.status}: ${errorText}`,
+			throw new ThoughtSpotApiError(
+				response.status,
+				"createAgentConversationWithAutoMode",
+				errorText,
 			);
 		}
 
@@ -282,6 +312,7 @@ function addSendAgentConversationMessageStreaming(
 	client: any,
 	instanceUrl: string,
 	token: string,
+	orgId?: string,
 ) {
 	(client as any).sendAgentConversationMessageStreaming = async ({
 		conversation_identifier,
@@ -294,12 +325,7 @@ function addSendAgentConversationMessageStreaming(
 		const endpoint = `/conversation/v2/${encodeURIComponent(conversation_identifier)}/query`;
 		const fetchOptions = {
 			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Accept: "text/event-stream",
-				"user-agent": "ThoughtSpot-ts-client",
-				Authorization: `Bearer ${token}`,
-			},
+			headers: buildHeaders(token, orgId, "text/event-stream"),
 			body: JSON.stringify({
 				mode: "spotter", // TODO(Rifdhan) support deep analysis mode
 				id: generateNanoID(),
@@ -317,11 +343,84 @@ function addSendAgentConversationMessageStreaming(
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			throw new Error(
-				`sendAgentConversationMessageStreaming failed with status ${response.status}: ${errorText}`,
+			throw new ThoughtSpotApiError(
+				response.status,
+				"sendAgentConversationMessageStreaming",
+				errorText,
 			);
 		}
 
 		return response;
+	};
+}
+
+// Lists the user's orgs via the user-scoped v1 session/orgs endpoint. We avoid
+// the v2 orgs/search REST endpoint because it needs ORG_ADMINISTRATION and 403s
+// for regular users.
+function addListOrgs(client: any, instanceUrl: string, token: string) {
+	(client as any).listOrgs = async (): Promise<Org[]> => {
+		const endpoint = "/callosum/v1/session/orgs?batchsize=-1&offset=-1";
+		const response = await fetch(`${instanceUrl}${endpoint}`, {
+			method: "GET",
+			headers: buildHeaders(token),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw new ThoughtSpotApiError(response.status, "listOrgs", errorText);
+		}
+
+		const data = (await response.json()) as any;
+		const orgs: any[] = Array.isArray(data?.orgs) ? data.orgs : [];
+		return orgs.map((org) => ({
+			id: Number(org.orgId ?? org.id),
+			name: org.orgName ?? org.name ?? String(org.orgId ?? org.id),
+			description: org.description || undefined,
+		}));
+	};
+}
+
+// Org-scoped token validity (30 days), matching the connector's login validity.
+const ORG_TOKEN_VALIDITY_SEC = 30 * 24 * 60 * 60;
+
+// Mint an org-scoped token via auth/token/fetch?org_identifier=... The working
+// path is /callosum/v1/v2/auth/token/fetch (the /callosum/v2/... path 404s);
+// token is nested under data.token.
+function addFetchOrgBearerToken(client: any, instanceUrl: string) {
+	(client as any).fetchOrgBearerToken = async ({
+		accessToken,
+		orgId,
+		validityTimeInSec = ORG_TOKEN_VALIDITY_SEC,
+	}: {
+		accessToken: string;
+		orgId: string;
+		validityTimeInSec?: number;
+	}): Promise<string> => {
+		const params = new URLSearchParams({
+			validity_time_in_sec: String(validityTimeInSec),
+			org_identifier: orgId,
+		});
+		const endpoint = `/callosum/v1/v2/auth/token/fetch?${params.toString()}`;
+		const response = await fetch(`${instanceUrl}${endpoint}`, {
+			method: "GET",
+			// No org header — the org is selected via org_identifier.
+			headers: buildHeaders(accessToken),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw new ThoughtSpotApiError(
+				response.status,
+				"fetchOrgBearerToken",
+				errorText,
+			);
+		}
+
+		const data = (await response.json()) as any;
+		const token = data?.data?.token ?? data?.token;
+		if (!token || typeof token !== "string") {
+			throw new Error("fetchOrgBearerToken: no token in response");
+		}
+		return token;
 	};
 }

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -16,7 +16,7 @@ import type { MetricsEnvLike } from "../metrics/runtime/runtime-config";
 import {
 	UPSTREAM_OPERATION_NAMES,
 	type UpstreamOperation,
-	recordUpstreamCallMetrics,
+	observeUpstreamCall,
 	recordUpstreamStreamStartedMetric,
 } from "../metrics/runtime/tool-metrics";
 import { WithSpan, getActiveSpan } from "../metrics/tracing/tracing-utils";
@@ -46,26 +46,11 @@ export class ThoughtSpotService {
 		private readonly metrics: ThoughtSpotServiceMetricsOptions = {},
 	) {}
 
-	private async observeUpstreamCall<T>(
+	private observeUpstreamCall<T>(
 		operation: UpstreamOperation,
 		call: () => Promise<T>,
 	): Promise<T> {
-		const startedAt = Date.now();
-		let outcome: "success" | "upstream_error" = "success";
-
-		try {
-			return await call();
-		} catch (error) {
-			outcome = "upstream_error";
-			throw error;
-		} finally {
-			recordUpstreamCallMetrics(
-				this.metrics.recorder,
-				operation,
-				outcome,
-				Date.now() - startedAt,
-			);
-		}
+		return observeUpstreamCall(this.metrics.recorder, operation, call);
 	}
 
 	private createStreamMetricsRecorder(): MetricsRecorder {
@@ -714,6 +699,7 @@ export class ThoughtSpotService {
 			privileges: info.privileges,
 			enableSpotterDataSourceDiscovery:
 				info.configInfo?.enableSpotterDataSourceDiscovery,
+			orgsEnabled: info.configInfo?.orgsConfiguration?.enabled,
 		};
 	}
 

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -4,6 +4,20 @@ export interface DataSource {
 	description: string;
 }
 
+// Error from a ThoughtSpot HTTP call, carrying the numeric status so callers can
+// branch on it (e.g. 401/403 = no access) instead of parsing message strings.
+// The response body is kept off `message` so it can't leak into logs/responses.
+export class ThoughtSpotApiError extends Error {
+	constructor(
+		readonly status: number,
+		operation: string,
+		readonly body?: string,
+	) {
+		super(`${operation} failed with status ${status}`);
+		this.name = "ThoughtSpotApiError";
+	}
+}
+
 export interface DataSourceSuggestion {
 	confidence: number;
 	header: {
@@ -18,6 +32,12 @@ export interface DataSourceSuggestionResponse {
 	dataSources: DataSourceSuggestion[];
 }
 
+export interface Org {
+	id: number;
+	name: string;
+	description?: string;
+}
+
 export interface SessionInfo {
 	mixpanelToken: string;
 	userGUID: string;
@@ -28,6 +48,9 @@ export interface SessionInfo {
 	currentOrgId: string;
 	privileges: any;
 	enableSpotterDataSourceDiscovery?: boolean;
+	// Whether Orgs are enabled on this cluster (configInfo.orgsConfiguration.enabled).
+	// Gates the org tools (list_orgs/switch_org).
+	orgsEnabled?: boolean;
 }
 
 export interface BaseMessage {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,11 +3,16 @@ import {
 	type BaseProps,
 	McpServerError as PkgMcpServerError,
 } from "@thoughtspot/mcp-auth";
-import type { ApiVersionMode } from "./metrics/runtime/metric-types";
+import type { ApiVersionMode, AuthMode } from "./metrics/runtime/metric-types";
 import { getActiveSpan } from "./metrics/tracing/tracing-utils";
 
 export type Props = {
 	accessToken: string;
+	// From gettoken, for keep-warm refresh.
+	refreshToken?: string;
+	tokenCreatedTime?: number;
+	// Absolute epoch-ms expiry (despite the name).
+	tokenExpiryDuration?: number;
 	instanceUrl: string;
 	clientName: {
 		clientId: string;
@@ -17,6 +22,8 @@ export type Props = {
 	apiVersion?: string;
 	apiVersionMode?: ApiVersionMode;
 	apiRequestedVersion?: string;
+	// Auth method ("oauth" vs "bearer"/"token"); gates OAuth-only tools.
+	authMode?: AuthMode;
 };
 
 const DEFAULT_CLIENT_NAME = "Bearer Token client";

--- a/static/oauth-callback.js
+++ b/static/oauth-callback.js
@@ -18,7 +18,7 @@
         if (!base.pathname.endsWith('/')) {
             base.pathname += '/';
         }
-        const tokenUrl = new URL('callosum/v1/v2/auth/token/fetch?validity_time_in_sec=2592000', base.toString());
+        const tokenUrl = new URL('callosum/v1/session/v2/gettoken?refresh=true', base.toString());
         
         document.getElementById('status').textContent = 'Retrieving authentication token...';
         
@@ -76,11 +76,21 @@
                             // Case 1: tokenText is a quoted string
                             tokenData = { data: { token: parsed } };
                         } else if (parsed.data && parsed.data.token) {
-                            // Case 2: { data: { token: ... } }
-                            tokenData = { data: { token: parsed.data.token } };
+                            // Case 2: { data: { token, refreshToken?, ... } }
+                            tokenData = { data: {
+                                token: parsed.data.token,
+                                refreshToken: parsed.data.refreshToken,
+                                tokenCreatedTime: parsed.data.tokenCreatedTime,
+                                tokenExpiryDuration: parsed.data.tokenExpiryDuration,
+                            } };
                         } else if (parsed.token) {
-                            // Case 3: { token: ... }
-                            tokenData = { data: { token: parsed.token } };
+                            // Case 3: { token, refreshToken?, ... }
+                            tokenData = { data: {
+                                token: parsed.token,
+                                refreshToken: parsed.refreshToken,
+                                tokenCreatedTime: parsed.tokenCreatedTime,
+                                tokenExpiryDuration: parsed.tokenExpiryDuration,
+                            } };
                         } else {
                             throw new Error('Unrecognized token format.');
                         }
@@ -130,7 +140,23 @@
             }
         }
         
-        const data = await response.json();
+        const raw = await response.json();
+        // gettoken returns the access token + refreshToken + timestamps. Normalize
+        // to the { data: { token, ... } } shape /store-token expects.
+        const src = (raw && raw.data) ? raw.data : raw;
+        if (!src || !src.token) {
+            // Fail loudly at login rather than storing an undefined token and
+            // failing opaquely on the first tool call.
+            throw new Error('Authentication response did not contain a token.');
+        }
+        const data = {
+            data: {
+                token: src.token,
+                refreshToken: src.refreshToken,
+                tokenCreatedTime: src.tokenCreatedTime,
+                tokenExpiryDuration: src.tokenExpiryDuration,
+            },
+        };
         document.getElementById('status').textContent = 'Authentication successful. Securing your session...';
 
         // Send the token to the server

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,9 @@
-import { createExecutionContext, env } from "cloudflare:test";
+import {
+	createExecutionContext,
+	env,
+	runInDurableObject,
+	waitOnExecutionContext,
+} from "cloudflare:test";
 import { describe, expect, it, vi } from "vitest";
 
 // For now, you'll need to do something like this to get a correctly-typed

--- a/test/servers/conversation-storage-server.spec.ts
+++ b/test/servers/conversation-storage-server.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConversationStorageServerSQLite } from "../../src/servers/conversation-storage-server";
 import type {
 	Message,
@@ -49,11 +49,13 @@ function createMockStorage() {
 					}
 				},
 			),
-			delete: vi.fn(async (keys: string[]): Promise<void> => {
+			delete: vi.fn(async (keyOrKeys: string | string[]): Promise<void> => {
+				const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
 				for (const key of keys) {
 					store.delete(key);
 				}
 			}),
+			getAlarm: vi.fn(async (): Promise<number | null> => alarm),
 			setAlarm: vi.fn(async (scheduledTime: number): Promise<void> => {
 				alarm = scheduledTime;
 			}),

--- a/test/servers/mcp-server-base.spec.ts
+++ b/test/servers/mcp-server-base.spec.ts
@@ -73,6 +73,18 @@ class TestMCPServer extends MCPServer {
 	public async testGetStorageService() {
 		return this.getStorageService();
 	}
+
+	public async testGetStorageKeyHash() {
+		return this.getStorageKeyHash();
+	}
+
+	public testIsOrgsEnabled() {
+		return this.isOrgsEnabled();
+	}
+
+	public setSessionInfo(info: any) {
+		this.sessionInfo = info;
+	}
 }
 
 describe("MCP Server Base", () => {
@@ -418,7 +430,7 @@ describe("MCP Server Base", () => {
 				env: mockEnv,
 			});
 			await expect(serverWithNoToken.testGetStorageService()).rejects.toThrow(
-				"Access token is required to use Storage Service",
+				"A token is required to derive the storage key",
 			);
 		});
 
@@ -428,7 +440,7 @@ describe("MCP Server Base", () => {
 				env: mockEnv,
 			});
 			await expect(serverWithNoToken.testGetStorageService()).rejects.toThrow(
-				"Access token is required to use Storage Service",
+				"A token is required to derive the storage key",
 			);
 		});
 
@@ -505,6 +517,86 @@ describe("MCP Server Base", () => {
 			expect((service1 as any).accessTokenHashUrlSafe).toBe(
 				(service2 as any).accessTokenHashUrlSafe,
 			);
+		});
+	});
+
+	describe("getStorageKeyHash", () => {
+		async function sha256Base64Url(token: string): Promise<string> {
+			const buf = await crypto.subtle.digest(
+				"SHA-256",
+				new TextEncoder().encode(token),
+			);
+			return Buffer.from(new Uint8Array(buf)).toString("base64url");
+		}
+
+		it("prefers the refresh token when present (stable across access-token rotation)", async () => {
+			const s = new TestMCPServer({
+				props: {
+					...mockProps,
+					accessToken: "access-A",
+					refreshToken: "refresh-X",
+				},
+				env: mockEnv,
+			});
+			expect(await s.testGetStorageKeyHash()).toBe(
+				await sha256Base64Url("refresh-X"),
+			);
+		});
+
+		it("is stable when the access token rotates but refresh token is unchanged", async () => {
+			const s1 = new TestMCPServer({
+				props: { ...mockProps, accessToken: "access-A", refreshToken: "r" },
+				env: mockEnv,
+			});
+			const s2 = new TestMCPServer({
+				props: { ...mockProps, accessToken: "access-B", refreshToken: "r" },
+				env: mockEnv,
+			});
+			expect(await s1.testGetStorageKeyHash()).toBe(
+				await s2.testGetStorageKeyHash(),
+			);
+		});
+
+		it("falls back to the access token when no refresh token (bearer/token auth)", async () => {
+			const s = new TestMCPServer({
+				props: {
+					...mockProps,
+					accessToken: "access-only",
+					refreshToken: undefined,
+				},
+				env: mockEnv,
+			});
+			expect(await s.testGetStorageKeyHash()).toBe(
+				await sha256Base64Url("access-only"),
+			);
+		});
+
+		it("throws when neither token is present", async () => {
+			const s = new TestMCPServer({
+				props: { ...mockProps, accessToken: "", refreshToken: undefined },
+				env: mockEnv,
+			});
+			await expect(s.testGetStorageKeyHash()).rejects.toThrow(
+				"A token is required to derive the storage key",
+			);
+		});
+	});
+
+	describe("isOrgsEnabled", () => {
+		it("returns false when session info is not initialized (fail closed)", () => {
+			expect(server.testIsOrgsEnabled()).toBe(false);
+		});
+
+		it("returns true when orgsEnabled is true", () => {
+			server.setSessionInfo({ orgsEnabled: true });
+			expect(server.testIsOrgsEnabled()).toBe(true);
+		});
+
+		it("returns false when orgsEnabled is false or absent", () => {
+			server.setSessionInfo({ orgsEnabled: false });
+			expect(server.testIsOrgsEnabled()).toBe(false);
+			server.setSessionInfo({});
+			expect(server.testIsOrgsEnabled()).toBe(false);
 		});
 	});
 

--- a/test/servers/mcp-server-orgs.spec.ts
+++ b/test/servers/mcp-server-orgs.spec.ts
@@ -1,0 +1,1227 @@
+import { connect } from "mcp-testing-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPServer } from "../../src/servers/mcp-server";
+import * as thoughtspotClient from "../../src/thoughtspot/thoughtspot-client";
+import { ThoughtSpotApiError } from "../../src/thoughtspot/types";
+
+vi.mock("../../src/metrics/mixpanel/mixpanel", () => ({
+	MixpanelTracker: vi.fn().mockImplementation(() => ({ track: vi.fn() })),
+}));
+
+/**
+ * Tests for the org tools (list_orgs / switch_org) and their supporting
+ * machinery: the OAuth + orgs-enabled gate, the shared active-org store, and
+ * org-scoped token minting.
+ */
+
+// A fake CONVERSATION_STORAGE_OBJECT namespace that emulates the active-org DO.
+// Stores active-org values in a Map keyed by the DO instance name, so reads and
+// writes from any server instance sharing the same storage-key hash see the same
+// value (mirroring the real shared store).
+// `store` maps DO instance name -> { activeOrgId, orgToken } (mirrors the real
+// shared active-org record). Setting the active org clears the token; a separate
+// active-org-token POST sets it.
+function makeStorageNamespace(
+	store: Map<string, { activeOrgId?: string; orgToken?: string }>,
+	tokenStore?: Map<string, any>,
+	touchLog?: string[],
+) {
+	return {
+		idFromName: (name: string) => ({ name }),
+		get: (id: { name: string }) => ({
+			fetch: async (url: string, init?: RequestInit) => {
+				const op = new URL(url).pathname.split("/").pop();
+				const rec = store.get(id.name) ?? {};
+				if (op === "active-org" && (init?.method ?? "GET") === "GET") {
+					return Response.json({
+						activeOrgId: rec.activeOrgId ?? null,
+						orgToken: rec.orgToken ?? null,
+					});
+				}
+				if (op === "active-org" && init?.method === "POST") {
+					const body = JSON.parse(String(init?.body)) as {
+						activeOrgId: string;
+						orgToken?: string | null;
+					};
+					// Mirror the real DO (F3): commit id+token atomically when a token
+					// is given; otherwise clear the token ONLY on an actual org change.
+					if (body.orgToken) {
+						store.set(id.name, {
+							activeOrgId: body.activeOrgId,
+							orgToken: body.orgToken,
+						});
+					} else {
+						const changed = rec.activeOrgId !== body.activeOrgId;
+						store.set(id.name, {
+							activeOrgId: body.activeOrgId,
+							orgToken: changed ? undefined : rec.orgToken,
+						});
+					}
+					return Response.json({ ok: true });
+				}
+				if (op === "active-org-token" && init?.method === "POST") {
+					const body = JSON.parse(String(init?.body)) as { orgToken: string };
+					store.set(id.name, { ...rec, orgToken: body.orgToken });
+					return Response.json({ ok: true });
+				}
+				if (op === "token-store" && (init?.method ?? "GET") === "GET") {
+					const s = tokenStore?.get(id.name);
+					return Response.json({
+						accessToken: s?.accessToken ?? null,
+						expiresAt: s?.expiresAt ?? null,
+					});
+				}
+				if (op === "token-store" && init?.method === "POST") {
+					tokenStore?.set(id.name, JSON.parse(String(init?.body)));
+					return Response.json({ ok: true });
+				}
+				if (op === "touch" && init?.method === "POST") {
+					touchLog?.push(id.name);
+					return Response.json({ ok: true });
+				}
+				return new Response("Not Found", { status: 404 });
+			},
+		}),
+	};
+}
+
+type SessionInfoOverrides = {
+	orgsEnabled?: boolean;
+	currentOrgId?: string;
+};
+
+function makeClientMock(opts: {
+	session?: SessionInfoOverrides;
+	orgs?: Array<{ id: number; name: string; status: string }>;
+	fetchOrgBearerToken?: ReturnType<typeof vi.fn>;
+	searchOrgs?: ReturnType<typeof vi.fn>;
+	listOrgs?: ReturnType<typeof vi.fn>;
+	validateConnection?: ReturnType<typeof vi.fn>;
+}) {
+	const orgsConfiguration =
+		opts.session?.orgsEnabled === undefined
+			? undefined
+			: { enabled: opts.session.orgsEnabled };
+	return {
+		getSessionInfo: vi.fn().mockResolvedValue({
+			clusterId: "test-cluster-123",
+			clusterName: "test-cluster",
+			releaseVersion: "10.13.0.cl-110",
+			userGUID: "test-user-123",
+			userName: "test-user",
+			currentOrgId: opts.session?.currentOrgId ?? "0",
+			privileges: [],
+			configInfo: {
+				mixpanelConfig: {
+					devSdkKey: "k",
+					prodSdkKey: "k",
+					production: false,
+				},
+				selfClusterName: "test-cluster",
+				selfClusterId: "test-cluster-123",
+				enableSpotterDataSourceDiscovery: false,
+				orgsConfiguration,
+			},
+		}),
+		searchOrgs:
+			opts.searchOrgs ??
+			vi.fn().mockResolvedValue(
+				opts.orgs ?? [
+					{ id: 0, name: "Primary", status: "ACTIVE", description: "Primary" },
+					{ id: 101, name: "DataPlatform", status: "ACTIVE" },
+				],
+			),
+		// list_orgs uses the user-scoped client.listOrgs() (v1 session/orgs),
+		// returning already-mapped Org[] ({ id, name, description }).
+		listOrgs:
+			opts.listOrgs ??
+			vi.fn().mockResolvedValue(
+				opts.orgs ?? [
+					{ id: 0, name: "Primary", description: "Primary" },
+					{ id: 101, name: "DataPlatform" },
+				],
+			),
+		fetchOrgBearerToken:
+			opts.fetchOrgBearerToken ?? vi.fn().mockResolvedValue("org-scoped-token"),
+		validateConnection:
+			opts.validateConnection ?? vi.fn().mockResolvedValue(true),
+		instanceUrl: "https://test.thoughtspot.cloud",
+	} as any;
+}
+
+function makeServer(opts: {
+	authMode?: string;
+	session?: SessionInfoOverrides;
+	orgs?: Array<{ id: number; name: string; status: string }>;
+	store?: Map<string, { activeOrgId?: string; orgToken?: string }>;
+	tokenStore?: Map<string, any>;
+	fetchOrgBearerToken?: ReturnType<typeof vi.fn>;
+	searchOrgs?: ReturnType<typeof vi.fn>;
+	listOrgs?: ReturnType<typeof vi.fn>;
+	validateConnection?: ReturnType<typeof vi.fn>;
+	touchLog?: string[];
+	apiVersion?: string;
+}) {
+	vi.spyOn(thoughtspotClient, "getThoughtSpotClient").mockReturnValue(
+		makeClientMock(opts),
+	);
+	const store =
+		opts.store ??
+		new Map<string, { activeOrgId?: string; orgToken?: string }>();
+	const tokenStore = opts.tokenStore ?? new Map<string, any>();
+	// The token/org methods now route to USER_TOKEN_OBJECT; conversation methods
+	// to CONVERSATION_STORAGE_OBJECT. The fake namespace dispatches by path, so a
+	// single shared instance backs both bindings in tests.
+	const namespace = makeStorageNamespace(store, tokenStore, opts.touchLog);
+	const env = {
+		CONVERSATION_STORAGE_OBJECT: namespace,
+		USER_TOKEN_OBJECT: namespace,
+	} as any;
+	const props = {
+		instanceUrl: "https://test.thoughtspot.cloud",
+		accessToken: "global-token",
+		refreshToken: "refresh-token",
+		tokenExpiryDuration: 1893456000000,
+		authMode: opts.authMode,
+		apiVersion: opts.apiVersion ?? "latest",
+		clientName: {
+			clientId: "c",
+			clientName: "c",
+			registrationDate: 0,
+		},
+	};
+	return { server: new MCPServer({ props, env }), store, tokenStore };
+}
+
+describe("MCP Server org tools", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("tool visibility gate (OAuth AND orgs enabled)", () => {
+		it("lists org tools when OAuth and orgs enabled", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+			});
+			await server.init();
+			const { listTools } = connect(server);
+			const names = (await listTools()).tools?.map((t) => t.name) ?? [];
+			expect(names).toContain("list_orgs");
+			expect(names).toContain("switch_org");
+		});
+
+		it("hides org tools when orgs are not enabled on the cluster", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: false },
+			});
+			await server.init();
+			const { listTools } = connect(server);
+			const names = (await listTools()).tools?.map((t) => t.name) ?? [];
+			expect(names).not.toContain("list_orgs");
+			expect(names).not.toContain("switch_org");
+		});
+
+		it("hides org tools for non-OAuth (bearer) connections even if orgs enabled", async () => {
+			const { server } = makeServer({
+				authMode: "bearer",
+				session: { orgsEnabled: true },
+			});
+			await server.init();
+			const { listTools } = connect(server);
+			const names = (await listTools()).tools?.map((t) => t.name) ?? [];
+			expect(names).not.toContain("list_orgs");
+			expect(names).not.toContain("switch_org");
+		});
+
+		it("hides org tools on the v1 (backwards-compatibility) API surface, even with OAuth + orgs enabled", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				apiVersion: "backwards-compatibility-default",
+			});
+			await server.init();
+			const { listTools } = connect(server);
+			const names = (await listTools()).tools?.map((t) => t.name) ?? [];
+			expect(names).not.toContain("list_orgs");
+			expect(names).not.toContain("switch_org");
+		});
+
+		it("does NOT apply the org overlay (no active org / no mint) on a v1 session", async () => {
+			const mint = vi.fn().mockResolvedValue("org-scoped-token");
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				apiVersion: "backwards-compatibility-default",
+				fetchOrgBearerToken: mint,
+				store,
+			});
+			await server.init();
+			// v1 session: no active org defaulted, no org token minted.
+			expect(mint).not.toHaveBeenCalled();
+			expect([...store.values()].some((r) => r.activeOrgId)).toBe(false);
+		});
+
+		it("fails closed: hides org tools when orgs-enabled flag is absent", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: {}, // orgsConfiguration undefined
+			});
+			await server.init();
+			const { listTools } = connect(server);
+			const names = (await listTools()).tools?.map((t) => t.name) ?? [];
+			expect(names).not.toContain("list_orgs");
+			expect(names).not.toContain("switch_org");
+		});
+	});
+
+	describe("non-org cluster (orgs disabled): no org overlay on connect", () => {
+		it("does NOT mint an org token or set an active org when orgs are disabled", async () => {
+			const mint = vi.fn().mockResolvedValue("org-scoped-token");
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: false, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+			// postInit must skip the org overlay entirely: no mint, no active-org write,
+			// and getActiveOrgId stays undefined (so no x-thoughtspot-orgs header).
+			expect(mint).not.toHaveBeenCalled();
+			expect(store.size).toBe(0);
+			expect((server as any).getActiveOrgId()).toBeUndefined();
+		});
+
+		it("still seeds the cluster-wide keep-warm token when orgs are disabled", async () => {
+			const tokenStore = new Map<string, any>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: false },
+				tokenStore,
+			});
+			await server.init();
+			// The global token is org-agnostic and must still be seeded/kept warm.
+			const seeded = [...tokenStore.values()][0];
+			expect(seeded?.accessToken).toBe("global-token");
+		});
+	});
+
+	describe("list_orgs", () => {
+		it("returns ACTIVE orgs and marks the current org active when none switched", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+			});
+			await server.init();
+			const { callTool } = connect(server);
+			const res = await callTool("list_orgs", {});
+			const data = JSON.parse(res.content[0].text);
+			expect(data.orgs.map((o: any) => o.id)).toEqual([0, 101]);
+			// On first connect the active org defaults to the session's current org
+			// (currentOrgId "0"), so that org is marked active.
+			expect(data.orgs.find((o: any) => o.is_active).id).toBe(0);
+		});
+
+		it("uses the GLOBAL token with no org header (not the org-scoped token)", async () => {
+			// Listing orgs is a cluster-level operation: it must authenticate with the
+			// global token and send NO x-thoughtspot-orgs header, even when an org is
+			// active. An org-scoped token can fail/under-report when enumerating orgs.
+			// (Driven directly rather than via connect().callTool, which deadlocks in
+			// mcp-testing-kit when a switch_org and a second tool call share a test.)
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+			});
+			await server.init();
+			const s = server as unknown as {
+				setActiveOrg: (orgId: string) => Promise<void>;
+				ensureOrgToken: (orgId: string) => Promise<string>;
+				callListOrgs: (recorder: any) => Promise<any>;
+			};
+			// Put an org token in play (the thing list_orgs must NOT use).
+			await s.setActiveOrg("101");
+			await s.ensureOrgToken("101");
+
+			const spy = vi.mocked(thoughtspotClient.getThoughtSpotClient);
+			spy.mockClear();
+			await s.callListOrgs(undefined);
+
+			// Every getThoughtSpotClient call made while serving list_orgs must use the
+			// global token ("global-token") and pass orgId undefined (no org header).
+			expect(spy).toHaveBeenCalled();
+			for (const call of spy.mock.calls) {
+				expect(call[1]).toBe("global-token"); // bearerToken arg
+				expect(call[2]).toBeUndefined(); // orgId arg
+			}
+		});
+
+		it("rejects direct invocation when org tools are unavailable", async () => {
+			const { server } = makeServer({
+				authMode: "bearer",
+				session: { orgsEnabled: true },
+			});
+			await server.init();
+			const { callTool } = connect(server);
+			const res = await callTool("list_orgs", {});
+			expect(res.isError).toBe(true);
+		});
+	});
+
+	describe("switch_org", () => {
+		it("mints an org token and persists the active org to the shared store", async () => {
+			const { server, store } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+			});
+			await server.init();
+
+			const switchRes = await connect(server).callTool("switch_org", {
+				org_id: 101,
+			});
+			const switchData = JSON.parse(switchRes.content[0].text);
+			expect(switchData.success).toBe(true);
+			expect(switchData.active_org_id).toBe(101);
+			// Persisted to the shared store: active org id AND the minted org token
+			// (so other fanned-out sessions reuse it instead of re-minting).
+			const rec = [...store.values()][0];
+			expect(rec.activeOrgId).toBe("101");
+			expect(rec.orgToken).toBe("org-scoped-token");
+		});
+
+		it("returns 'not accessible' when minting the org token 401s", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				fetchOrgBearerToken: vi
+					.fn()
+					.mockRejectedValue(
+						new Error("fetchOrgBearerToken failed with status 401: nope"),
+					),
+			});
+			await server.init();
+			const { callTool } = connect(server);
+			const res = await callTool("switch_org", { org_id: 999 });
+			expect(res.isError).toBe(true);
+			expect(res.content[0].text).toMatch(/do not have access/i);
+		});
+
+		it("returns 'not accessible' when minting the org token 403s (no access)", async () => {
+			// Access-denied commonly surfaces as 403, not 401 — same "no access"
+			// guidance. Uses the real typed error to exercise status-based detection.
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				fetchOrgBearerToken: vi
+					.fn()
+					.mockRejectedValue(
+						new ThoughtSpotApiError(403, "fetchOrgBearerToken", "forbidden"),
+					),
+			});
+			await server.init();
+			const { callTool } = connect(server);
+			const res = await callTool("switch_org", { org_id: 999 });
+			expect(res.isError).toBe(true);
+			expect(res.content[0].text).toMatch(/do not have access/i);
+		});
+
+		it("a wrong/invalid org_id (400) is a NO-OP: active org is unchanged", async () => {
+			// mint-first: a bad org_id fails the mint (400) BEFORE we commit, so the
+			// shared active org must NOT move to the bogus org (important for fan-out:
+			// one session's bad switch must not corrupt every session's active org).
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			// First mint (postInit default → org 0) succeeds; the switch mint 400s.
+			const mint = vi
+				.fn()
+				.mockResolvedValueOnce("org-0-token")
+				.mockRejectedValue(
+					new ThoughtSpotApiError(400, "fetchOrgBearerToken", "bad org"),
+				);
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+			const before = { ...[...store.values()][0] };
+			expect(before.activeOrgId).toBe("0");
+
+			const res = await connect(server).callTool("switch_org", { org_id: 999 });
+			expect(res.isError).toBe(true);
+			expect(res.content[0].text).toMatch(/do not have access|does not exist/i);
+			// Active org untouched — still org 0 with its token.
+			const after = [...store.values()][0];
+			expect(after.activeOrgId).toBe("0");
+			expect(after.orgToken).toBe(before.orgToken);
+		});
+	});
+
+	describe("shared active-org store persists across server instances", () => {
+		it("a switch in one instance is visible to another instance with the same token", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const a = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				store,
+			});
+			await a.server.init();
+			await connect(a.server).callTool("switch_org", { org_id: 101 });
+
+			// Second server instance (e.g. a different MCP session/DO) sharing the
+			// same store + token.
+			const b = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				store,
+			});
+			await b.server.init();
+			const listRes = await connect(b.server).callTool("list_orgs", {});
+			const listData = JSON.parse(listRes.content[0].text);
+			expect(listData.orgs.find((o: any) => o.is_active).id).toBe(101);
+		});
+
+		it("mints the org token ONCE and reuses it across fanned-out instances", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const mint = vi.fn().mockResolvedValue("org-scoped-token");
+
+			// First instance connects + switches -> mints once, persists to store.
+			const a = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				store,
+				fetchOrgBearerToken: mint,
+			});
+			await a.server.init();
+			await connect(a.server).callTool("switch_org", { org_id: 101 });
+			const mintsAfterSwitch = mint.mock.calls.length;
+			expect(mintsAfterSwitch).toBeGreaterThan(0);
+
+			// Subsequent fanned-out instances (new DOs) sharing the same store must
+			// reuse the stored token, NOT re-mint — this is the whole point of moving
+			// the org token into the shared store.
+			for (let i = 0; i < 3; i++) {
+				const b = makeServer({
+					authMode: "oauth",
+					session: { orgsEnabled: true },
+					store,
+					fetchOrgBearerToken: mint,
+				});
+				await b.server.init();
+			}
+			expect(mint.mock.calls.length).toBe(mintsAfterSwitch);
+		});
+	});
+
+	describe("keep-warm token store", () => {
+		it("seeds the token store from props on first connect", async () => {
+			const tokenStore = new Map<string, any>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				tokenStore,
+			});
+			await server.init();
+			// The per-user instance now holds the seeded token + refresh token.
+			const seeded = [...tokenStore.values()][0];
+			expect(seeded.accessToken).toBe("global-token");
+			expect(seeded.refreshToken).toBe("refresh-token");
+			expect(seeded.expiresAt).toBe(1893456000000);
+		});
+
+		it("does not re-seed when the store already has a (refreshed) token", async () => {
+			const tokenStore = new Map<string, any>();
+			// Pre-populate as if the alarm already refreshed the token.
+			const a = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				tokenStore,
+			});
+			await a.server.init();
+			// Simulate an alarm refresh updating the stored token.
+			const key = [...tokenStore.keys()][0];
+			tokenStore.set(key, {
+				...tokenStore.get(key),
+				accessToken: "refreshed-token",
+			});
+
+			// A new connection should read the refreshed token, not overwrite it with
+			// the (stale) props token.
+			const b = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				tokenStore,
+			});
+			await b.server.init();
+			expect(tokenStore.get(key).accessToken).toBe("refreshed-token");
+		});
+
+		it("re-seeds from props when the stored token has EXPIRED (refresh chain died)", async () => {
+			const tokenStore = new Map<string, any>();
+			const a = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				tokenStore,
+			});
+			await a.server.init();
+			// Simulate the refresh chain having died: the stored token is now stale
+			// (expiresAt in the past), not merely absent.
+			const key = [...tokenStore.keys()][0];
+			tokenStore.set(key, {
+				...tokenStore.get(key),
+				accessToken: "expired-token",
+				expiresAt: Date.now() - 60_000,
+			});
+
+			// A new connect carries a fresh props token; it must re-seed (heal the
+			// chain) rather than trust the expired stored token.
+			const b = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				tokenStore,
+			});
+			await b.server.init();
+			expect(tokenStore.get(key).accessToken).toBe("global-token");
+		});
+	});
+
+	// These exercise withOrgTokenRetry / validateConnectionWithOrgRetry directly
+	// rather than through connect().callTool, which deadlocks in mcp-testing-kit
+	// when a tool handler throws-then-recovers within a single request. The retry
+	// machinery itself is server-internal, so driving it directly is both reliable
+	// and a tighter test of the recovery behavior.
+	describe("stale org token: reactive 401 re-mint", () => {
+		// Put the server into the "org 101 active with an org token" state by
+		// switching, then return the server cast to reach its protected helpers.
+		async function makeServerWithActiveOrg(opts: {
+			store: Map<string, { activeOrgId?: string; orgToken?: string }>;
+			mint: ReturnType<typeof vi.fn>;
+			validateConnection?: ReturnType<typeof vi.fn>;
+		}) {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store: opts.store,
+				fetchOrgBearerToken: opts.mint,
+				validateConnection: opts.validateConnection,
+			});
+			await server.init();
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			return server as unknown as {
+				withOrgTokenRetry: <T>(
+					recorder: undefined,
+					fn: (svc: any) => Promise<T>,
+				) => Promise<T>;
+				validateConnectionWithOrgRetry: (
+					recorder?: undefined,
+				) => Promise<boolean>;
+				getThoughtSpotService: (recorder?: undefined) => any;
+			};
+		}
+
+		it("re-mints the org token and retries when an org-scoped call 401s", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			// Each mint returns a uniquely-numbered token so we can identify the
+			// re-mint regardless of how many mints happened during connect/switch.
+			let mintN = 0;
+			const mint = vi
+				.fn()
+				.mockImplementation(async () => `org-token-${++mintN}`);
+			const server = await makeServerWithActiveOrg({ store, mint });
+			const tokenBefore = [...store.values()][0].orgToken;
+			const mintsBefore = mint.mock.calls.length;
+
+			// A call that 401s once then succeeds: the wrapper should clear+re-mint
+			// the org token and retry transparently.
+			let calls = 0;
+			const result = await server.withOrgTokenRetry(undefined, async () => {
+				calls++;
+				if (calls === 1) {
+					throw new Error("searchOrgs failed with status 401: token expired");
+				}
+				return ["recovered"];
+			});
+
+			expect(result).toEqual(["recovered"]);
+			expect(calls).toBe(2); // first 401, retry ok
+			expect(mint.mock.calls.length).toBe(mintsBefore + 1); // exactly one re-mint
+			// A fresh (different) token replaced the stale one in the shared store.
+			const tokenAfter = [...store.values()][0].orgToken;
+			expect(tokenAfter).not.toBe(tokenBefore);
+			expect(tokenAfter).toBe(`org-token-${mintN}`);
+		});
+
+		it("recovers when the 401 is swallowed into an { error } result", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const mint = vi
+				.fn()
+				.mockResolvedValueOnce("org-token-stale")
+				.mockResolvedValue("org-token-fresh");
+			const server = await makeServerWithActiveOrg({ store, mint });
+			const mintsBefore = mint.mock.calls.length;
+
+			let calls = 0;
+			const result = await server.withOrgTokenRetry(undefined, async () => {
+				calls++;
+				if (calls === 1) {
+					// Service methods that catch and return the failure instead of throwing.
+					return { error: { message: "failed with status 401: expired" } };
+				}
+				return { data: "ok" };
+			});
+
+			expect(result).toEqual({ data: "ok" });
+			expect(calls).toBe(2);
+			expect(mint.mock.calls.length).toBe(mintsBefore + 1);
+		});
+
+		it("does NOT re-mint when no org token is active (global-token 401 passes through)", async () => {
+			// No switch -> withOrgTokenRetry sees no active org token, so a 401 is
+			// about the global token and must pass straight through with no re-mint.
+			const mint = vi.fn().mockResolvedValue("org-scoped-token");
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: false, currentOrgId: "0" },
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+			const s = server as unknown as {
+				withOrgTokenRetry: <T>(
+					recorder: undefined,
+					fn: (svc: any) => Promise<T>,
+				) => Promise<T>;
+			};
+			const mintsBefore = mint.mock.calls.length;
+
+			await expect(
+				s.withOrgTokenRetry(undefined, async () => {
+					throw new Error("failed with status 401: token expired");
+				}),
+			).rejects.toThrow(/401/);
+			// No re-mint attempted.
+			expect(mint.mock.calls.length).toBe(mintsBefore);
+		});
+
+		it("re-mints + re-validates when validateConnection fails with an org token active", async () => {
+			// ThoughtSpotService.validateConnection() probes the cluster via
+			// getSessionInfo() and maps a throw -> false. So a stale-token failure
+			// surfaces as getSessionInfo throwing a 401. We let it succeed during
+			// connect/switch, then throw exactly once (the stale-token call), then
+			// succeed again after the re-mint.
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			let mintN = 0;
+			const mint = vi
+				.fn()
+				.mockImplementation(async () => `org-token-${++mintN}`);
+
+			let failNextSessionInfo = false;
+			const sessionInfo = {
+				clusterId: "c",
+				clusterName: "c",
+				releaseVersion: "10.13.0",
+				userGUID: "u",
+				userName: "u",
+				currentOrgId: "0",
+				privileges: [],
+				configInfo: {
+					mixpanelConfig: {
+						devSdkKey: "k",
+						prodSdkKey: "k",
+						production: false,
+					},
+					selfClusterName: "c",
+					selfClusterId: "c",
+					enableSpotterDataSourceDiscovery: false,
+					orgsConfiguration: { enabled: true },
+				},
+			};
+			const getSessionInfo = vi.fn().mockImplementation(async () => {
+				if (failNextSessionInfo) {
+					failNextSessionInfo = false; // fail exactly once
+					throw new Error("getSessionInfo failed with status 401: expired");
+				}
+				return sessionInfo;
+			});
+
+			// Build a client mock with our custom getSessionInfo + mint.
+			const client = {
+				getSessionInfo,
+				searchOrgs: vi.fn().mockResolvedValue([]),
+				fetchOrgBearerToken: mint,
+				instanceUrl: "https://test.thoughtspot.cloud",
+			} as any;
+			vi.spyOn(thoughtspotClient, "getThoughtSpotClient").mockReturnValue(
+				client,
+			);
+			const ns = makeStorageNamespace(store, new Map());
+			const env = {
+				CONVERSATION_STORAGE_OBJECT: ns,
+				USER_TOKEN_OBJECT: ns,
+			} as any;
+			const props = {
+				instanceUrl: "https://test.thoughtspot.cloud",
+				accessToken: "global-token",
+				refreshToken: "refresh-token",
+				authMode: "oauth",
+				apiVersion: "latest",
+				clientName: { clientId: "c", clientName: "c", registrationDate: 0 },
+			};
+			const server = new MCPServer({ props, env });
+			await server.init();
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			const s = server as unknown as {
+				validateConnectionWithOrgRetry: () => Promise<boolean>;
+			};
+			const mintsBefore = mint.mock.calls.length;
+			const sessionCallsBefore = getSessionInfo.mock.calls.length;
+
+			// Now make the next probe (the stale-token attempt) fail once.
+			failNextSessionInfo = true;
+			const ok = await s.validateConnectionWithOrgRetry();
+
+			expect(ok).toBe(true);
+			// Two probes: the failing one, then the post-re-mint success.
+			expect(getSessionInfo.mock.calls.length).toBe(sessionCallsBefore + 2);
+			expect(mint.mock.calls.length).toBe(mintsBefore + 1);
+		});
+
+		it("propagates the error and does not loop if the retry also 401s", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			let mintN = 0;
+			const mint = vi
+				.fn()
+				.mockImplementation(async () => `org-token-${++mintN}`);
+			const server = await makeServerWithActiveOrg({ store, mint });
+			const mintsBefore = mint.mock.calls.length;
+
+			// Always 401: re-mint happens once, the retry also 401s, and the error is
+			// surfaced (exactly two attempts, not an infinite loop).
+			let calls = 0;
+			await expect(
+				server.withOrgTokenRetry(undefined, async () => {
+					calls++;
+					throw new Error("failed with status 401: still expired");
+				}),
+			).rejects.toThrow(/401/);
+			expect(calls).toBe(2); // initial + one retry only
+			expect(mint.mock.calls.length).toBe(mintsBefore + 1); // one re-mint only
+		});
+
+		it("passes a non-401 error straight through without re-minting", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			let mintN = 0;
+			const mint = vi
+				.fn()
+				.mockImplementation(async () => `org-token-${++mintN}`);
+			const server = await makeServerWithActiveOrg({ store, mint });
+			const mintsBefore = mint.mock.calls.length;
+
+			let calls = 0;
+			await expect(
+				server.withOrgTokenRetry(undefined, async () => {
+					calls++;
+					throw new Error("failed with status 500: server error");
+				}),
+			).rejects.toThrow(/500/);
+			expect(calls).toBe(1); // no retry for non-401
+			expect(mint.mock.calls.length).toBe(mintsBefore); // no re-mint
+		});
+
+		it("does not treat a successful non-error result as unauthorized", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			let mintN = 0;
+			const mint = vi
+				.fn()
+				.mockImplementation(async () => `org-token-${++mintN}`);
+			const server = await makeServerWithActiveOrg({ store, mint });
+			const mintsBefore = mint.mock.calls.length;
+
+			// A normal result that merely contains "401" in unrelated data must not
+			// trigger a re-mint — only an { error } shape or a thrown 401 does.
+			let calls = 0;
+			const result = await server.withOrgTokenRetry(undefined, async () => {
+				calls++;
+				return { rows: [{ value: "401 Main St" }] };
+			});
+			expect(result).toEqual({ rows: [{ value: "401 Main St" }] });
+			expect(calls).toBe(1);
+			expect(mint.mock.calls.length).toBe(mintsBefore);
+		});
+
+		it("does not re-mint on a thrown error whose message contains 401 outside the status form", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			let mintN = 0;
+			const mint = vi
+				.fn()
+				.mockImplementation(async () => `org-token-${++mintN}`);
+			const server = await makeServerWithActiveOrg({ store, mint });
+			const mintsBefore = mint.mock.calls.length;
+
+			// "401" appears (e.g. a datasource id / title), but NOT as "status 401".
+			// This must NOT be misread as an auth failure — no re-mint, error passes
+			// through. (Guards against the old over-broad \b401\b match.)
+			let calls = 0;
+			await expect(
+				server.withOrgTokenRetry(undefined, async () => {
+					calls++;
+					throw new Error("datasource 401 not found (status 404)");
+				}),
+			).rejects.toThrow(/401 not found/);
+			expect(calls).toBe(1); // no retry
+			expect(mint.mock.calls.length).toBe(mintsBefore); // no re-mint
+		});
+	});
+
+	describe("idle-activity tracking on tool calls", () => {
+		// touchLastSeen is fire-and-forget; flush the microtask queue so the
+		// POST /touch lands before we assert.
+		const flush = () => new Promise((r) => setTimeout(r, 0));
+
+		it("records activity (POST /touch) on a tool call for OAuth sessions", async () => {
+			const touchLog: string[] = [];
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				touchLog,
+			});
+			await server.init();
+			await connect(server).callTool("ping", {});
+			await flush();
+			expect(touchLog.length).toBeGreaterThan(0);
+		});
+
+		it("does NOT record activity for non-OAuth (bearer) sessions", async () => {
+			const touchLog: string[] = [];
+			const { server } = makeServer({
+				authMode: "bearer",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				touchLog,
+			});
+			await server.init();
+			await connect(server).callTool("ping", {});
+			await flush();
+			expect(touchLog.length).toBe(0);
+		});
+	});
+
+	// Org isolation on data calls: an active org must always use its org-scoped
+	// token + header; the global token must never authenticate a data call.
+	describe("data-call org isolation (never the global token)", () => {
+		// Build an OAuth+orgs server already switched into org 101, returning the
+		// server plus the getThoughtSpotClient spy for asserting outbound (bearer,
+		// orgId) pairs.
+		async function serverInOrg(
+			store = new Map<string, { activeOrgId?: string; orgToken?: string }>(),
+			mint = vi.fn().mockResolvedValue("org-101-token"),
+		) {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			const spy = vi.mocked(thoughtspotClient.getThoughtSpotClient);
+			return { server: server as any, store, mint, spy };
+		}
+
+		// A1: an org-active data path builds its client with the org token + header.
+		it("uses the org-scoped token and org id (header) on a data call", async () => {
+			const { server, spy } = await serverInOrg();
+			spy.mockClear();
+			await server.withOrgTokenRetry(undefined, async () => ["ok"]);
+			// Every client built for the data call carried the org token + org id.
+			expect(spy.mock.calls.length).toBeGreaterThan(0);
+			for (const call of spy.mock.calls) {
+				expect(call[1]).toBe("org-101-token"); // bearer = org token, not global
+				expect(call[2]).toBe("101"); // x-thoughtspot-orgs header value
+			}
+		});
+
+		// A2: fail-closed — org active but no token cached => throw, never global.
+		it("throws (never falls back to global) if the org token is missing", async () => {
+			const { server } = await serverInOrg();
+			// Simulate the token being gone from memory (e.g. mid-remint window)
+			// while the active org id remains set.
+			server.activeOrgToken = undefined;
+			expect(() => server.getActiveBearerToken()).toThrow(
+				/token is not minted/,
+			);
+		});
+
+		// A_new: callTool mints the org token up front so unwrapped data paths have
+		// it — verified by the store holding a token before any data tool runs.
+		it("mints the org token up front on a data tool call", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			// Fresh instance sharing the store, but with no in-memory token yet.
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: vi.fn().mockResolvedValue("org-101-token"),
+			});
+			await server.init();
+			// Seed only the active org id (no token) into the shared store.
+			store.set([...store.keys()][0] ?? "x", {});
+			const s = server as any;
+			s.activeOrgId = "101";
+			s.activeOrgToken = undefined;
+			expect(s.getActiveOrgId()).toBe("101");
+			// Ensuring the token is what callTool does before dispatching a data tool.
+			await s.ensureOrgToken("101", undefined);
+			expect(s.activeOrgToken).toBe("org-101-token");
+			expect(() => s.getActiveBearerToken()).not.toThrow();
+		});
+
+		// list_orgs / mint still use the global token, header-less.
+		it("switch_org mint uses the global token with no org header", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+			});
+			await server.init();
+			const spy = vi.mocked(thoughtspotClient.getThoughtSpotClient);
+			spy.mockClear();
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			// The mint client is built global-token + no org id.
+			const mintClient = spy.mock.calls.find((c) => c[1] === "global-token");
+			expect(mintClient).toBeDefined();
+			expect(mintClient?.[2]).toBeUndefined();
+		});
+	});
+
+	// F2(a): re-mint mints first, then overwrites atomically — the shared store is
+	// never observed without a token, so concurrent siblings can't read a
+	// tokenless active org.
+	describe("re-mint is mint-first (store never tokenless)", () => {
+		it("keeps the old token in the store until the new one replaces it", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			let mintN = 0;
+			let assertStoreHasToken = false;
+			const mint = vi.fn().mockImplementation(async () => {
+				// On the RE-mint (not the initial switch) the store must still hold the
+				// previous token when the new one is being minted — never empty.
+				if (assertStoreHasToken) {
+					const rec = [...store.values()].find((r) => r.activeOrgId === "101");
+					expect(rec?.orgToken).toBeTruthy();
+				}
+				return `org-token-${++mintN}`;
+			});
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			const rec101 = () =>
+				[...store.values()].find((r) => r.activeOrgId === "101");
+			const before = rec101()?.orgToken;
+			expect(before).toBeTruthy();
+			assertStoreHasToken = true;
+			await (server as any).forceRemintOrgToken("101", undefined);
+			const after = rec101()?.orgToken;
+			expect(after).toBeTruthy();
+			expect(after).not.toBe(before);
+		});
+
+		it("leaves the old token intact if the re-mint throws", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			let failNext = false;
+			const mint = vi.fn().mockImplementation(async () => {
+				if (failNext) throw new Error("mint failed with status 500");
+				return "org-101-token";
+			});
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			const rec101 = () =>
+				[...store.values()].find((r) => r.activeOrgId === "101");
+			const before = rec101()?.orgToken;
+			expect(before).toBeTruthy();
+			failNext = true; // the re-mint will throw
+			await expect(
+				(server as any).forceRemintOrgToken("101", undefined),
+			).rejects.toThrow();
+			// The store still holds the prior valid token — not cleared.
+			expect(rec101()?.orgToken).toBe(before);
+		});
+	});
+
+	// Fan-out consistency across separate server instances sharing one store.
+	describe("fan-out consistency", () => {
+		// F1: a switch in instance A is seen by instance B's next call.
+		it("B sees A's switch on its next tool call (per-request reload)", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const a = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+			});
+			const b = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+			});
+			await a.server.init();
+			await b.server.init();
+			await connect(a.server).callTool("switch_org", { org_id: 101 });
+			const listRes = await connect(b.server).callTool("list_orgs", {});
+			const parsed = JSON.parse((listRes as any).content[0].text);
+			const active = parsed.orgs.find((o: any) => o.is_active);
+			expect(String(active.id)).toBe("101");
+		});
+
+		// E13: two sequential switches to different orgs — last write wins.
+		it("last-write-wins across concurrent switches to different orgs", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const a = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+			});
+			const b = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+			});
+			await a.server.init();
+			await b.server.init();
+			await connect(a.server).callTool("switch_org", { org_id: 101 });
+			await connect(b.server).callTool("switch_org", { org_id: 0 });
+			// B committed last → the shared store reflects org 0.
+			expect([...store.values()][0].activeOrgId).toBe("0");
+		});
+
+		// F4: datasource cache refetches after the active org changes.
+		it("refetches datasources after an org switch (org-tagged cache)", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+			});
+			await server.init();
+			const s = server as any;
+			let fetches = 0;
+			s.getThoughtSpotService = () => ({
+				getDataSources: async () => {
+					fetches++;
+					return [{ id: `ds-${s.getActiveOrgId()}`, name: "x" }];
+				},
+			});
+			s.activeOrgId = "0";
+			await s.getDatasources();
+			await s.getDatasources(); // same org → cached
+			expect(fetches).toBe(1);
+			s.activeOrgId = "101"; // org changed
+			await s.getDatasources(); // must refetch
+			expect(fetches).toBe(2);
+		});
+	});
+
+	// T3: the global token is re-read from the store before minting/listing, so a
+	// long-lived instance picks up an alarm-rotated token.
+	describe("global token freshness (T3)", () => {
+		it("re-reads the store's refreshed token before minting", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const tokenStore = new Map<string, any>();
+			const mint = vi.fn().mockResolvedValue("org-101-token");
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				tokenStore,
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+			// The alarm rotated the store's global token after connect.
+			const key = [...tokenStore.keys()][0];
+			tokenStore.set(key, {
+				accessToken: "rotated-global",
+				expiresAt: 1893456000000,
+			});
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			// The mint used the rotated token, not the connect-time "global-token".
+			const spy = vi.mocked(thoughtspotClient.getThoughtSpotClient);
+			const mintClient = spy.mock.calls.find((c) => c[1] === "rotated-global");
+			expect(mintClient).toBeDefined();
+		});
+	});
+});

--- a/test/servers/mcp-server-orgs.spec.ts
+++ b/test/servers/mcp-server-orgs.spec.ts
@@ -314,6 +314,44 @@ describe("MCP Server org tools", () => {
 			expect(mint).not.toHaveBeenCalled();
 			expect([...store.values()].some((r) => r.activeOrgId)).toBe(false);
 		});
+
+		// Org selection is user-aware (shared among re-authed sessions) but must NOT
+		// leak into a still-legacy session: an old grant keeps working as-is until it
+		// re-authenticates, regardless of a switch elsewhere.
+		it("an old-grant session ignores an org switch made by a new session (uses its login token)", async () => {
+			// A new session records a switch into the shared store.
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const neu = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: vi.fn().mockResolvedValue("org-101-token"),
+			});
+			await neu.server.init();
+			await connect(neu.server).callTool("switch_org", { org_id: 101 });
+			expect([...store.values()].some((r) => r.activeOrgId === "101")).toBe(
+				true,
+			);
+
+			// Old-grant session sharing the SAME store (worst case). It must not adopt
+			// the switch: no active org, and its bearer stays the login token.
+			const old = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				noRefreshToken: true,
+			});
+			await old.server.init();
+			const s = old.server as unknown as {
+				getActiveOrgId(): string | undefined;
+				getActiveBearerToken(): string;
+			};
+			expect(s.getActiveOrgId()).toBeUndefined();
+			expect(s.getActiveBearerToken()).toBe("global-token"); // login token, not the org token
+		});
 	});
 
 	describe("non-org cluster (orgs disabled): no org overlay on connect", () => {

--- a/test/servers/mcp-server-orgs.spec.ts
+++ b/test/servers/mcp-server-orgs.spec.ts
@@ -476,6 +476,20 @@ describe("MCP Server org tools", () => {
 			expect(rec.orgToken).toBe("org-scoped-token");
 		});
 
+		it("notifies the client to re-list resources on a successful switch (org-specific datasources)", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+			});
+			await server.init();
+			const notify = vi
+				.spyOn(server as any, "sendResourceListChanged")
+				.mockResolvedValue(undefined);
+
+			await connect(server).callTool("switch_org", { org_id: 101 });
+			expect(notify).toHaveBeenCalledTimes(1);
+		});
+
 		it("returns 'not accessible' when minting the org token 401s", async () => {
 			const { server } = makeServer({
 				authMode: "oauth",

--- a/test/servers/mcp-server-orgs.spec.ts
+++ b/test/servers/mcp-server-orgs.spec.ts
@@ -161,6 +161,7 @@ function makeServer(opts: {
 	validateConnection?: ReturnType<typeof vi.fn>;
 	touchLog?: string[];
 	apiVersion?: string;
+	noRefreshToken?: boolean;
 }) {
 	vi.spyOn(thoughtspotClient, "getThoughtSpotClient").mockReturnValue(
 		makeClientMock(opts),
@@ -180,7 +181,8 @@ function makeServer(opts: {
 	const props = {
 		instanceUrl: "https://test.thoughtspot.cloud",
 		accessToken: "global-token",
-		refreshToken: "refresh-token",
+		// Old (pre-multi-org) grants have no refresh token; noRefreshToken emulates one.
+		refreshToken: opts.noRefreshToken ? undefined : "refresh-token",
 		tokenExpiryDuration: 1893456000000,
 		authMode: opts.authMode,
 		apiVersion: opts.apiVersion ?? "latest",
@@ -277,6 +279,40 @@ describe("MCP Server org tools", () => {
 			const names = (await listTools()).tools?.map((t) => t.name) ?? [];
 			expect(names).not.toContain("list_orgs");
 			expect(names).not.toContain("switch_org");
+		});
+
+		// Backward compatibility: a grant minted before multi-org shipped has no
+		// refresh token. Such sessions must NOT see org tools until they re-auth.
+		it("hides org tools for a pre-multi-org grant (no refresh token) even with OAuth + orgs enabled", async () => {
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true },
+				noRefreshToken: true,
+			});
+			await server.init();
+			const { listTools } = connect(server);
+			const names = (await listTools()).tools?.map((t) => t.name) ?? [];
+			expect(names).not.toContain("list_orgs");
+			expect(names).not.toContain("switch_org");
+		});
+
+		it("applies NO org overlay (no active org / no mint) for a pre-multi-org grant", async () => {
+			const mint = vi.fn().mockResolvedValue("org-scoped-token");
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				noRefreshToken: true,
+				fetchOrgBearerToken: mint,
+				store,
+			});
+			await server.init();
+			// Old grant: no active org defaulted, no org token minted → old behavior.
+			expect(mint).not.toHaveBeenCalled();
+			expect([...store.values()].some((r) => r.activeOrgId)).toBe(false);
 		});
 	});
 

--- a/test/servers/mcp-server-orgs.spec.ts
+++ b/test/servers/mcp-server-orgs.spec.ts
@@ -545,6 +545,34 @@ describe("MCP Server org tools", () => {
 			expect(after.activeOrgId).toBe("0");
 			expect(after.orgToken).toBe(before.orgToken);
 		});
+
+		it("a non-4xx mint failure (5xx) returns a generic retry error, NOT 'no access', and is a no-op", async () => {
+			const store = new Map<
+				string,
+				{ activeOrgId?: string; orgToken?: string }
+			>();
+			const mint = vi
+				.fn()
+				.mockResolvedValueOnce("org-0-token")
+				.mockRejectedValue(
+					new ThoughtSpotApiError(500, "fetchOrgBearerToken", "server error"),
+				);
+			const { server } = makeServer({
+				authMode: "oauth",
+				session: { orgsEnabled: true, currentOrgId: "0" },
+				store,
+				fetchOrgBearerToken: mint,
+			});
+			await server.init();
+
+			const res = await connect(server).callTool("switch_org", { org_id: 101 });
+			expect(res.isError).toBe(true);
+			// Generic "try again" — must NOT claim the org is inaccessible on a 5xx.
+			expect(res.content[0].text).toMatch(/try again/i);
+			expect(res.content[0].text).not.toMatch(/do not have access/i);
+			// Still a no-op: active org unchanged.
+			expect([...store.values()][0].activeOrgId).toBe("0");
+		});
 	});
 
 	describe("shared active-org store persists across server instances", () => {

--- a/test/servers/user-token-store-server.spec.ts
+++ b/test/servers/user-token-store-server.spec.ts
@@ -1,0 +1,436 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UserTokenStoreSQLite } from "../../src/servers/user-token-store-server";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror the conversation-storage mock; this DO uses the same
+// DurableObjectState storage + alarm surface).
+// ---------------------------------------------------------------------------
+
+function createMockStorage() {
+	const store = new Map<string, unknown>();
+	let alarm: number | null = null;
+
+	return {
+		store,
+		get alarm() {
+			return alarm;
+		},
+		storage: {
+			get: vi.fn(
+				async <T>(
+					keyOrKeys: string | string[],
+				): Promise<T | undefined | Map<string, T>> => {
+					if (Array.isArray(keyOrKeys)) {
+						const result = new Map<string, T>();
+						for (const key of keyOrKeys) {
+							if (store.has(key)) {
+								result.set(key, store.get(key) as T);
+							}
+						}
+						return result;
+					}
+					return store.get(keyOrKeys) as T | undefined;
+				},
+			),
+			put: vi.fn(
+				async (
+					keyOrEntries: string | Record<string, unknown>,
+					value?: unknown,
+				): Promise<void> => {
+					if (typeof keyOrEntries === "string") {
+						store.set(keyOrEntries, value);
+					} else {
+						for (const [k, v] of Object.entries(keyOrEntries)) {
+							store.set(k, v);
+						}
+					}
+				},
+			),
+			delete: vi.fn(async (keyOrKeys: string | string[]): Promise<void> => {
+				const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+				for (const key of keys) {
+					store.delete(key);
+				}
+			}),
+			getAlarm: vi.fn(async (): Promise<number | null> => alarm),
+			setAlarm: vi.fn(async (scheduledTime: number): Promise<void> => {
+				alarm = scheduledTime;
+			}),
+			deleteAlarm: vi.fn(async (): Promise<void> => {
+				alarm = null;
+			}),
+			deleteAll: vi.fn(async (): Promise<void> => {
+				store.clear();
+			}),
+		},
+	};
+}
+
+function createServer(mock: ReturnType<typeof createMockStorage>) {
+	const state = { storage: mock.storage } as unknown as DurableObjectState;
+	return new UserTokenStoreSQLite(state, {} as Env);
+}
+
+function makeRequest(
+	method: string,
+	operation: string,
+	body?: unknown,
+): Request {
+	const url = `https://example.com/storage/__active_org__/${operation}`;
+	return new Request(url, {
+		method,
+		headers: body ? { "Content-Type": "application/json" } : {},
+		body: body ? JSON.stringify(body) : undefined,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UserTokenStoreSQLite", () => {
+	let mock: ReturnType<typeof createMockStorage>;
+	let server: UserTokenStoreSQLite;
+
+	beforeEach(() => {
+		mock = createMockStorage();
+		server = createServer(mock);
+	});
+
+	describe("routing", () => {
+		it("returns 404 for an unknown route", async () => {
+			const res = await server.fetch(makeRequest("GET", "unknown"));
+			expect(res.status).toBe(404);
+		});
+
+		it("returns 404 for a valid operation with the wrong HTTP method", async () => {
+			const res = await server.fetch(makeRequest("DELETE", "token-store"));
+			expect(res.status).toBe(404);
+		});
+	});
+
+	describe("active-org", () => {
+		it("returns nulls when nothing is set", async () => {
+			const res = await server.fetch(makeRequest("GET", "active-org"));
+			expect(await res.json()).toEqual({ activeOrgId: null, orgToken: null });
+		});
+
+		it("sets the active org and (optional) token", async () => {
+			await server.fetch(
+				makeRequest("POST", "active-org", {
+					activeOrgId: "101",
+					orgToken: "org-tok",
+				}),
+			);
+			const res = await server.fetch(makeRequest("GET", "active-org"));
+			expect(await res.json()).toEqual({
+				activeOrgId: "101",
+				orgToken: "org-tok",
+			});
+		});
+
+		it("clears the stored token when set without one (org change)", async () => {
+			await server.fetch(
+				makeRequest("POST", "active-org", {
+					activeOrgId: "101",
+					orgToken: "org-tok",
+				}),
+			);
+			// Re-set the active org with no token -> token must be cleared.
+			await server.fetch(
+				makeRequest("POST", "active-org", { activeOrgId: "202" }),
+			);
+			expect(mock.store.has("active-org-token")).toBe(false);
+			expect(mock.store.get("active-org")).toBe("202");
+		});
+
+		it("PRESERVES the stored token when re-setting the SAME org id (fan-out safety)", async () => {
+			await server.fetch(
+				makeRequest("POST", "active-org", {
+					activeOrgId: "101",
+					orgToken: "org-tok",
+				}),
+			);
+			// A concurrent/cold-start sibling re-asserts the same active org with no
+			// token (postInit default path). The token another session just minted
+			// must NOT be deleted, or the fan-out would thrash re-minting.
+			await server.fetch(
+				makeRequest("POST", "active-org", { activeOrgId: "101" }),
+			);
+			expect(mock.store.get("active-org-token")).toBe("org-tok");
+			expect(mock.store.get("active-org")).toBe("101");
+		});
+	});
+
+	describe("POST /active-org-token clear", () => {
+		it("deletes the stored org token when given an empty/null token", async () => {
+			await server.fetch(
+				makeRequest("POST", "active-org", {
+					activeOrgId: "101",
+					orgToken: "org-tok",
+				}),
+			);
+			expect(mock.store.get("active-org-token")).toBe("org-tok");
+
+			await server.fetch(
+				makeRequest("POST", "active-org-token", { orgToken: null }),
+			);
+			expect(mock.store.has("active-org-token")).toBe(false);
+			// The active org id itself is untouched.
+			expect(mock.store.get("active-org")).toBe("101");
+		});
+
+		it("stores the org token when given a non-empty value", async () => {
+			await server.fetch(
+				makeRequest("POST", "active-org-token", { orgToken: "fresh-tok" }),
+			);
+			expect(mock.store.get("active-org-token")).toBe("fresh-tok");
+		});
+	});
+
+	describe("keep-warm token store", () => {
+		const ELEVEN_HOURS_MS = 11 * 60 * 60 * 1000;
+		const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
+
+		function seedBody(overrides: Record<string, unknown> = {}) {
+			return {
+				accessToken: "access-1",
+				refreshToken: "refresh-1",
+				instanceUrl: "https://ts.cloud",
+				...overrides,
+			};
+		}
+
+		it("seeds the store and arms an ~11h refresh alarm", async () => {
+			const before = Date.now();
+			const res = await server.fetch(
+				makeRequest("POST", "token-store", seedBody()),
+			);
+			expect(res.status).toBe(200);
+			expect(mock.alarm).not.toBeNull();
+			const delay = (mock.alarm as number) - before;
+			expect(delay).toBeGreaterThan(ELEVEN_HOURS_MS - 60_000);
+			expect(delay).toBeLessThan(ELEVEN_HOURS_MS + 60_000);
+		});
+
+		it("stamps lastSeenAt when seeding", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			const stored = mock.store.get("token-store") as { lastSeenAt?: number };
+			expect(typeof stored.lastSeenAt).toBe("number");
+		});
+
+		it("refreshes the token and re-arms ~11h on success", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(
+					new Response(
+						JSON.stringify({ token: "access-2", refreshToken: "refresh-1" }),
+						{ status: 200 },
+					),
+				);
+			const before = Date.now();
+			await server.alarm();
+			fetchSpy.mockRestore();
+
+			const stored = mock.store.get("token-store") as { accessToken: string };
+			expect(stored.accessToken).toBe("access-2");
+			const delay = (mock.alarm as number) - before;
+			expect(delay).toBeGreaterThan(ELEVEN_HOURS_MS - 60_000);
+			expect(delay).toBeLessThan(ELEVEN_HOURS_MS + 60_000);
+		});
+
+		it("re-arms (does NOT stop) when a refresh fails, leaving the old token", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(new Response("nope", { status: 503 }));
+			const before = Date.now();
+			await server.alarm();
+			fetchSpy.mockRestore();
+
+			// Old token kept (reads still work), and the alarm is re-armed for ~11h
+			// so the next regular tick (<24h) retries.
+			const stored = mock.store.get("token-store") as { accessToken: string };
+			expect(stored.accessToken).toBe("access-1");
+			expect(mock.alarm).not.toBeNull();
+			const delay = (mock.alarm as number) - before;
+			expect(delay).toBeGreaterThan(ELEVEN_HOURS_MS - 60_000);
+			expect(delay).toBeLessThan(ELEVEN_HOURS_MS + 60_000);
+		});
+
+		it("abandons the session (deletes token + active-org, no re-arm) after 14 idle days", async () => {
+			// Seed, then also set active-org state and back-date lastSeenAt past the TTL.
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			await server.fetch(
+				makeRequest("POST", "active-org", {
+					activeOrgId: "101",
+					orgToken: "org-tok",
+				}),
+			);
+			const stored = mock.store.get("token-store") as Record<string, unknown>;
+			mock.store.set("token-store", {
+				...stored,
+				lastSeenAt: Date.now() - FOURTEEN_DAYS_MS - 1000,
+			});
+			mock.storage.setAlarm.mockClear();
+			const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+			await server.alarm();
+
+			// Token + active-org state deleted; refresh NOT attempted; alarm NOT re-armed.
+			expect(mock.store.has("token-store")).toBe(false);
+			expect(mock.store.has("active-org")).toBe(false);
+			expect(mock.store.has("active-org-token")).toBe(false);
+			expect(fetchSpy).not.toHaveBeenCalled();
+			expect(mock.storage.setAlarm).not.toHaveBeenCalled();
+			fetchSpy.mockRestore();
+		});
+
+		it("POST /touch records activity, throttled to ~1/hour", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			// Back-date lastSeenAt > 1h so the next touch writes.
+			const stored = mock.store.get("token-store") as Record<string, unknown>;
+			const oldSeen = Date.now() - 2 * 60 * 60 * 1000;
+			mock.store.set("token-store", { ...stored, lastSeenAt: oldSeen });
+
+			await server.fetch(makeRequest("POST", "touch"));
+			const afterFirst = (
+				mock.store.get("token-store") as { lastSeenAt: number }
+			).lastSeenAt;
+			expect(afterFirst).toBeGreaterThan(oldSeen);
+
+			// A second immediate touch is within the throttle window -> no change.
+			await server.fetch(makeRequest("POST", "touch"));
+			const afterSecond = (
+				mock.store.get("token-store") as { lastSeenAt: number }
+			).lastSeenAt;
+			expect(afterSecond).toBe(afterFirst);
+		});
+
+		it("POST /touch is a no-op when no token store exists", async () => {
+			const res = await server.fetch(makeRequest("POST", "touch"));
+			expect(res.status).toBe(200);
+			expect(mock.store.has("token-store")).toBe(false);
+		});
+
+		it("POST /touch writes immediately when there is no prior lastSeenAt", async () => {
+			// Write a token store WITHOUT lastSeenAt directly (legacy / never-touched).
+			mock.store.set("token-store", {
+				accessToken: "access-1",
+				refreshToken: "refresh-1",
+				instanceUrl: "https://ts.cloud",
+			});
+
+			await server.fetch(makeRequest("POST", "touch"));
+			const after = mock.store.get("token-store") as { lastSeenAt?: number };
+			expect(typeof after.lastSeenAt).toBe("number");
+		});
+
+		it("refreshes (does NOT abandon) when idle is just under the 14-day TTL", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			const stored = mock.store.get("token-store") as Record<string, unknown>;
+			// One hour short of the TTL — must still refresh, not delete.
+			mock.store.set("token-store", {
+				...stored,
+				lastSeenAt: Date.now() - (FOURTEEN_DAYS_MS - 60 * 60 * 1000),
+			});
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(
+					new Response(JSON.stringify({ token: "access-2" }), { status: 200 }),
+				);
+
+			await server.alarm();
+			fetchSpy.mockRestore();
+
+			expect(mock.store.has("token-store")).toBe(true);
+			const after = mock.store.get("token-store") as { accessToken: string };
+			expect(after.accessToken).toBe("access-2");
+			expect(mock.alarm).not.toBeNull();
+		});
+
+		it("recovers on the next interval: failure then success re-arms cleanly", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+
+			// First alarm: refresh fails -> old token kept, alarm re-armed.
+			const failSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(new Response("err", { status: 503 }));
+			await server.alarm();
+			failSpy.mockRestore();
+			expect(
+				(mock.store.get("token-store") as { accessToken: string }).accessToken,
+			).toBe("access-1");
+			expect(mock.alarm).not.toBeNull();
+
+			// Second alarm: refresh succeeds -> token updated, still armed.
+			const okSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(
+					new Response(JSON.stringify({ token: "access-2" }), { status: 200 }),
+				);
+			await server.alarm();
+			okSpy.mockRestore();
+			expect(
+				(mock.store.get("token-store") as { accessToken: string }).accessToken,
+			).toBe("access-2");
+			expect(mock.alarm).not.toBeNull();
+		});
+
+		it("preserves lastSeenAt across a successful refresh", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			const seen = Date.now() - 3 * 60 * 60 * 1000;
+			const stored = mock.store.get("token-store") as Record<string, unknown>;
+			mock.store.set("token-store", { ...stored, lastSeenAt: seen });
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(
+					new Response(JSON.stringify({ token: "access-2" }), { status: 200 }),
+				);
+
+			await server.alarm();
+			fetchSpy.mockRestore();
+
+			const after = mock.store.get("token-store") as {
+				accessToken: string;
+				lastSeenAt: number;
+			};
+			expect(after.accessToken).toBe("access-2");
+			expect(after.lastSeenAt).toBe(seen); // activity tracking survives refresh
+		});
+
+		it("keeps the prior expiresAt when the refresh response omits one", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			const priorExpiry = Date.now() + 24 * 60 * 60 * 1000;
+			const stored = mock.store.get("token-store") as Record<string, unknown>;
+			mock.store.set("token-store", { ...stored, expiresAt: priorExpiry });
+			// Refresh response has a token but NO tokenExpiryDuration.
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(
+					new Response(JSON.stringify({ token: "access-2" }), { status: 200 }),
+				);
+
+			await server.alarm();
+			fetchSpy.mockRestore();
+
+			const after = mock.store.get("token-store") as {
+				accessToken: string;
+				expiresAt?: number;
+			};
+			expect(after.accessToken).toBe("access-2");
+			// Expiry tracking preserved (not dropped to undefined), so reconnect
+			// self-heal still works.
+			expect(after.expiresAt).toBe(priorExpiry);
+		});
+
+		it("seeding twice does not stack alarms (idempotent arm)", async () => {
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			mock.storage.setAlarm.mockClear();
+			// Re-seed (e.g. a later connect) — alarm already armed, must not re-arm.
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			expect(mock.storage.setAlarm).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/test/servers/user-token-store-server.spec.ts
+++ b/test/servers/user-token-store-server.spec.ts
@@ -213,10 +213,14 @@ describe("UserTokenStoreSQLite", () => {
 			expect(delay).toBeLessThan(ELEVEN_HOURS_MS + 60_000);
 		});
 
-		it("stamps lastSeenAt when seeding", async () => {
+		it("stamps lastSeenAt on first seed but preserves it on re-seeds", async () => {
 			await server.fetch(makeRequest("POST", "token-store", seedBody()));
-			const stored = mock.store.get("token-store") as { lastSeenAt?: number };
-			expect(typeof stored.lastSeenAt).toBe("number");
+			const after1 = mock.store.get("token-store") as { lastSeenAt?: number };
+			expect(typeof after1.lastSeenAt).toBe("number");
+			const first = after1.lastSeenAt;
+			await server.fetch(makeRequest("POST", "token-store", seedBody()));
+			const after2 = mock.store.get("token-store") as { lastSeenAt?: number };
+			expect(after2.lastSeenAt).toBe(first);
 		});
 
 		it("refreshes the token and re-arms ~11h on success", async () => {

--- a/test/storage-service/storage-service.spec.ts
+++ b/test/storage-service/storage-service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StorageServiceClient } from "../../src/storage-service/storage-service";
 import type {
 	Message,

--- a/test/thoughtspot/org-service.spec.ts
+++ b/test/thoughtspot/org-service.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { OrgService } from "../../src/thoughtspot/org-service";
+
+// OrgService is a thin, instrumented wrapper over the client's org/token methods.
+// These assert it delegates correctly and tolerates a nullish list response.
+
+function makeClient(overrides: Record<string, unknown> = {}) {
+	return {
+		listOrgs: vi.fn(),
+		fetchOrgBearerToken: vi.fn(),
+		...overrides,
+	} as any;
+}
+
+describe("OrgService", () => {
+	describe("listOrgs", () => {
+		it("delegates to client.listOrgs and returns the user's orgs", async () => {
+			const client = makeClient({
+				listOrgs: vi.fn().mockResolvedValue([
+					{ id: 0, name: "Primary", description: "P" },
+					{ id: 101, name: "DataPlatform" },
+				]),
+			});
+			const orgs = await new OrgService(client).listOrgs();
+			expect(client.listOrgs).toHaveBeenCalled();
+			expect(orgs).toEqual([
+				{ id: 0, name: "Primary", description: "P" },
+				{ id: 101, name: "DataPlatform" },
+			]);
+		});
+
+		it("tolerates a nullish upstream response", async () => {
+			const client = makeClient({
+				listOrgs: vi.fn().mockResolvedValue(undefined),
+			});
+			await expect(new OrgService(client).listOrgs()).resolves.toEqual([]);
+		});
+	});
+
+	describe("fetchOrgBearerToken", () => {
+		it("delegates to the client with the access token and org id", async () => {
+			const client = makeClient({
+				fetchOrgBearerToken: vi.fn().mockResolvedValue("org-token-xyz"),
+			});
+			const token = await new OrgService(client).fetchOrgBearerToken(
+				"global-tok",
+				"101",
+			);
+			expect(client.fetchOrgBearerToken).toHaveBeenCalledWith({
+				accessToken: "global-tok",
+				orgId: "101",
+			});
+			expect(token).toBe("org-token-xyz");
+		});
+	});
+});

--- a/test/thoughtspot/thoughtspot-client.spec.ts
+++ b/test/thoughtspot/thoughtspot-client.spec.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getThoughtSpotClient } from "../../src/thoughtspot/thoughtspot-client";
 import {
-	createBearerAuthenticationConfig,
 	ThoughtSpotRestApi,
+	createBearerAuthenticationConfig,
 } from "@thoughtspot/rest-api-sdk";
 import type { ResponseContext } from "@thoughtspot/rest-api-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
+import { getThoughtSpotClient } from "../../src/thoughtspot/thoughtspot-client";
 
 // Mock the ThoughtSpot REST API SDK
 vi.mock("@thoughtspot/rest-api-sdk", () => ({
@@ -459,9 +459,10 @@ describe("ThoughtSpot Client", () => {
 					session_identifier: "session-123",
 					generation_number: 2,
 				}),
-			).rejects.toThrow(
-				"getAnswerSession failed with status 401: Invalid token",
-			);
+			).rejects.toMatchObject({
+				status: 401,
+				message: "getAnswerSession failed with status 401",
+			});
 		});
 
 		it("should throw when response is missing answer session", async () => {
@@ -640,9 +641,10 @@ describe("ThoughtSpot Client", () => {
 
 			await expect(
 				client.createAgentConversationWithAutoMode({}),
-			).rejects.toThrow(
-				"createAgentConversationWithAutoMode failed with status 401: Unauthorized",
-			);
+			).rejects.toMatchObject({
+				status: 401,
+				message: "createAgentConversationWithAutoMode failed with status 401",
+			});
 		});
 
 		it("should handle network errors", async () => {
@@ -753,9 +755,10 @@ describe("ThoughtSpot Client", () => {
 					conversation_identifier: "foo",
 					message: "bar",
 				}),
-			).rejects.toThrow(
-				"sendAgentConversationMessageStreaming failed with status 401: Invalid token",
-			);
+			).rejects.toMatchObject({
+				status: 401,
+				message: "sendAgentConversationMessageStreaming failed with status 401",
+			});
 		});
 
 		it("should use correct headers for send agent conversation message streaming request", async () => {
@@ -854,6 +857,130 @@ mutation GetUnsavedAnswerTML($session: BachSessionIdInput!, $exportDependencies:
 			expect(query).toContain("BachSessionIdInput");
 			expect(query).toContain("UnsavedAnswer_getTML");
 			expect(query).toContain("edoc");
+		});
+	});
+
+	describe("fetchOrgBearerToken (org-scoped token mint)", () => {
+		function makeClient() {
+			return getThoughtSpotClient(mockInstanceUrl, mockBearerToken) as any;
+		}
+
+		it("calls the v2 auth/token/fetch endpoint with org_identifier and a 30-day validity", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(JSON.stringify({ data: { token: "org-tok" } }), {
+					status: 200,
+				}),
+			);
+			const client = makeClient();
+			const token = await client.fetchOrgBearerToken({
+				accessToken: "global-tok",
+				orgId: "101",
+			});
+
+			expect(token).toBe("org-tok");
+			const [url, init] = (global.fetch as any).mock.calls[0];
+			expect(url).toContain("/callosum/v1/v2/auth/token/fetch");
+			expect(url).toContain("org_identifier=101");
+			// Default validity is 30 days in seconds.
+			expect(url).toContain(`validity_time_in_sec=${30 * 24 * 60 * 60}`);
+			expect(init.method).toBe("GET");
+			// Authenticates with the (global) access token, no org header on the mint.
+			expect(init.headers.Authorization).toBe("Bearer global-tok");
+		});
+
+		it("honors an explicit validityTimeInSec override", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(JSON.stringify({ token: "org-tok" }), { status: 200 }),
+			);
+			const client = makeClient();
+			await client.fetchOrgBearerToken({
+				accessToken: "g",
+				orgId: "5",
+				validityTimeInSec: 300,
+			});
+			const [url] = (global.fetch as any).mock.calls[0];
+			expect(url).toContain("validity_time_in_sec=300");
+			expect(url).toContain("org_identifier=5");
+		});
+
+		it("reads the token from either data.token or top-level token", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(JSON.stringify({ token: "flat-tok" }), { status: 200 }),
+			);
+			const client = makeClient();
+			await expect(
+				client.fetchOrgBearerToken({ accessToken: "g", orgId: "1" }),
+			).resolves.toBe("flat-tok");
+		});
+
+		it("throws on a non-OK response, including the status", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response("forbidden", { status: 403 }),
+			);
+			const client = makeClient();
+			await expect(
+				client.fetchOrgBearerToken({ accessToken: "g", orgId: "999" }),
+			).rejects.toThrow(/status 403/);
+		});
+
+		it("throws when the response has no token", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(JSON.stringify({ data: {} }), { status: 200 }),
+			);
+			const client = makeClient();
+			await expect(
+				client.fetchOrgBearerToken({ accessToken: "g", orgId: "1" }),
+			).rejects.toThrow(/no token/);
+		});
+	});
+
+	describe("listOrgs (user-scoped org membership)", () => {
+		function makeClient() {
+			return getThoughtSpotClient(mockInstanceUrl, mockBearerToken) as any;
+		}
+
+		it("calls the v1 session/orgs endpoint and maps orgId/orgName/description", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						orgs: [
+							{ orgId: 0, orgName: "Primary", description: "Primary org" },
+							{ orgId: 101, orgName: "DataPlatform" },
+						],
+						currentOrgId: 0,
+					}),
+					{ status: 200 },
+				),
+			);
+			const client = makeClient();
+			const orgs = await client.listOrgs();
+
+			const [url, init] = (global.fetch as any).mock.calls[0];
+			// User-scoped v1 endpoint, NOT the admin orgs/search.
+			expect(url).toContain("/callosum/v1/session/orgs");
+			expect(url).not.toContain("orgs/search");
+			expect(init.method).toBe("GET");
+			expect(init.headers.Authorization).toBe(`Bearer ${mockBearerToken}`);
+			expect(orgs).toEqual([
+				{ id: 0, name: "Primary", description: "Primary org" },
+				{ id: 101, name: "DataPlatform", description: undefined },
+			]);
+		});
+
+		it("returns an empty list when the response has no orgs array", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(JSON.stringify({ currentOrgId: 0 }), { status: 200 }),
+			);
+			const client = makeClient();
+			await expect(client.listOrgs()).resolves.toEqual([]);
+		});
+
+		it("throws (with status) on a non-OK response — e.g. an unexpected 403", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response("Operation is not allowed", { status: 403 }),
+			);
+			const client = makeClient();
+			await expect(client.listOrgs()).rejects.toThrow(/status 403/);
 		});
 	});
 });

--- a/test/thoughtspot/thoughtspot-client.spec.ts
+++ b/test/thoughtspot/thoughtspot-client.spec.ts
@@ -982,5 +982,43 @@ mutation GetUnsavedAnswerTML($session: BachSessionIdInput!, $exportDependencies:
 			const client = makeClient();
 			await expect(client.listOrgs()).rejects.toThrow(/status 403/);
 		});
+
+		it("falls back to id/name fields when orgId/orgName are absent", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(JSON.stringify({ orgs: [{ id: 7, name: "Alt" }] }), {
+					status: 200,
+				}),
+			);
+			const client = makeClient();
+			await expect(client.listOrgs()).resolves.toEqual([
+				{ id: 7, name: "Alt", description: undefined },
+			]);
+		});
+
+		it("uses the id as the name when neither orgName nor name is present", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(JSON.stringify({ orgs: [{ orgId: 42 }] }), {
+					status: 200,
+				}),
+			);
+			const client = makeClient();
+			await expect(client.listOrgs()).resolves.toEqual([
+				{ id: 42, name: "42", description: undefined },
+			]);
+		});
+
+		it("maps an empty-string description to undefined", async () => {
+			(global.fetch as any).mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						orgs: [{ orgId: 1, orgName: "X", description: "" }],
+					}),
+					{ status: 200 },
+				),
+			);
+			const client = makeClient();
+			const [org] = await client.listOrgs();
+			expect(org.description).toBeUndefined();
+		});
 	});
 });

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -4,12 +4,13 @@
 declare namespace Cloudflare {
 	interface GlobalProps {
 		mainModule: typeof import("./src/index");
-		durableNamespaces: "ThoughtSpotMCP";
+		durableNamespaces: "ThoughtSpotMCP" | "UserTokenStoreSQLite";
 	}
 	interface Env {
 		OAUTH_KV: KVNamespace;
 		MCP_OBJECT: DurableObjectNamespace<import("./src/index").ThoughtSpotMCP>;
 		CONVERSATION_STORAGE_OBJECT: DurableObjectNamespace<import("./src/index").ConversationStorageServerSQLite>;
+		USER_TOKEN_OBJECT: DurableObjectNamespace<import("./src/index").UserTokenStoreSQLite>;
 		ANALYTICS: AnalyticsEngineDataset;
 		ASSETS: Fetcher;
 	}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,6 +20,10 @@
 			{
 				"class_name": "ConversationStorageServerSQLite",
 				"name": "CONVERSATION_STORAGE_OBJECT"
+			},
+			{
+				"class_name": "UserTokenStoreSQLite",
+				"name": "USER_TOKEN_OBJECT"
 			}
 		]
 	},
@@ -58,6 +62,12 @@
 			"tag": "v7",
 			"new_sqlite_classes": [
 				"ConversationStorageServerSQLite"
+			]
+		},
+		{
+			"tag": "v8",
+			"new_sqlite_classes": [
+				"UserTokenStoreSQLite"
 			]
 		}
 	],


### PR DESCRIPTION
## Summary
Adds multi-org support to the ThoughtSpot MCP server on top of the shared `@thoughtspot/mcp-auth` auth layer (post-#165 extraction):

- **`list_orgs` / `switch_org`** v2 tools — list the user's orgs and switch the active org mid-session.
- **`OrgService`** — user-scoped org listing (`session/orgs`) + org-scoped token minting (`auth/token/fetch?org_identifier=`).
- **`UserTokenStoreSQLite`** DO — per-user active org + org token + keep-warm cluster token (11h refresh alarm; 14-day idle abandonment). Keyed by `hash(refreshToken)` so it's shared across the client's fan-out.
- **Org overlay** in `MCPServer`: per-request active-org reload, org-scoped bearer (fail-closed — never the global token on a data call), reactive 401 re-mint (mint-first/atomic), org-tagged datasource cache.

## Backward compatibility
Gated on **OAuth + Orgs-enabled + v2 + a multi-org grant** (a refresh token in the grant, decided once in `postInit`). A pre-multi-org grant (no refresh token) keeps the exact old behavior — no org tools, no overlay, its login token — until the user re-authenticates. Bearer/token and v1 sessions are unaffected.

## Dependency
Requires **`@thoughtspot/mcp-auth@^2.0.0`**, which adds the `extendGrantProps` hook that carries the refresh token / expiry into the OAuth grant (needed for keep-warm). That must be published before CI is green.

## Testing
- Unit/integration: 627 passing (org tools/gate, isolation, fan-out last-write-wins, F2a mint-first re-mint, org-tagged cache, keep-warm lifecycle, backward-compat gate, listOrgs mapping edges, switch_org 4xx/5xx).
- Live E2E on a test worker: list/switch/bad-org-no-op, cross-org data isolation (disjoint datasets), keep-warm refresh cycle + idle abandonment verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)