### PR TITLE
Keep org tools available when session info fails to load

### DIFF
--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -103,8 +103,14 @@ export abstract class BaseMCPServer extends Server {
 	 * org tools stay hidden.
 	 */
 	protected isOrgsEnabled(): boolean {
+		// When session info failed to load (e.g. the init-time getSessionInfo call
+		// used an expired props token before the keep-warm DO token was reconciled),
+		// default to true so org tools stay available rather than silently vanishing.
+		// The tool call paths reconcile the live token from the DO independently, so
+		// they still work when the kept-warm token is healthy. When session info IS
+		// present, respect the cluster's actual orgsEnabled flag.
 		if (!this.sessionInfo) {
-			return false;
+			return true;
 		}
 		return this.sessionInfo.orgsEnabled === true;
 	}

--- a/test/servers/mcp-server-base.spec.ts
+++ b/test/servers/mcp-server-base.spec.ts
@@ -591,8 +591,8 @@ describe("MCP Server Base", () => {
 	});
 
 	describe("isOrgsEnabled", () => {
-		it("returns false when session info is not initialized (fail closed)", () => {
-			expect(server.testIsOrgsEnabled()).toBe(false);
+		it("returns true when session info is not initialized (default so org tools survive a failed getSessionInfo)", () => {
+			expect(server.testIsOrgsEnabled()).toBe(true);
 		});
 
 		it("returns true when orgsEnabled is true", () => {


### PR DESCRIPTION
## Problem
After ~24h, `list_orgs`/`switch_org` disappear even though keep-warm `gettoken` succeeds and the refresh token is valid.

## Cause
`isOrgsEnabled()` is false whenever `sessionInfo` is null. `sessionInfo` is set once at init by `getSessionInfo()`, which runs **before** the keep-warm global token is loaded from the DO. On a cold-start init after the frozen props token expires (~24h), `getSessionInfo()` uses the stale token, 401s, and leaves `sessionInfo` null → org tools filtered out. The DO token was valid the whole time (other tool calls kept working since they reconcile it at call time).

## Fix (hotfix)
Default `isOrgsEnabled()` to true when `sessionInfo` is absent. Tool calls reconcile the live DO token independently, so the tools work when the kept-warm token is healthy. When `sessionInfo` is present we still respect the real `orgsEnabled` flag. Bearer/token clusters unaffected (authMode gate short-circuits first).

Root-cause fix (reconcile token before `getSessionInfo`) to follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)