### PR TITLE
Close conversation if send message fails

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -770,14 +770,42 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			);
 		}
 
-		await this.getThoughtSpotService(recorder, {
-			analyticalSessionId: analytical_session_id,
-		}).sendAgentConversationMessageStreaming(
-			analytical_session_id,
-			message,
-			storageService.appendMessages.bind(storageService),
-			additional_context,
-		);
+		try {
+			await this.getThoughtSpotService(recorder, {
+				analyticalSessionId: analytical_session_id,
+			}).sendAgentConversationMessageStreaming(
+				analytical_session_id,
+				message,
+				storageService.appendMessages.bind(storageService),
+				additional_context,
+			);
+		} catch (error) {
+			console.error("Error sending message to Spotter conversation:", error);
+			try {
+				// Close out the conversation state in the storage (mark isDone = true), so
+				// that clients don't accidentally get stuck polling for updates forever
+				await storageService.appendMessages(
+					analytical_session_id,
+					[
+						{
+							is_thinking: false,
+							type: "text",
+							text: "Something went wrong",
+						},
+					],
+					true,
+				);
+			} catch (storageError) {
+				console.error(
+					"Error appending error message to storage service:",
+					storageError,
+				);
+			}
+			return this.createErrorResponse(
+				"Encountered an error while sending the message. Please check your inputs and try again.",
+				`Error sending message to conversation ${analytical_session_id}: ${error}`,
+			);
+		}
 
 		return this.createStructuredContentSuccessResponse(
 			{ success: true },

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -1427,6 +1427,70 @@ describe("MCP Server", () => {
 				"ERROR: The analytical session has an ongoing response",
 			);
 		});
+
+		it("should close out the conversation when sending the message fails", async () => {
+			mockSendAgentConversationMessageStreaming.mockRejectedValue(
+				new Error("Spotter stream failed"),
+			);
+
+			await server.init();
+			const { callTool } = connect(server);
+
+			const result = await callTool("send_session_message", {
+				analytical_session_id: "conv-abc-123",
+				message: "What is the total revenue?",
+			});
+
+			expect(result.isError).toBe(true);
+			expect((result.content as any[])[0].text).toContain(
+				"Encountered an error while sending the message",
+			);
+			// The conversation must be marked done so clients don't poll forever.
+			expect(mockStorageService.appendMessages).toHaveBeenCalledWith(
+				"conv-abc-123",
+				[
+					{
+						is_thinking: false,
+						type: "text",
+						text: "Something went wrong",
+					},
+				],
+				true,
+			);
+		});
+
+		it("should still return an error when closing out the conversation fails", async () => {
+			mockSendAgentConversationMessageStreaming.mockRejectedValue(
+				new Error("Spotter stream failed"),
+			);
+			mockStorageService.appendMessages.mockRejectedValue(
+				new Error("Storage write failed"),
+			);
+
+			await server.init();
+			const { callTool } = connect(server);
+
+			const result = await callTool("send_session_message", {
+				analytical_session_id: "conv-abc-123",
+				message: "What is the total revenue?",
+			});
+
+			expect(result.isError).toBe(true);
+			expect((result.content as any[])[0].text).toContain(
+				"Encountered an error while sending the message",
+			);
+			expect(mockStorageService.appendMessages).toHaveBeenCalledWith(
+				"conv-abc-123",
+				[
+					{
+						is_thinking: false,
+						type: "text",
+						text: "Something went wrong",
+					},
+				],
+				true,
+			);
+		});
 	});
 
 	describe("Get Session Updates Tool", () => {


### PR DESCRIPTION
- Clients polling for updates on a conversation where sending a message failed will now see is_done marked true, with an error message in the contents
- Add test coverage