### PR TITLE
Add chat history support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,8 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .wrangler
+.wrangler.old
+.wrangler.new
 .dev.vars
 coverage
 key.pem

--- a/package-lock.json
+++ b/package-lock.json
@@ -1492,6 +1492,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1508,6 +1509,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1524,6 +1526,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1540,6 +1543,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1556,6 +1560,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,6 +1577,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1588,6 +1594,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1604,6 +1611,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1620,6 +1628,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1636,6 +1645,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1652,6 +1662,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1668,6 +1679,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1684,6 +1696,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1700,6 +1713,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1716,6 +1730,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1732,6 +1747,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1748,6 +1764,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1764,6 +1781,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1780,6 +1798,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1796,6 +1815,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1812,6 +1832,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1828,6 +1849,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1844,6 +1866,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1860,6 +1883,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1876,6 +1900,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1892,6 +1917,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3381,6 +3407,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3394,6 +3421,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3407,6 +3435,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3420,6 +3449,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3433,6 +3463,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3446,6 +3477,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3459,6 +3491,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3472,6 +3505,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3485,6 +3519,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3498,6 +3533,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3511,6 +3547,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3524,6 +3561,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3537,6 +3575,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3550,6 +3589,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3563,6 +3603,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3576,6 +3617,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3589,6 +3631,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3602,6 +3645,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3615,6 +3659,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3628,6 +3673,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3641,6 +3687,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3654,6 +3701,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3667,6 +3715,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3680,6 +3729,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3693,6 +3743,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5067,7 +5118,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5484,6 +5535,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7721,7 +7773,7 @@
       "version": "4.22.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -8001,6 +8053,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8017,6 +8070,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8033,6 +8087,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8049,6 +8104,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8065,6 +8121,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8081,6 +8138,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8097,6 +8155,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8113,6 +8172,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8129,6 +8189,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8145,6 +8206,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8161,6 +8223,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8177,6 +8240,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8193,6 +8257,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8209,6 +8274,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8225,6 +8291,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8241,6 +8308,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8257,6 +8325,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8273,6 +8342,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8289,6 +8359,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8305,6 +8376,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8321,6 +8393,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8337,6 +8410,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8353,6 +8427,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8369,6 +8444,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8385,6 +8461,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8401,6 +8478,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -32,6 +32,7 @@ import { StorageServiceClient } from "../storage-service/storage-service";
 import { OrgService } from "../thoughtspot/org-service";
 import { getThoughtSpotClient } from "../thoughtspot/thoughtspot-client";
 import { ThoughtSpotService } from "../thoughtspot/thoughtspot-service";
+import type { SessionInfo } from "../thoughtspot/types";
 import type { Props } from "../utils";
 
 // Response utility types
@@ -60,7 +61,7 @@ export interface Context {
 
 export abstract class BaseMCPServer extends Server {
 	protected trackers: Trackers = new Trackers();
-	protected sessionInfo: any;
+	protected sessionInfo: SessionInfo | undefined;
 
 	constructor(
 		protected ctx: Context,
@@ -85,34 +86,28 @@ export abstract class BaseMCPServer extends Server {
 	}
 
 	/**
-	 * Check if data source discovery is available
+	 * Whether Spotter data source discovery (Auto Mode) is enabled
 	 */
-	protected isDatasourceDiscoveryAvailable(): boolean {
-		if (!this.sessionInfo) {
-			console.warn(
-				"[DEBUG] sessionInfo is not initialized when checking datasource discovery availability",
-			);
-			return false;
-		}
-		return String(this.sessionInfo.enableSpotterDataSourceDiscovery) === "true";
+	protected isSpotterDataSourceDiscoveryEnabled(): boolean {
+		return this.sessionInfo?.isSpotterDataSourceDiscoveryEnabled === true;
 	}
 
 	/**
-	 * Whether Orgs are enabled on this cluster (from session info). Fails closed:
-	 * if session info is unavailable or the flag is absent, returns false so the
-	 * org tools stay hidden.
+	 * Whether Orgs feature is enabled. If session info is not available, we assume Orgs is
+	 * enabled to ensure the Org-related tools do not disappear.
 	 */
 	protected isOrgsEnabled(): boolean {
-		// When session info failed to load (e.g. the init-time getSessionInfo call
-		// used an expired props token before the keep-warm DO token was reconciled),
-		// default to true so org tools stay available rather than silently vanishing.
-		// The tool call paths reconcile the live token from the DO independently, so
-		// they still work when the kept-warm token is healthy. When session info IS
-		// present, respect the cluster's actual orgsEnabled flag.
 		if (!this.sessionInfo) {
 			return true;
 		}
 		return this.sessionInfo.orgsEnabled === true;
+	}
+
+	/**
+	 * Whether Spotter chat history (save chat) is enabled
+	 */
+	protected isSpotterChatHistoryEnabled(): boolean {
+		return this.sessionInfo?.isSpotterChatHistoryEnabled === true;
 	}
 
 	/**

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -360,7 +360,7 @@ export class MCPServer extends BaseMCPServer {
 
 		// Filter out GetDataSourceSuggestions if feature flag is not available
 		if (
-			!this.isDatasourceDiscoveryAvailable() &&
+			!this.isSpotterDataSourceDiscoveryEnabled() &&
 			tools.some((tool) => tool.name === ToolName.GetDataSourceSuggestions)
 		) {
 			tools = tools.filter(
@@ -712,10 +712,13 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 
 		let response: AgentConversation;
 		try {
-			response =
-				await this.getThoughtSpotService(recorder).createAgentConversation(
-					data_source_id,
-				);
+			response = await this.getThoughtSpotService(
+				recorder,
+			).createAgentConversation(
+				this.isSpotterDataSourceDiscoveryEnabled(),
+				this.isSpotterChatHistoryEnabled(),
+				data_source_id,
+			);
 		} catch (error) {
 			if (this.apiErrorStatus(error) !== 401) {
 				throw error;

--- a/src/thoughtspot/thoughtspot-client.ts
+++ b/src/thoughtspot/thoughtspot-client.ts
@@ -247,8 +247,12 @@ function addCreateAgentConversationWithAutoMode(
 	orgId?: string,
 ) {
 	(client as any).createAgentConversationWithAutoMode = async ({
+		isSpotterDataSourceDiscoveryEnabled,
+		isSpotterChatHistoryEnabled,
 		dataSourceId,
 	}: {
+		isSpotterDataSourceDiscoveryEnabled: boolean;
+		isSpotterChatHistoryEnabled: boolean;
 		dataSourceId?: string;
 	}): Promise<AgentConversation> => {
 		const endpoint = "/conversation/v2/";
@@ -269,10 +273,13 @@ function addCreateAgentConversationWithAutoMode(
 				conv_settings: {
 					enable_nls: true,
 					enable_why: true,
-					save_chat_enabled: false,
+					save_chat_enabled: isSpotterChatHistoryEnabled,
 					enable_tool_permissions: false,
-					enable_search_datasets: !dataSourceId,
-					enable_auto_select_dataset: !dataSourceId,
+					enable_search_datasets:
+						isSpotterDataSourceDiscoveryEnabled && !dataSourceId,
+					enable_auto_select_dataset:
+						isSpotterDataSourceDiscoveryEnabled && !dataSourceId,
+					tags: ["mcp-server"],
 				},
 			}),
 		};

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -295,6 +295,8 @@ export class ThoughtSpotService {
 	 */
 	@WithSpan("create-agent-conversation")
 	async createAgentConversation(
+		isSpotterDataSourceDiscoveryEnabled: boolean,
+		isSpotterChatHistoryEnabled: boolean,
 		dataSourceId?: string,
 	): Promise<AgentConversation> {
 		const span = trace.getSpan(context.active());
@@ -306,6 +308,8 @@ export class ThoughtSpotService {
 				UPSTREAM_OPERATION_NAMES.createAgentConversation,
 				() =>
 					(this.client as any).createAgentConversationWithAutoMode({
+						isSpotterDataSourceDiscoveryEnabled,
+						isSpotterChatHistoryEnabled,
 						dataSourceId,
 					}),
 			);
@@ -673,10 +677,10 @@ export class ThoughtSpotService {
 	async getSessionInfo(): Promise<SessionInfo> {
 		const span = getActiveSpan();
 
-		const info = await this.observeUpstreamCall(
+		const info = (await this.observeUpstreamCall(
 			UPSTREAM_OPERATION_NAMES.getSessionInfo,
 			() => (this.client as any).getSessionInfo(),
-		);
+		)) as any;
 		const devMixpanelToken = info.configInfo.mixpanelConfig.devSdkKey;
 		const prodMixpanelToken = info.configInfo.mixpanelConfig.prodSdkKey;
 		const mixpanelToken = info.configInfo.mixpanelConfig.production
@@ -697,9 +701,11 @@ export class ThoughtSpotService {
 			releaseVersion: info.releaseVersion,
 			currentOrgId: info.currentOrgId,
 			privileges: info.privileges,
-			enableSpotterDataSourceDiscovery:
+			isSpotterDataSourceDiscoveryEnabled:
 				info.configInfo?.enableSpotterDataSourceDiscovery,
 			orgsEnabled: info.configInfo?.orgsConfiguration?.enabled,
+			isSpotterChatHistoryEnabled:
+				info.configInfo?.showSpotterPastConversations,
 		};
 	}
 

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -47,10 +47,9 @@ export interface SessionInfo {
 	releaseVersion: string;
 	currentOrgId: string;
 	privileges: any;
-	enableSpotterDataSourceDiscovery?: boolean;
-	// Whether Orgs are enabled on this cluster (configInfo.orgsConfiguration.enabled).
-	// Gates the org tools (list_orgs/switch_org).
+	isSpotterDataSourceDiscoveryEnabled?: boolean;
 	orgsEnabled?: boolean;
+	isSpotterChatHistoryEnabled?: boolean;
 }
 
 export interface BaseMessage {

--- a/test/servers/mcp-server-base.spec.ts
+++ b/test/servers/mcp-server-base.spec.ts
@@ -54,8 +54,8 @@ class TestMCPServer extends MCPServer {
 		);
 	}
 
-	public testIsDatasourceDiscoveryAvailable() {
-		return this.isDatasourceDiscoveryAvailable();
+	public testIsSpotterDataSourceDiscoveryEnabled() {
+		return this.isSpotterDataSourceDiscoveryEnabled();
 	}
 
 	public getTrackers() {
@@ -253,18 +253,13 @@ describe("MCP Server Base", () => {
 
 	describe("Datasource Discovery Check", () => {
 		it("should return false before init is called (sessionInfo not set)", () => {
-			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			const result = server.testIsDatasourceDiscoveryAvailable();
+			const result = server.testIsSpotterDataSourceDiscoveryEnabled();
 			expect(result).toBe(false);
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining("sessionInfo is not initialized"),
-			);
-			warnSpy.mockRestore();
 		});
 
 		it("should return true when enableSpotterDataSourceDiscovery is enabled", async () => {
 			await server.init();
-			const result = server.testIsDatasourceDiscoveryAvailable();
+			const result = server.testIsSpotterDataSourceDiscoveryEnabled();
 			expect(result).toBe(true);
 		});
 
@@ -281,7 +276,7 @@ describe("MCP Server Base", () => {
 
 			const testServer = new TestMCPServer({ props: mockProps, env: mockEnv });
 			await testServer.init();
-			expect(testServer.testIsDatasourceDiscoveryAvailable()).toBe(false);
+			expect(testServer.testIsSpotterDataSourceDiscoveryEnabled()).toBe(false);
 		});
 
 		it("should return false when enableSpotterDataSourceDiscovery is undefined", async () => {
@@ -297,7 +292,7 @@ describe("MCP Server Base", () => {
 
 			const testServer = new TestMCPServer({ props: mockProps, env: mockEnv });
 			await testServer.init();
-			expect(testServer.testIsDatasourceDiscoveryAvailable()).toBe(false);
+			expect(testServer.testIsSpotterDataSourceDiscoveryEnabled()).toBe(false);
 		});
 	});
 

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -146,7 +146,7 @@ describe("MCP Server", () => {
 					userName: "test-user",
 					currentOrgId: "test-org",
 					privileges: [],
-					enableSpotterDataSourceDiscovery: true,
+					isSpotterDataSourceDiscoveryEnabled: true,
 				},
 				{
 					clientId: "test-client-id",
@@ -1238,6 +1238,8 @@ describe("MCP Server", () => {
 				"conv-with-ds-456",
 			);
 			expect(mockCreateAgentConversationWithAutoMode).toHaveBeenCalledWith({
+				isSpotterDataSourceDiscoveryEnabled: true,
+				isSpotterChatHistoryEnabled: false,
 				dataSourceId: "ds-123",
 			});
 		});

--- a/test/thoughtspot/thoughtspot-client.spec.ts
+++ b/test/thoughtspot/thoughtspot-client.spec.ts
@@ -560,7 +560,10 @@ describe("ThoughtSpot Client", () => {
 				json: vi.fn().mockResolvedValue(mockConversation),
 			});
 
-			const result = await client.createAgentConversationWithAutoMode({});
+			const result = await client.createAgentConversationWithAutoMode({
+				isSpotterDataSourceDiscoveryEnabled: true,
+				isSpotterChatHistoryEnabled: false,
+			});
 
 			expect(fetch).toHaveBeenCalledWith(
 				`${mockInstanceUrl}/conversation/v2/`,
@@ -596,6 +599,8 @@ describe("ThoughtSpot Client", () => {
 			});
 
 			const result = await client.createAgentConversationWithAutoMode({
+				isSpotterDataSourceDiscoveryEnabled: true,
+				isSpotterChatHistoryEnabled: false,
 				dataSourceId,
 			});
 
@@ -618,7 +623,10 @@ describe("ThoughtSpot Client", () => {
 				json: vi.fn().mockResolvedValue({ conversation_id: "conv-789" }),
 			});
 
-			await client.createAgentConversationWithAutoMode({});
+			await client.createAgentConversationWithAutoMode({
+				isSpotterDataSourceDiscoveryEnabled: true,
+				isSpotterChatHistoryEnabled: false,
+			});
 
 			const fetchCall = (fetch as any).mock.calls[0];
 			const body = JSON.parse(fetchCall[1].body);
@@ -629,6 +637,7 @@ describe("ThoughtSpot Client", () => {
 				enable_tool_permissions: false,
 				enable_search_datasets: true,
 				enable_auto_select_dataset: true,
+				tags: ["mcp-server"],
 			});
 		});
 

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -192,11 +192,13 @@ describe("thoughtspot-service", () => {
 				.mockResolvedValue(mockResponse);
 
 			const service = new ThoughtSpotService(mockClient);
-			const result = await service.createAgentConversation();
+			const result = await service.createAgentConversation(false, false);
 
 			expect(
 				mockClient.createAgentConversationWithAutoMode,
 			).toHaveBeenCalledWith({
+				isSpotterDataSourceDiscoveryEnabled: false,
+				isSpotterChatHistoryEnabled: false,
 				dataSourceId: undefined,
 			});
 			expect(result).toEqual(mockResponse);
@@ -212,11 +214,13 @@ describe("thoughtspot-service", () => {
 				.mockResolvedValue(mockResponse);
 
 			const service = new ThoughtSpotService(mockClient);
-			await service.createAgentConversation("worksheet-123");
+			await service.createAgentConversation(false, false, "worksheet-123");
 
 			expect(
 				mockClient.createAgentConversationWithAutoMode,
 			).toHaveBeenCalledWith({
+				isSpotterDataSourceDiscoveryEnabled: false,
+				isSpotterChatHistoryEnabled: false,
 				dataSourceId: "worksheet-123",
 			});
 		});


### PR DESCRIPTION
- Plumb through cluster flag for Spotter chat history
- Start honoring flag for data source discovery
- Add tag for Spotter chats created from MCP Server
- Improve types and naming scheme for other flags
- Add test coverage