### PR TITLE
Provide safe defaults for flags if sessionInfo is unavailable

### DIFF
--- a/src/servers/mcp-server-base.ts
+++ b/src/servers/mcp-server-base.ts
@@ -89,15 +89,21 @@ export abstract class BaseMCPServer extends Server {
 	 * Whether Spotter data source discovery (Auto Mode) is enabled
 	 */
 	protected isSpotterDataSourceDiscoveryEnabled(): boolean {
-		return this.sessionInfo?.isSpotterDataSourceDiscoveryEnabled === true;
+		if (!this.sessionInfo) {
+			console.warn(
+				"Session info not available when checking data source discovery flag",
+			);
+			return true;
+		}
+		return this.sessionInfo.isSpotterDataSourceDiscoveryEnabled === true;
 	}
 
 	/**
-	 * Whether Orgs feature is enabled. If session info is not available, we assume Orgs is
-	 * enabled to ensure the Org-related tools do not disappear.
+	 * Whether Orgs feature is enabled
 	 */
 	protected isOrgsEnabled(): boolean {
 		if (!this.sessionInfo) {
+			console.warn("Session info not available when checking orgs flag");
 			return true;
 		}
 		return this.sessionInfo.orgsEnabled === true;
@@ -107,7 +113,13 @@ export abstract class BaseMCPServer extends Server {
 	 * Whether Spotter chat history (save chat) is enabled
 	 */
 	protected isSpotterChatHistoryEnabled(): boolean {
-		return this.sessionInfo?.isSpotterChatHistoryEnabled === true;
+		if (!this.sessionInfo) {
+			console.warn(
+				"Session info not available when checking chat history flag",
+			);
+			return true;
+		}
+		return this.sessionInfo.isSpotterChatHistoryEnabled === true;
 	}
 
 	/**

--- a/test/servers/mcp-server-base.spec.ts
+++ b/test/servers/mcp-server-base.spec.ts
@@ -92,27 +92,30 @@ describe("MCP Server Base", () => {
 	let mockProps: any;
 	let mockStreamingStorage: any;
 
-	const makeSessionInfo = (overrides: any = {}) => ({
-		clusterId: "test-cluster-123",
-		clusterName: "test-cluster",
-		releaseVersion: "10.13.0.cl-110",
-		userGUID: "test-user-123",
-		configInfo: {
-			mixpanelConfig: {
-				devSdkKey: "test-dev-token",
-				prodSdkKey: "test-prod-token",
-				production: false,
+	const makeSessionInfo = (overrides: any = {}) => {
+		const { configInfo: configInfoOverride, ...restOverrides } = overrides;
+		return {
+			clusterId: "test-cluster-123",
+			clusterName: "test-cluster",
+			releaseVersion: "10.13.0.cl-110",
+			userGUID: "test-user-123",
+			configInfo: {
+				mixpanelConfig: {
+					devSdkKey: "test-dev-token",
+					prodSdkKey: "test-prod-token",
+					production: false,
+				},
+				selfClusterName: "test-cluster",
+				selfClusterId: "test-cluster-123",
+				enableSpotterDataSourceDiscovery: true,
+				...configInfoOverride,
 			},
-			selfClusterName: "test-cluster",
-			selfClusterId: "test-cluster-123",
-			enableSpotterDataSourceDiscovery: true,
-			...overrides.configInfo,
-		},
-		userName: "test-user",
-		currentOrgId: "test-org",
-		privileges: [],
-		...overrides,
-	});
+			userName: "test-user",
+			currentOrgId: "test-org",
+			privileges: [],
+			...restOverrides,
+		};
+	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -252,9 +255,9 @@ describe("MCP Server Base", () => {
 	});
 
 	describe("Datasource Discovery Check", () => {
-		it("should return false before init is called (sessionInfo not set)", () => {
+		it("should return true before init is called (sessionInfo not set — safe default)", () => {
 			const result = server.testIsSpotterDataSourceDiscoveryEnabled();
-			expect(result).toBe(false);
+			expect(result).toBe(true);
 		});
 
 		it("should return true when enableSpotterDataSourceDiscovery is enabled", async () => {


### PR DESCRIPTION
- Temporary fix to ensure flags are passed correctly in most cases
- Update tests