### PR TITLE
Add step notifications in MCP Server response

### DIFF
--- a/src/metrics/runtime/tool-metrics.ts
+++ b/src/metrics/runtime/tool-metrics.ts
@@ -33,6 +33,7 @@ export type UpstreamStreamMessageType =
 	| "text"
 	| "text_chunk"
 	| "answer"
+	| "step_notification"
 	| "error";
 
 function buildToolMetricLabels(

--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -125,9 +125,9 @@ export const GetSessionUpdatesInputSchema = z.object({
 
 export const ConversationUpdateSchema = z.object({
 	type: z
-		.enum(["text", "text_chunk", "answer"])
+		.enum(["text", "text_chunk", "answer", "step_notification"])
 		.describe(
-			"The type of update: `text` or `text_chunk` for a natural language message from the Analytics Agent, or `answer` for a data visualization with query results. Determines which other fields are populated.",
+			"The type of update: `text` or `text_chunk` for a natural language message from the Analytics Agent, `answer` for a data visualization with query results, or `step_notification` to announce key progress steps which the Agent is working through. Determines which other fields are populated.",
 		),
 	is_thinking: z
 		.boolean()
@@ -138,7 +138,7 @@ export const ConversationUpdateSchema = z.object({
 		.string()
 		.optional()
 		.describe(
-			"The text content of the message. Only present when `type` is `text` or `text_chunk`. If `type` is `text_chunk`, concatenate the chunks of text together in the order received to form the complete message.",
+			"The text content of the message. Only present when `type` is `text`, `text_chunk`, or `step_notification`. If `type` is `text_chunk`, concatenate the chunks of text together in the order received to form the complete message. If `type` is `step_notification`, the text will describe the step the Analytics Agent is currently working on, and is not meant to be concatenated with other text-based events.",
 		),
 	answer_id: z
 		.string()

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -137,9 +137,29 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 									answer_query: item.metadata?.sage_query,
 									iframe_url: iframeUrl,
 								});
+							} else if (item.type === "notification") {
+								if (
+									item.code !== "TOOL_CALL_NOTIFICATION" ||
+									!item.metadata?.tool_title
+								) {
+									nMessagesIgnored++;
+									continue;
+								}
+
+								nTextMessagesParsed++;
+								recordUpstreamStreamMessageMetric(
+									recorder,
+									upstreamOperation,
+									"step_notification",
+									item.metadata?.type === "thinking",
+								);
+								newMessages.push({
+									is_thinking: item.metadata?.type === "thinking",
+									type: "step_notification",
+									text: item.metadata.tool_title,
+								});
 							} else if (
 								item.type === "ack" ||
-								item.type === "notification" ||
 								item.type === "search_datasets" ||
 								item.type === "file" ||
 								item.type === "conv_title"

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -57,7 +57,7 @@ export interface BaseMessage {
 }
 
 export interface TextMessage extends BaseMessage {
-	type: "text" | "text_chunk";
+	type: "text" | "text_chunk" | "step_notification";
 	text: string;
 }
 

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -634,4 +634,143 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			{ is_thinking: false, type: "text_chunk", text: "two" },
 		]);
 	});
+
+	it("parses a step_notification event and stores a step_notification message", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "notification", code: "TOOL_CALL_NOTIFICATION", metadata: { tool_title: "Running query" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			{ is_thinking: false, type: "step_notification", text: "Running query" },
+		]);
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+	});
+
+	it("sets is_thinking=true on a step_notification event when metadata.type is 'thinking'", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "notification", code: "TOOL_CALL_NOTIFICATION", metadata: { tool_title: "Thinking step", type: "thinking" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			{ is_thinking: true, type: "step_notification", text: "Thinking step" },
+		]);
+	});
+
+	it("records a step_notification metric for a TOOL_CALL_NOTIFICATION event", async () => {
+		const storage = makeMockStorage();
+		const recorder: MetricsRecorder = {
+			...NOOP_METRICS_RECORDER,
+			count: vi.fn(),
+		};
+		const line = `data: ${JSON.stringify([{ type: "notification", code: "TOOL_CALL_NOTIFICATION", metadata: { tool_title: "Running query" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+			recorder,
+		);
+
+		expect(recorder.count).toHaveBeenCalledWith(
+			METRIC_NAMES.upstreamStreamMessagesTotal,
+			1,
+			expect.objectContaining({
+				upstream_operation: "send_agent_conversation_message_streaming",
+				message_type: "step_notification",
+				is_thinking: false,
+			}),
+		);
+	});
+
+	it("increments total_text_messages_parsed for a step_notification event", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "notification", code: "TOOL_CALL_NOTIFICATION", metadata: { tool_title: "Running query" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 1,
+			total_text_messages_parsed: 1,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 0,
+		});
+	});
+
+	it("ignores a notification event when code is not TOOL_CALL_NOTIFICATION", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "notification", code: "OTHER_NOTIFICATION", metadata: { tool_title: "Running query" } }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 1,
+		});
+	});
+
+	it("ignores a notification event when metadata.tool_title is missing", async () => {
+		const storage = makeMockStorage();
+		const line = `data: ${JSON.stringify([{ type: "notification", code: "TOOL_CALL_NOTIFICATION", metadata: {} }])}\n`;
+		const reader = makeReader([line]);
+
+		await processSendAgentConversationMessageStreamingResponse(
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			INSTANCE_URL,
+		);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 1,
+		});
+	});
 });


### PR DESCRIPTION
- Add a new message type for step_notification, which indicates the major steps which the agent is working through while generating its response
- Add test coverage