### PR TITLE
Aggregate same-series counters in Analytics Engine sink

### DIFF
--- a/src/metrics/runtime/analytics-engine-sink.ts
+++ b/src/metrics/runtime/analytics-engine-sink.ts
@@ -203,11 +203,56 @@ export function toAnalyticsEngineDataPoint(
 	};
 }
 
+function counterSeriesKey(observation: MetricObservation): string {
+	const labelEntries = Object.entries(observation.labels)
+		.filter(([, value]) => value !== undefined)
+		.sort(([a], [b]) => a.localeCompare(b));
+	return JSON.stringify([observation.name, labelEntries]);
+}
+
+// Analytics Engine allows at most 25 writeDataPoint calls per Worker
+// invocation; per-event counters (e.g. one increment per upstream stream
+// message) can produce hundreds of observations in a single flush, so
+// counters sharing a series (name + labels) are summed into one data point.
+// Histograms and gauges keep one point per observation: summing would
+// destroy percentile/last-value semantics.
+export function aggregateCounterObservations(
+	observations: readonly MetricObservation[],
+): MetricObservation[] {
+	const aggregated: MetricObservation[] = [];
+	const counters = new Map<string, MetricObservation>();
+
+	for (const observation of observations) {
+		if (observation.kind !== "counter") {
+			aggregated.push(observation);
+			continue;
+		}
+
+		const key = counterSeriesKey(observation);
+		const existing = counters.get(key);
+		if (existing) {
+			existing.value += observation.value;
+			existing.timestampMs = Math.max(
+				existing.timestampMs,
+				observation.timestampMs,
+			);
+		} else {
+			const copy = { ...observation, labels: { ...observation.labels } };
+			counters.set(key, copy);
+			aggregated.push(copy);
+		}
+	}
+
+	return aggregated;
+}
+
 export class AnalyticsEngineMetricsSink implements MetricsSink {
 	constructor(private readonly dataset: AnalyticsEngineDatasetLike) {}
 
 	async flush(payload: MetricsFlushPayload): Promise<void> {
-		for (const observation of payload.observations) {
+		for (const observation of aggregateCounterObservations(
+			payload.observations,
+		)) {
 			try {
 				this.dataset.writeDataPoint(
 					toAnalyticsEngineDataPoint(

--- a/test/metrics/runtime/analytics-engine-sink.spec.ts
+++ b/test/metrics/runtime/analytics-engine-sink.spec.ts
@@ -196,6 +196,79 @@ describe("AnalyticsEngineMetricsSink", () => {
 		);
 	});
 
+	it("sums same-series counter observations into a single data point", async () => {
+		const dataset = { writeDataPoint: vi.fn() };
+		const sink = new AnalyticsEngineMetricsSink(dataset);
+		const streamMessage = {
+			kind: "counter",
+			name: METRIC_NAMES.upstreamStreamMessagesTotal,
+			value: 1,
+			labels: {
+				upstream_operation: "agent_conversation",
+				message_type: "data",
+				is_thinking: "false",
+			},
+			timestampMs: 1_714_000_000_000,
+		} satisfies MetricObservation;
+
+		await sink.flush({
+			observations: [
+				streamMessage,
+				{ ...streamMessage, timestampMs: 1_714_000_000_500 },
+				{ ...streamMessage, timestampMs: 1_714_000_000_250 },
+			],
+			resourceAttributes: {},
+		});
+
+		expect(dataset.writeDataPoint).toHaveBeenCalledTimes(1);
+		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
+			expect.objectContaining({
+				doubles: [3, 1_714_000_000_500],
+			}),
+		);
+	});
+
+	it("keeps counters with different names or labels as separate data points", async () => {
+		const dataset = { writeDataPoint: vi.fn() };
+		const sink = new AnalyticsEngineMetricsSink(dataset);
+
+		await sink.flush({
+			observations: [
+				observation,
+				{ ...observation, labels: { ...observation.labels, outcome: "error" } },
+				{ ...observation, name: METRIC_NAMES.httpRequestsTotal },
+			],
+			resourceAttributes: {},
+		});
+
+		expect(dataset.writeDataPoint).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not aggregate histogram observations", async () => {
+		const dataset = { writeDataPoint: vi.fn() };
+		const sink = new AnalyticsEngineMetricsSink(dataset);
+		const histogram = {
+			kind: "histogram",
+			name: METRIC_NAMES.toolDurationMs,
+			value: 120,
+			labels: { tool_name: "create_liveboard", outcome: "success" },
+			timestampMs: 1_714_000_000_000,
+		} satisfies MetricObservation;
+
+		await sink.flush({
+			observations: [histogram, { ...histogram, value: 340 }],
+			resourceAttributes: {},
+		});
+
+		expect(dataset.writeDataPoint).toHaveBeenCalledTimes(2);
+		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
+			expect.objectContaining({ doubles: [120, 1_714_000_000_000] }),
+		);
+		expect(dataset.writeDataPoint).toHaveBeenCalledWith(
+			expect.objectContaining({ doubles: [340, 1_714_000_000_000] }),
+		);
+	});
+
 	it("continues writing remaining data points when one write fails", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const secondObservation = {


### PR DESCRIPTION
Analytics Engine allows at most 25 writeDataPoint calls per Worker invocation. Per-event counters (one increment per upstream stream message) produced hundreds of observations in a single flush, so writes past the cap threw and were dropped (~10-15% undercount on ts_mcp_upstream_stream_messages_total, occasionally clipping tool metrics flushed in the same invocation).

Sum counter observations sharing a series (name + labels) into one data point before writing. Histograms and gauges keep one point per observation.