### PR TITLE
Add raw Spotter output mode behind a flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,10 @@ const hooks: AuthHooks<Props> = {
 		props.apiVersion = apiVersion;
 		props.apiVersionMode = apiVersionMode;
 
+		const enableRawSessionUpdates =
+			url.searchParams.get("enable-raw-session-updates") === "true";
+		props.enableRawSessionUpdates = enableRawSessionUpdates;
+
 		return props;
 	},
 };
@@ -149,6 +153,9 @@ const oauthFetchHandler = createOAuthHandler<Props>({
 			apiVersionMode = resolveRequestedApiVersionMode(apiVersion);
 		}
 
+		const enableRawSessionUpdates =
+			url.searchParams.get("enable-raw-session-updates") === "true";
+
 		return {
 			...(baseProps as Props),
 			clientName: normalizeClientName(baseProps.clientName),
@@ -159,6 +166,7 @@ const oauthFetchHandler = createOAuthHandler<Props>({
 			apiVersionMode,
 			// OAuth-authenticated flow; enables the OAuth-only org tools.
 			authMode: "oauth",
+			enableRawSessionUpdates,
 		};
 	},
 	// Extra routes mounted on the default handler app (consumer-specific).

--- a/src/servers/conversation-storage-server.ts
+++ b/src/servers/conversation-storage-server.ts
@@ -1,5 +1,9 @@
 import { isBoolean } from "lodash";
-import type { Message, StreamingMessagesState } from "../thoughtspot/types";
+import type {
+	Message,
+	RawMessage,
+	StreamingMessagesState,
+} from "../thoughtspot/types";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const STORAGE_BATCH_SIZE = 127; // Cloudflare DO bulk get/put limit is 128, we use 127 to be safe
@@ -93,7 +97,7 @@ export class ConversationStorageServerSQLite {
 	 * will never think the conversation is done before all messages have been written.
 	 */
 	private async appendMessagesAndRestartTtl(
-		newMessages: Message[],
+		newMessages: (Message | RawMessage)[],
 		isDone = false,
 	): Promise<void> {
 		const existingIsDone = await this.state.storage.get<boolean>(IS_DONE_KEY);
@@ -107,7 +111,10 @@ export class ConversationStorageServerSQLite {
 		}
 
 		let idx = (await this.state.storage.get<number>(WRITE_BOOKMARK_KEY)) ?? 0;
-		const entriesToStore = {} as Record<string, Message | number | boolean>;
+		const entriesToStore = {} as Record<
+			string,
+			Message | RawMessage | number | boolean
+		>;
 		for (const message of newMessages) {
 			entriesToStore[`${MESSAGE_KEY_PREFIX}${idx}`] = message;
 			idx++;
@@ -140,8 +147,8 @@ export class ConversationStorageServerSQLite {
 			keys.push(MESSAGE_KEY_PREFIX + i);
 		}
 
-		const newMessages: Message[] = [];
-		const messagesMap = await this.getInBatches<Message>(keys);
+		const newMessages: (Message | RawMessage)[] = [];
+		const messagesMap = await this.getInBatches<Message | RawMessage>(keys);
 		for (let i = readBookmark; i < writeBookmark; i++) {
 			const message = messagesMap.get(MESSAGE_KEY_PREFIX + i);
 			if (!message) {

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -19,6 +19,7 @@ import type {
 } from "../thoughtspot/thoughtspot-service";
 import {
 	type Answer,
+	SpotterResponseFormat,
 	type StreamingMessagesState,
 	ThoughtSpotApiError,
 } from "../thoughtspot/types";
@@ -356,10 +357,18 @@ export class MCPServer extends BaseMCPServer {
 			versionConfig.version[versionConfig.version.length - 1],
 		);
 
-		// Get base tools from version config
 		let tools = [...versionConfig.tools];
 
-		// Filter out GetDataSourceSuggestions if feature flag is not available
+		// Select which get_session_updates tool to expose based on raw session updates flag (for
+		// v1 toolset we don't do anything)
+		const toolIdxToDrop = this.ctx.props.enableRawSessionUpdates
+			? tools.findIndex((tool) => tool.name === ToolName.GetSessionUpdates)
+			: tools.findLastIndex((tool) => tool.name === ToolName.GetSessionUpdates);
+		if (toolIdxToDrop !== -1) {
+			tools.splice(toolIdxToDrop, 1);
+		}
+
+		// Filter out GetDataSourceSuggestions if feature is disabled
 		if (
 			!this.isSpotterDataSourceDiscoveryEnabled() &&
 			tools.some((tool) => tool.name === ToolName.GetDataSourceSuggestions)
@@ -369,6 +378,7 @@ export class MCPServer extends BaseMCPServer {
 			);
 		}
 
+		// Filter out orgs tools if feature is disabled
 		if (!this.areOrgToolsAvailable()) {
 			tools = tools.filter(
 				(tool) =>
@@ -784,6 +794,9 @@ Provide this url to the user as a link to view the liveboard in ThoughtSpot.`;
 			}).sendAgentConversationMessageStreaming(
 				analytical_session_id,
 				message,
+				this.ctx.props.enableRawSessionUpdates
+					? SpotterResponseFormat.RAW
+					: SpotterResponseFormat.SIMPLIFIED,
 				storageService.appendMessages.bind(storageService),
 				additional_context,
 			);

--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -537,10 +537,8 @@ export const toolDefinitionsV1 = [
 	},
 ];
 
-const GET_SESSION_UPDATES_BASE_TOOL_DEFINITION = {
+const GET_SESSION_UPDATES_SHARED_TOOL_DEFINITION = {
 	name: ToolName.GetSessionUpdates,
-	description:
-		"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true. If the completed response indicates that no data or no results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org or the user may not have access to it in the current org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.",
 	inputSchema: z.toJSONSchema(GetSessionUpdatesInputSchema),
 	annotations: {
 		title: "Get Analysis Session Updates",
@@ -549,6 +547,12 @@ const GET_SESSION_UPDATES_BASE_TOOL_DEFINITION = {
 		openWorldHint: false,
 	},
 };
+
+const GET_SESSION_UPDATES_STRUCTURED_DESCRIPTION =
+	"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true. If the completed response indicates that no data or no results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org or the user may not have access to it in the current org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.";
+
+const GET_SESSION_UPDATES_RAW_DESCRIPTION =
+	"Get the latest updates from the Analytics Agent, returned in their raw upstream form. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. Each item in `session_updates` has no guaranteed shape, since it is passed through unfiltered from the upstream Agent — inspect each item's fields defensively rather than assuming a fixed structure, though answer-type items still carry an `answer_id` you can pass to `create_dashboard`. When `is_done` is true, the Agent has finished responding and no further updates will arrive for this message; you can also send a follow-up message in the same session at that point. If you cannot tell from the raw updates whether any data or results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org or the user may not have access to it in the current org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.";
 
 export const toolDefinitionsV2 = [
 	{
@@ -618,11 +622,13 @@ export const toolDefinitionsV2 = [
 	// There are two versions of the get_session_updates tool; we will filter the tool list to pick
 	// only the version we want based on whether the raw session updates flag is enabled or not
 	{
-		...GET_SESSION_UPDATES_BASE_TOOL_DEFINITION,
+		...GET_SESSION_UPDATES_SHARED_TOOL_DEFINITION,
+		description: GET_SESSION_UPDATES_STRUCTURED_DESCRIPTION,
 		outputSchema: z.toJSONSchema(GetSessionUpdatesOutputSchema),
 	},
 	{
-		...GET_SESSION_UPDATES_BASE_TOOL_DEFINITION,
+		...GET_SESSION_UPDATES_SHARED_TOOL_DEFINITION,
+		description: GET_SESSION_UPDATES_RAW_DESCRIPTION,
 		outputSchema: z.toJSONSchema(GetSessionUpdatesRawOutputSchema),
 	},
 	{

--- a/src/servers/tool-definitions.ts
+++ b/src/servers/tool-definitions.ts
@@ -333,6 +333,19 @@ export const GetSessionUpdatesOutputSchema = z.object({
 		),
 });
 
+export const GetSessionUpdatesRawOutputSchema = z.object({
+	session_updates: z
+		.array(z.unknown())
+		.describe(
+			"List of incremental new updates from the analytical session. The updates can be in any format, with no guarantees on their structure. Updates returned in a previous response will not be sent again. This may be an empty list if the Analytics Agent is still thinking. You can instead use the `is_done` flag to know whether the Agent response is complete.",
+		),
+	is_done: z
+		.boolean()
+		.describe(
+			"Whether the Analytics Agent has finished responding. If `is_done` is false, you can make another `get_session_updates` call to get the next set of updates.",
+		),
+});
+
 export const CreateLiveboardSchema = z.object({
 	name: z.string().describe("The name of the liveboard to create"),
 	answers: z
@@ -524,6 +537,19 @@ export const toolDefinitionsV1 = [
 	},
 ];
 
+const GET_SESSION_UPDATES_BASE_TOOL_DEFINITION = {
+	name: ToolName.GetSessionUpdates,
+	description:
+		"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true. If the completed response indicates that no data or no results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org or the user may not have access to it in the current org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.",
+	inputSchema: z.toJSONSchema(GetSessionUpdatesInputSchema),
+	annotations: {
+		title: "Get Analysis Session Updates",
+		readOnlyHint: true,
+		destructiveHint: false,
+		openWorldHint: false,
+	},
+};
+
 export const toolDefinitionsV2 = [
 	{
 		name: ToolName.SearchObjects,
@@ -589,18 +615,15 @@ export const toolDefinitionsV2 = [
 			openWorldHint: false,
 		},
 	},
+	// There are two versions of the get_session_updates tool; we will filter the tool list to pick
+	// only the version we want based on whether the raw session updates flag is enabled or not
 	{
-		name: ToolName.GetSessionUpdates,
-		description:
-			"Get the latest updates from the Analytics Agent. You can call this after `send_session_message` to retrieve the Agent's response. If `is_done` is false, you can call this tool again to continue polling, as the Agent is still generating a response. Even if `is_done` is false, you can use the updates to show status updates or progress to the user, so that they are informed about the ongoing process. An empty `session_updates` list while `is_done` is false is normal; it means the Agent is still thinking. When `is_done` is true, the Agent has finished and the results in `session_updates` are complete, so you can present them to the user. You can also send a follow-up message in the same session after `is_done` is true. If the completed response indicates that no data or no results were found, AND the `list_orgs` tool is available to you, the requested data may live in a different org or the user may not have access to it in the current org: tell the user this and that they can call `list_orgs` to see their orgs (the active one is marked `is_active`) and `switch_org` to switch to another org, then retry. If `list_orgs` is not available, do not mention orgs.",
-		inputSchema: z.toJSONSchema(GetSessionUpdatesInputSchema),
+		...GET_SESSION_UPDATES_BASE_TOOL_DEFINITION,
 		outputSchema: z.toJSONSchema(GetSessionUpdatesOutputSchema),
-		annotations: {
-			title: "Get Analysis Session Updates",
-			readOnlyHint: true,
-			destructiveHint: false,
-			openWorldHint: false,
-		},
+	},
+	{
+		...GET_SESSION_UPDATES_BASE_TOOL_DEFINITION,
+		outputSchema: z.toJSONSchema(GetSessionUpdatesRawOutputSchema),
 	},
 	{
 		name: ToolName.CreateDashboard,

--- a/src/storage-service/storage-service.ts
+++ b/src/storage-service/storage-service.ts
@@ -1,4 +1,8 @@
-import type { Message, StreamingMessagesState } from "../thoughtspot/types";
+import type {
+	Message,
+	RawMessage,
+	StreamingMessagesState,
+} from "../thoughtspot/types";
 
 /**
  * Client for the ConversationStorageServer Durable Object.
@@ -62,7 +66,7 @@ export class StorageServiceClient {
 	 */
 	async appendMessages(
 		conversationId: string,
-		messages: Message[],
+		messages: (Message | RawMessage)[],
 		isDone = false,
 	): Promise<void> {
 		const body: StreamingMessagesState = { messages, isDone };

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -5,7 +5,7 @@ import {
 	recordUpstreamStreamMessageMetric,
 } from "./metrics/runtime/tool-metrics";
 import { withSpan } from "./metrics/tracing/tracing-utils";
-import type { Message } from "./thoughtspot/types";
+import { type Message, SpotterResponseFormat } from "./thoughtspot/types";
 
 /*
  * Handles processing the event stream from a send agent conversation message response. Reads from
@@ -13,6 +13,8 @@ import type { Message } from "./thoughtspot/types";
  * wrap it with a span to collect relevant metrics during processing.
  */
 export const processSendAgentConversationMessageStreamingResponse = async (
+	instanceUrl: string,
+	spotterResponseFormat: SpotterResponseFormat,
 	conversationId: string,
 	streamingResponseReader: ReadableStreamDefaultReader,
 	appendStoredMessages: (
@@ -20,7 +22,6 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 		messages: Message[],
 		isDone?: boolean,
 	) => Promise<void>,
-	instanceUrl: string,
 	recorder?: MetricsRecorder,
 ) => {
 	return await withSpan(
@@ -78,6 +79,14 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 
 						// Loop through the items in the line and convert to messages if applicable
 						for (const item of data) {
+							// For the raw format, we don't need to perform any post-processing, so
+							// just add the messages directly
+							if (spotterResponseFormat === SpotterResponseFormat.RAW) {
+								newMessages.push({ ...item });
+								continue;
+							}
+
+							// For the simplified format, we perform some further processing
 							if (item.type === "text") {
 								// Ignore non-markdown text messages
 								if (item.metadata?.format !== "markdown") {

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -5,7 +5,11 @@ import {
 	recordUpstreamStreamMessageMetric,
 } from "./metrics/runtime/tool-metrics";
 import { withSpan } from "./metrics/tracing/tracing-utils";
-import { type Message, SpotterResponseFormat } from "./thoughtspot/types";
+import {
+	type Message,
+	type RawMessage,
+	SpotterResponseFormat,
+} from "./thoughtspot/types";
 
 /*
  * Handles processing the event stream from a send agent conversation message response. Reads from
@@ -19,7 +23,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 	streamingResponseReader: ReadableStreamDefaultReader,
 	appendStoredMessages: (
 		conversationId: string,
-		messages: Message[],
+		messages: (Message | RawMessage)[],
 		isDone?: boolean,
 	) => Promise<void>,
 	recorder?: MetricsRecorder,
@@ -59,7 +63,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 					buffer = lines.pop() || "";
 
 					// Loop through the lines and parse them into messages to be stored
-					const newMessages: Message[] = [];
+					const newMessages: (Message | RawMessage)[] = [];
 					for (const line of lines) {
 						// Ignore blank lines and heartbeats
 						if (line === "" || line === ": heartbeat") {
@@ -79,10 +83,79 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 
 						// Loop through the items in the line and convert to messages if applicable
 						for (const item of data) {
-							// For the raw format, we don't need to perform any post-processing, so
-							// just add the messages directly
+							// For the raw format, we don't reshape messages, but we still record
+							// metrics and flag span errors so upstream failures stay observable,
+							// and we still synthesize `answer_id` on answer events so the
+							// get_session_updates -> create_dashboard handoff keeps working.
 							if (spotterResponseFormat === SpotterResponseFormat.RAW) {
-								newMessages.push({ ...item });
+								if (item.type === "text" || item.type === "text-chunk") {
+									if (item.metadata?.format === "markdown") {
+										nTextMessagesParsed++;
+										recordUpstreamStreamMessageMetric(
+											recorder,
+											upstreamOperation,
+											item.type === "text-chunk" ? "text_chunk" : "text",
+											item.metadata?.type === "thinking",
+										);
+									} else {
+										nMessagesIgnored++;
+									}
+								} else if (item.type === "answer") {
+									nAnswerMessagesParsed++;
+									recordUpstreamStreamMessageMetric(
+										recorder,
+										upstreamOperation,
+										"answer",
+										item.metadata?.type === "thinking",
+									);
+								} else if (item.type === "notification") {
+									if (
+										item.code === "TOOL_CALL_NOTIFICATION" &&
+										item.metadata?.tool_title
+									) {
+										nTextMessagesParsed++;
+										recordUpstreamStreamMessageMetric(
+											recorder,
+											upstreamOperation,
+											"step_notification",
+											item.metadata?.type === "thinking",
+										);
+									} else {
+										nMessagesIgnored++;
+									}
+								} else if (item.type === "error") {
+									console.error(
+										"Error event in event stream, error code",
+										item.error_code,
+									);
+									recordUpstreamStreamMessageMetric(
+										recorder,
+										upstreamOperation,
+										"error",
+										false,
+									);
+									spanHasError = true;
+									span.setStatus({
+										code: SpanStatusCode.ERROR,
+										message: `Error event in event stream, error code: ${item.error_code}`,
+									});
+								} else {
+									// Includes ack/search_datasets/file/conv_title (intentionally
+									// ignored upstream events) and any unrecognized event type.
+									nMessagesIgnored++;
+								}
+
+								newMessages.push(
+									item.type === "answer"
+										? {
+												...item,
+												answer_id: JSON.stringify({
+													session_id: item.metadata?.session_id,
+													gen_no: item.metadata?.gen_no,
+												}),
+											}
+										: { ...item },
+								);
 								continue;
 							}
 

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -31,6 +31,7 @@ import type {
 	DataSourceSuggestion,
 	Message,
 	SessionInfo,
+	SpotterResponseFormat,
 } from "./types";
 
 type ThoughtSpotServiceMetricsOptions = {
@@ -342,6 +343,7 @@ export class ThoughtSpotService {
 	async sendAgentConversationMessageStreaming(
 		conversationId: string,
 		message: string,
+		spotterResponseFormat: SpotterResponseFormat,
 		appendStoredMessages: (
 			conversationId: string,
 			messages: Message[],
@@ -388,10 +390,11 @@ export class ThoughtSpotService {
 
 			const processStreamPromise =
 				processSendAgentConversationMessageStreamingResponse(
+					(this.client as any).instanceUrl,
+					spotterResponseFormat,
 					conversationId,
 					reader,
 					appendStoredMessages,
-					(this.client as any).instanceUrl,
 					streamRecorder,
 				).finally(() => {
 					this.scheduleBackgroundMetricsFlush(streamRecorder);

--- a/src/thoughtspot/thoughtspot-service.ts
+++ b/src/thoughtspot/thoughtspot-service.ts
@@ -30,6 +30,7 @@ import type {
 	DataSource,
 	DataSourceSuggestion,
 	Message,
+	RawMessage,
 	SessionInfo,
 	SpotterResponseFormat,
 } from "./types";
@@ -346,7 +347,7 @@ export class ThoughtSpotService {
 		spotterResponseFormat: SpotterResponseFormat,
 		appendStoredMessages: (
 			conversationId: string,
-			messages: Message[],
+			messages: (Message | RawMessage)[],
 			isDone?: boolean,
 		) => Promise<void>,
 		additionalContext?: string | undefined,

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -77,8 +77,12 @@ export interface AnswerMessage extends BaseMessage {
 
 export type Message = TextMessage | AnswerMessage;
 
+// In raw mode, upstream events are passed through unmodified instead of being reshaped into a
+// `Message`, so their shape is not guaranteed to match `Message` at all.
+export type RawMessage = Record<string, unknown>;
+
 export interface StreamingMessagesState {
-	messages: Message[];
+	messages: (Message | RawMessage)[];
 	isDone: boolean;
 }
 

--- a/src/thoughtspot/types.ts
+++ b/src/thoughtspot/types.ts
@@ -52,6 +52,11 @@ export interface SessionInfo {
 	isSpotterChatHistoryEnabled?: boolean;
 }
 
+export enum SpotterResponseFormat {
+	SIMPLIFIED = "SIMPLIFIED",
+	RAW = "RAW",
+}
+
 export interface BaseMessage {
 	is_thinking: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,10 +8,8 @@ import { getActiveSpan } from "./metrics/tracing/tracing-utils";
 
 export type Props = {
 	accessToken: string;
-	// From gettoken, for keep-warm refresh.
 	globalRefreshToken?: string;
 	globalTokenCreatedAt?: number;
-	// Absolute epoch-ms expiry.
 	globalTokenExpiresAt?: number;
 	instanceUrl: string;
 	clientName: {
@@ -22,8 +20,8 @@ export type Props = {
 	apiVersion?: string;
 	apiVersionMode?: ApiVersionMode;
 	apiRequestedVersion?: string;
-	// Auth method ("oauth" vs "bearer"/"token"); gates OAuth-only tools.
 	authMode?: AuthMode;
+	enableRawSessionUpdates?: boolean;
 };
 
 const DEFAULT_CLIENT_NAME = "Bearer Token client";

--- a/test/servers/mcp-server-v2.integration.spec.ts
+++ b/test/servers/mcp-server-v2.integration.spec.ts
@@ -26,7 +26,10 @@ import { MCPServer } from "../../src/servers/mcp-server";
 import { StorageServiceClient } from "../../src/storage-service/storage-service";
 import { processSendAgentConversationMessageStreamingResponse } from "../../src/streaming-utils";
 import * as thoughtspotClient from "../../src/thoughtspot/thoughtspot-client";
-import type { Message } from "../../src/thoughtspot/types";
+import {
+	type Message,
+	SpotterResponseFormat,
+} from "../../src/thoughtspot/types";
 import { makeReader, makeRequest } from "./helpers";
 
 vi.mock("../../src/metrics/mixpanel/mixpanel", () => ({
@@ -289,6 +292,7 @@ describe("V2 MCPServer + Real Storage Integration", () => {
 					async (
 						convId: string,
 						_msg: string,
+						_format: SpotterResponseFormat,
 						appendFn: typeof realStorage.appendMessages,
 					) => {
 						await appendFn(convId, [expectedMessages[0]]);
@@ -326,6 +330,7 @@ describe("V2 MCPServer + Real Storage Integration", () => {
 					async (
 						convId: string,
 						_msg: string,
+						_format: SpotterResponseFormat,
 						appendFn: typeof realStorage.appendMessages,
 					) => {
 						// Intentionally omit isDone: true — the conversation stays "in progress"
@@ -379,6 +384,7 @@ describe("V2 MCPServer + Real Storage Integration", () => {
 					async (
 						convId: string,
 						_msg: string,
+						_format: SpotterResponseFormat,
 						appendFn: typeof realStorage.appendMessages,
 					) => {
 						await appendFn(convId, [msg1], true /* isDone */);
@@ -412,6 +418,7 @@ describe("V2 MCPServer + Real Storage Integration", () => {
 					async (
 						convId: string,
 						_msg: string,
+						_format: SpotterResponseFormat,
 						appendFn: typeof realStorage.appendMessages,
 					) => {
 						await appendFn(convId, [msg2], true /* isDone */);
@@ -455,10 +462,11 @@ describe("V2 Streaming Parser + Real Storage Integration", () => {
 		]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			"stream-conv-1",
 			reader,
 			client.appendMessages.bind(client),
-			INSTANCE_URL,
 		);
 
 		const state = await client.getNewMessages("stream-conv-1");
@@ -490,10 +498,11 @@ describe("V2 Streaming Parser + Real Storage Integration", () => {
 		const reader = makeReader([`data: ${JSON.stringify([answerEvent])}\n`]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			"stream-conv-2",
 			reader,
 			client.appendMessages.bind(client),
-			INSTANCE_URL,
 		);
 
 		const state = await client.getNewMessages("stream-conv-2");
@@ -519,10 +528,11 @@ describe("V2 Streaming Parser + Real Storage Integration", () => {
 		const reader = makeReader([thinkingLine, answerLine, textLine]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			"stream-conv-3",
 			reader,
 			client.appendMessages.bind(client),
-			INSTANCE_URL,
 		);
 
 		const state = await client.getNewMessages("stream-conv-3");

--- a/test/servers/mcp-server.spec.ts
+++ b/test/servers/mcp-server.spec.ts
@@ -6,6 +6,7 @@ import { METRIC_NAMES } from "../../src/metrics/runtime/metric-types";
 import { MCPServer } from "../../src/servers/mcp-server";
 import * as thoughtspotClient from "../../src/thoughtspot/thoughtspot-client";
 import { ThoughtSpotService } from "../../src/thoughtspot/thoughtspot-service";
+import { SpotterResponseFormat } from "../../src/thoughtspot/types";
 import { makeRequest } from "./helpers";
 
 // Mock the MixpanelTracker
@@ -1501,6 +1502,7 @@ describe("MCP Server", () => {
 			expect(mockSendAgentConversationMessageStreaming).toHaveBeenCalledWith(
 				"conv-abc-123",
 				"What is the total revenue?",
+				SpotterResponseFormat.SIMPLIFIED,
 				expect.any(Function),
 				undefined,
 			);
@@ -1519,6 +1521,7 @@ describe("MCP Server", () => {
 			expect(mockSendAgentConversationMessageStreaming).toHaveBeenCalledWith(
 				"conv-abc-123",
 				"Compare revenue by region",
+				SpotterResponseFormat.SIMPLIFIED,
 				expect.any(Function),
 				"The user is focused on North America",
 			);
@@ -1949,7 +1952,12 @@ describe("MCP Server", () => {
 				sendAgentConversationMessageStreaming: vi
 					.fn()
 					.mockImplementation(
-						async (convId: string, _msg: string, appendFn: any) => {
+						async (
+							convId: string,
+							_msg: string,
+							_format: SpotterResponseFormat,
+							appendFn: any,
+						) => {
 							await appendFn(convId, [expectedMessages[0]]);
 							await appendFn(convId, [expectedMessages[1]], true);
 						},
@@ -1982,7 +1990,12 @@ describe("MCP Server", () => {
 			const mockSendStreaming = vi
 				.fn()
 				.mockImplementation(
-					async (convId: string, _msg: string, appendFn: any) => {
+					async (
+						convId: string,
+						_msg: string,
+						_format: SpotterResponseFormat,
+						appendFn: any,
+					) => {
 						await appendFn(convId, [], true);
 					},
 				);
@@ -2018,7 +2031,12 @@ describe("MCP Server", () => {
 			const mockSendStreaming = vi
 				.fn()
 				.mockImplementation(
-					async (convId: string, _msg: string, appendFn: any) => {
+					async (
+						convId: string,
+						_msg: string,
+						_format: SpotterResponseFormat,
+						appendFn: any,
+					) => {
 						await appendFn(convId, [], true);
 					},
 				);
@@ -2047,9 +2065,9 @@ describe("MCP Server", () => {
 			);
 
 			// Without context: additional_context arg is undefined
-			expect(mockSendStreaming.mock.calls[0][3]).toBeUndefined();
+			expect(mockSendStreaming.mock.calls[0][4]).toBeUndefined();
 			// With context: additional_context is forwarded to the service
-			expect(mockSendStreaming.mock.calls[1][3]).toBe(
+			expect(mockSendStreaming.mock.calls[1][4]).toBe(
 				"Fiscal year starts in April",
 			);
 		});

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -1,3 +1,4 @@
+import { SpanStatusCode } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const tracingState = vi.hoisted(() => ({
 	span: undefined as
@@ -27,6 +28,7 @@ import {
 	NOOP_METRICS_RECORDER,
 } from "../src/metrics/runtime/metrics-recorder";
 import { processSendAgentConversationMessageStreamingResponse } from "../src/streaming-utils";
+import { SpotterResponseFormat } from "../src/thoughtspot/types";
 import { makeReader } from "./servers/helpers";
 
 // Mock storage
@@ -61,10 +63,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
@@ -81,10 +84,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -108,10 +112,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 			recorder,
 		);
 
@@ -132,10 +137,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -149,10 +155,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -166,10 +173,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -183,10 +191,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		// Only the terminal done call should have been made (no message stored)
@@ -210,10 +219,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
@@ -240,10 +250,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 			recorder,
 		);
 
@@ -256,10 +267,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
@@ -282,10 +294,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
@@ -318,10 +331,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -351,10 +365,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		const expectedIframeUrl = `${INSTANCE_URL}/?tsmcp=true#/embed/conv-assist-answer?sessionId=sess-1&genNo=42&acSessionId=txn-1&acGenNo=7`;
@@ -386,10 +401,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		const expectedIframeUrl = `${INSTANCE_URL}/?tsmcp=true#/embed/conv-assist-answer?sessionId=sess-2&genNo=1&acSessionId=txn-2&acGenNo=2`;
@@ -411,10 +427,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -428,10 +445,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -445,10 +463,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
@@ -473,10 +492,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		// Only the terminal done call should have been made (no messages stored)
@@ -495,10 +515,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([chunk]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -512,10 +533,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([chunk]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -531,10 +553,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([chunk]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -549,10 +572,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -571,10 +595,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([part1, part2]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -589,10 +614,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([chunk1, chunk2]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenNthCalledWith(
@@ -623,10 +649,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([chunk]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -641,10 +668,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -663,10 +691,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
@@ -684,10 +713,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 			recorder,
 		);
 
@@ -708,10 +738,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
@@ -728,10 +759,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
@@ -754,10 +786,11 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		const reader = makeReader([line]);
 
 		await processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.SIMPLIFIED,
 			CONV_ID,
 			reader,
 			storage.appendMessages,
-			INSTANCE_URL,
 		);
 
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
@@ -771,6 +804,234 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
 			total_messages_ignored: 1,
+		});
+	});
+});
+
+describe("processSendAgentConversationMessageStreamingResponse — raw format", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		tracingState.span = undefined;
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	const processRaw = (
+		reader: ReadableStreamDefaultReader,
+		storage: ReturnType<typeof makeMockStorage>,
+		recorder?: MetricsRecorder,
+	) =>
+		processSendAgentConversationMessageStreamingResponse(
+			INSTANCE_URL,
+			SpotterResponseFormat.RAW,
+			CONV_ID,
+			reader,
+			storage.appendMessages,
+			recorder,
+		);
+
+	it("stores a text event verbatim instead of reshaping it", async () => {
+		const storage = makeMockStorage();
+		const item = {
+			type: "text",
+			content: "Hello world",
+			metadata: { format: "markdown" },
+		};
+		const reader = makeReader([`data: ${JSON.stringify([item])}\n`]);
+
+		await processRaw(reader, storage);
+
+		// Raw mode passes the upstream item straight through — no is_thinking/text
+		// projection like the simplified format performs.
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			item,
+		]);
+	});
+
+	it("keeps text events that the simplified format drops for non-markdown", async () => {
+		const storage = makeMockStorage();
+		const plain = {
+			type: "text",
+			content: "Plain text",
+			metadata: { format: "plain" },
+		};
+		const noFormat = { type: "text", content: "No format at all" };
+		const reader = makeReader([`data: ${JSON.stringify([plain, noFormat])}\n`]);
+
+		await processRaw(reader, storage);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			plain,
+			noFormat,
+		]);
+	});
+
+	it("keeps ack, notification, search_datasets, file, and conv_title events", async () => {
+		const storage = makeMockStorage();
+		const items = [
+			{ type: "ack" },
+			{ type: "notification", code: "OTHER_NOTIFICATION", metadata: {} },
+			{ type: "search_datasets", datasets: ["ds-1"] },
+			{ type: "file", url: "https://example.com/f.csv" },
+			{ type: "conv_title", title: "Revenue analysis" },
+		];
+		const reader = makeReader([`data: ${JSON.stringify(items)}\n`]);
+
+		await processRaw(reader, storage);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(
+			CONV_ID,
+			items,
+		);
+	});
+
+	it("keeps unknown event types without logging a warning", async () => {
+		const storage = makeMockStorage();
+		const item = { type: "some_future_event_type", payload: { a: 1 } };
+		const reader = makeReader([`data: ${JSON.stringify([item])}\n`]);
+
+		await processRaw(reader, storage);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			item,
+		]);
+		expect(consoleWarnSpy).not.toHaveBeenCalled();
+	});
+
+	it("passes an answer event through without building an iframe url", async () => {
+		const storage = makeMockStorage();
+		const item = {
+			type: "answer",
+			metadata: {
+				session_id: "sess-1",
+				gen_no: 42,
+				transaction_id: "txn-1",
+				generation_number: 7,
+				title: "Revenue by Region",
+				sage_query: "revenue by region",
+			},
+		};
+		const reader = makeReader([`data: ${JSON.stringify([item])}\n`]);
+
+		await processRaw(reader, storage);
+
+		const [, messages] = (
+			storage.appendMessagesAndRestartTtl as ReturnType<typeof vi.fn>
+		).mock.calls[0];
+		expect(messages).toEqual([item]);
+		expect(messages[0]).not.toHaveProperty("iframe_url");
+		expect(messages[0]).not.toHaveProperty("answer_id");
+	});
+
+	it("passes an error event through without logging or a fallback message", async () => {
+		const storage = makeMockStorage();
+		const item = {
+			type: "error",
+			error_code: "SPOTTER_500",
+			display_message: "Something broke upstream",
+		};
+		const reader = makeReader([`data: ${JSON.stringify([item])}\n`]);
+
+		await processRaw(reader, storage);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
+			item,
+		]);
+		expect(consoleErrorSpy).not.toHaveBeenCalled();
+		// The simplified format flags the span on an error event; raw mode does not
+		// inspect the payload, so the span still concludes successfully.
+		expect(tracingState.span?.setStatus).toHaveBeenCalledWith({
+			code: SpanStatusCode.OK,
+			message: "Streaming response concluded successfully",
+		});
+	});
+
+	it("marks the conversation as done when the stream ends", async () => {
+		const storage = makeMockStorage();
+		const reader = makeReader([
+			`data: ${JSON.stringify([{ type: "text", content: "Hi" }])}\n`,
+		]);
+
+		await processRaw(reader, storage);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenLastCalledWith(
+			CONV_ID,
+			[],
+			true,
+		);
+	});
+
+	it("stores every item from a multi-item line in a single append", async () => {
+		const storage = makeMockStorage();
+		const items = [
+			{ type: "text", content: "First", metadata: { format: "markdown" } },
+			{ type: "ack" },
+			{ type: "text", content: "Second", metadata: { format: "plain" } },
+		];
+		const reader = makeReader([`data: ${JSON.stringify(items)}\n`]);
+
+		await processRaw(reader, storage);
+
+		// One append for the batch, one terminal done call.
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledTimes(2);
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenNthCalledWith(
+			1,
+			CONV_ID,
+			items,
+		);
+	});
+
+	it("still skips blank lines and heartbeats", async () => {
+		const storage = makeMockStorage();
+		const item = { type: "text", content: "After heartbeat" };
+		const reader = makeReader([
+			`\n: heartbeat\ndata: ${JSON.stringify([item])}\n`,
+		]);
+
+		await processRaw(reader, storage);
+
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledTimes(2);
+		expect(storage.appendMessagesAndRestartTtl).toHaveBeenNthCalledWith(
+			1,
+			CONV_ID,
+			[item],
+		);
+	});
+
+	it("records no per-message metrics and reports zero parse counters", async () => {
+		const storage = makeMockStorage();
+		const recorder: MetricsRecorder = {
+			...NOOP_METRICS_RECORDER,
+			count: vi.fn(),
+		};
+		const reader = makeReader([
+			`data: ${JSON.stringify([
+				{ type: "text", content: "Hi", metadata: { format: "markdown" } },
+				{ type: "answer", metadata: { session_id: "s1", gen_no: 1 } },
+			])}\n`,
+		]);
+
+		await processRaw(reader, storage, recorder);
+
+		// Raw mode short-circuits before the recordUpstreamStreamMessageMetric calls,
+		// so the per-message counters stay untouched and the span counts stay at zero.
+		expect(recorder.count).not.toHaveBeenCalledWith(
+			METRIC_NAMES.upstreamStreamMessagesTotal,
+			expect.anything(),
+			expect.anything(),
+		);
+		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			total_messages_parsed: 0,
+			total_text_messages_parsed: 0,
+			total_answer_messages_parsed: 0,
+			total_messages_ignored: 0,
 		});
 	});
 });

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -905,7 +905,7 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 		expect(consoleWarnSpy).not.toHaveBeenCalled();
 	});
 
-	it("passes an answer event through without building an iframe url", async () => {
+	it("passes an answer event through, synthesizing answer_id but not an iframe url", async () => {
 		const storage = makeMockStorage();
 		const item = {
 			type: "answer",
@@ -925,12 +925,19 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 		const [, messages] = (
 			storage.appendMessagesAndRestartTtl as ReturnType<typeof vi.fn>
 		).mock.calls[0];
-		expect(messages).toEqual([item]);
+		// Raw mode still synthesizes `answer_id` so the get_session_updates ->
+		// create_dashboard handoff keeps working, but does not otherwise reshape
+		// the item (e.g. no iframe_url).
+		expect(messages).toEqual([
+			{
+				...item,
+				answer_id: JSON.stringify({ session_id: "sess-1", gen_no: 42 }),
+			},
+		]);
 		expect(messages[0]).not.toHaveProperty("iframe_url");
-		expect(messages[0]).not.toHaveProperty("answer_id");
 	});
 
-	it("passes an error event through without logging or a fallback message", async () => {
+	it("passes an error event through unmodified while still logging and flagging the span", async () => {
 		const storage = makeMockStorage();
 		const item = {
 			type: "error",
@@ -941,15 +948,18 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 
 		await processRaw(reader, storage);
 
+		// Raw mode does not reshape the item (no fallback text message is built),
+		// but it still surfaces the error for observability.
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
 			item,
 		]);
-		expect(consoleErrorSpy).not.toHaveBeenCalled();
-		// The simplified format flags the span on an error event; raw mode does not
-		// inspect the payload, so the span still concludes successfully.
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			"Error event in event stream, error code",
+			"SPOTTER_500",
+		);
 		expect(tracingState.span?.setStatus).toHaveBeenCalledWith({
-			code: SpanStatusCode.OK,
-			message: "Streaming response concluded successfully",
+			code: SpanStatusCode.ERROR,
+			message: "Error event in event stream, error code: SPOTTER_500",
 		});
 	});
 
@@ -1005,7 +1015,7 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 		);
 	});
 
-	it("records no per-message metrics and reports zero parse counters", async () => {
+	it("still records per-message metrics and parse counters despite not reshaping messages", async () => {
 		const storage = makeMockStorage();
 		const recorder: MetricsRecorder = {
 			...NOOP_METRICS_RECORDER,
@@ -1020,17 +1030,22 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 
 		await processRaw(reader, storage, recorder);
 
-		// Raw mode short-circuits before the recordUpstreamStreamMessageMetric calls,
-		// so the per-message counters stay untouched and the span counts stay at zero.
-		expect(recorder.count).not.toHaveBeenCalledWith(
+		// Raw mode does not reshape messages, but it still classifies each item by
+		// type so metrics/counters stay accurate for observability.
+		expect(recorder.count).toHaveBeenCalledWith(
 			METRIC_NAMES.upstreamStreamMessagesTotal,
-			expect.anything(),
-			expect.anything(),
+			1,
+			expect.objectContaining({ message_type: "text" }),
+		);
+		expect(recorder.count).toHaveBeenCalledWith(
+			METRIC_NAMES.upstreamStreamMessagesTotal,
+			1,
+			expect.objectContaining({ message_type: "answer" }),
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
-			total_messages_parsed: 0,
-			total_text_messages_parsed: 0,
-			total_answer_messages_parsed: 0,
+			total_messages_parsed: 2,
+			total_text_messages_parsed: 1,
+			total_answer_messages_parsed: 1,
 			total_messages_ignored: 0,
 		});
 	});

--- a/test/thoughtspot/thoughtspot-service.spec.ts
+++ b/test/thoughtspot/thoughtspot-service.spec.ts
@@ -11,6 +11,7 @@ import {
 	getRelevantQuestions,
 	getSessionInfo,
 } from "../../src/thoughtspot/thoughtspot-service";
+import { SpotterResponseFormat } from "../../src/thoughtspot/types";
 
 // Mock the ThoughtSpot REST API client
 const mockClient = {
@@ -303,6 +304,7 @@ describe("thoughtspot-service", () => {
 			await service.sendAgentConversationMessageStreaming(
 				"conv-123",
 				"Show me revenue",
+				SpotterResponseFormat.SIMPLIFIED,
 				appendMessages,
 			);
 			await recorder.flush();
@@ -379,6 +381,7 @@ describe("thoughtspot-service", () => {
 				service.sendAgentConversationMessageStreaming(
 					"conv-123",
 					"Show me revenue",
+					SpotterResponseFormat.SIMPLIFIED,
 					{
 						appendMessagesAndRestartTtl: vi.fn(),
 					} as any,
@@ -420,6 +423,7 @@ describe("thoughtspot-service", () => {
 				service.sendAgentConversationMessageStreaming(
 					"conv-123",
 					"Show me revenue",
+					SpotterResponseFormat.SIMPLIFIED,
 					{
 						appendMessagesAndRestartTtl: vi.fn(),
 					} as any,
@@ -457,6 +461,7 @@ describe("thoughtspot-service", () => {
 			await service.sendAgentConversationMessageStreaming(
 				"conv-123",
 				"Show me revenue",
+				SpotterResponseFormat.SIMPLIFIED,
 				streamingMessageStorage,
 				"User is in the EMEA region",
 			);
@@ -503,6 +508,7 @@ describe("thoughtspot-service", () => {
 			await service.sendAgentConversationMessageStreaming(
 				"conv-123",
 				"Show me revenue",
+				SpotterResponseFormat.SIMPLIFIED,
 				streamingMessageStorage,
 			);
 
@@ -543,6 +549,7 @@ describe("thoughtspot-service", () => {
 			await service.sendAgentConversationMessageStreaming(
 				"conv-123",
 				"Show me revenue",
+				SpotterResponseFormat.SIMPLIFIED,
 				appendStoredMessages,
 			);
 
@@ -564,6 +571,52 @@ describe("thoughtspot-service", () => {
 				[],
 				true,
 			);
+		});
+
+		it("should forward the RAW format so stream items reach storage unprocessed", async () => {
+			const encoder = new TextEncoder();
+			// A non-markdown text item: the simplified format drops it, so seeing it
+			// in storage proves the RAW format reached the stream parser.
+			const rawItem = {
+				type: "text",
+				content: "The revenue is $1M",
+				metadata: { format: "plain", type: "thinking" },
+			};
+			const reader = {
+				read: vi
+					.fn()
+					.mockResolvedValueOnce({
+						done: false,
+						value: encoder.encode(`data: ${JSON.stringify([rawItem])}\n`),
+					})
+					.mockResolvedValueOnce({ done: true, value: undefined }),
+			};
+
+			mockClient.sendAgentConversationMessageStreaming = vi
+				.fn()
+				.mockResolvedValue({
+					body: { getReader: vi.fn().mockReturnValue(reader) },
+				});
+
+			const appendStoredMessages = vi.fn().mockResolvedValue(undefined);
+
+			const service = new ThoughtSpotService(mockClient);
+			await service.sendAgentConversationMessageStreaming(
+				"conv-123",
+				"Show me revenue",
+				SpotterResponseFormat.RAW,
+				appendStoredMessages,
+			);
+
+			await vi.waitFor(() => {
+				expect(appendStoredMessages).toHaveBeenLastCalledWith(
+					"conv-123",
+					[],
+					true,
+				);
+			});
+
+			expect(appendStoredMessages).toHaveBeenCalledWith("conv-123", [rawItem]);
 		});
 
 		it("should call appendStoredMessages with parsed answer messages", async () => {
@@ -603,6 +656,7 @@ describe("thoughtspot-service", () => {
 			await service.sendAgentConversationMessageStreaming(
 				"conv-123",
 				"Show me revenue by region",
+				SpotterResponseFormat.SIMPLIFIED,
 				appendStoredMessages,
 			);
 
@@ -658,6 +712,7 @@ describe("thoughtspot-service", () => {
 			await service.sendAgentConversationMessageStreaming(
 				"conv-123",
 				"Test",
+				SpotterResponseFormat.SIMPLIFIED,
 				appendStoredMessages,
 			);
 
@@ -701,6 +756,7 @@ describe("thoughtspot-service", () => {
 			await service.sendAgentConversationMessageStreaming(
 				"conv-123",
 				"Test",
+				SpotterResponseFormat.SIMPLIFIED,
 				appendStoredMessages,
 			);
 


### PR DESCRIPTION
- Client can specify via URL flag if they want the full raw Spotter output instead of the simplified version we are providing
- Pass along the unmodified Spotter event stream if this flag has been set
- No impact when using v1 tools, this is only for v2 tools
- Update tests and add coverage