### PR TITLE
Add CODEOWNERS requiring mcp-dev review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,16 @@
 # Code owners for thoughtspot/mcp-server
 #
 # Every pull request targeting the default branch requires an approving review
-# from a member of @thoughtspot/mcp-dev. This is enforced by the `main`
-# repository ruleset (require_code_owner_review) and by classic branch
-# protection (require_code_owner_reviews).
+# from a code owner listed below. This is enforced by the `main` repository
+# ruleset (require_code_owner_review) and by classic branch protection
+# (require_code_owner_reviews).
 #
-# Note: the team must retain at least write access to this repository for
-# these entries to be treated as valid code owners.
+# Approval is satisfied by ANY ONE owner, not all of them.
+#
+# Owners must hold at least write access to this repository, or GitHub
+# silently ignores the entry. @mouryab is listed individually rather than via
+# the team because that account is a direct repository collaborator and not a
+# member of the thoughtspot org, so it cannot belong to @thoughtspot/mcp-dev.
+# If it later joins the org and the team, drop it from this line.
 
-*   @thoughtspot/mcp-dev
+*   @thoughtspot/mcp-dev @mouryab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for thoughtspot/mcp-server
+#
+# Every pull request targeting the default branch requires an approving review
+# from a member of @thoughtspot/mcp-dev. This is enforced by the `main`
+# repository ruleset (require_code_owner_review) and by classic branch
+# protection (require_code_owner_reviews).
+#
+# Note: the team must retain at least write access to this repository for
+# these entries to be treated as valid code owners.
+
+*   @thoughtspot/mcp-dev


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` routing every pull request to `@thoughtspot/mcp-dev` for approval.

This is one half of a change to make reviews genuinely mandatory on `main`. The other half is branch protection configuration, applied separately via the API:

- **Ruleset `main`** (id 5374175): `required_approving_review_count` 0 → 1, `require_code_owner_review` false → true, and the Admin `bypass_actor` removed.
- **Classic branch protection** on `main`: `require_code_owner_reviews` false → true, `enforce_admins` false → true.

Both layers needed changing — GitHub enforces the union of ruleset and classic protection, so leaving the classic layer permissive would have kept an admin bypass open.

## Effect

- Contributors with write access can push branches and open PRs, but cannot merge to `main` without an approving review from an `mcp-dev` member.
- Repository admins are subject to the same gate. There is no bypass path.
- A PR author who is themselves in `mcp-dev` cannot self-approve; another team member must review.

## Note on merging this PR

Once the protection changes are live, this PR itself requires an approval from `@thoughtspot/mcp-dev` before it can merge.