### PR TITLE
Simplify raw Spotter response format handling

### DIFF
--- a/src/metrics/runtime/tool-metrics.ts
+++ b/src/metrics/runtime/tool-metrics.ts
@@ -35,7 +35,8 @@ export type UpstreamStreamMessageType =
 	| "text_chunk"
 	| "answer"
 	| "step_notification"
-	| "error";
+	| "error"
+	| "raw_untyped";
 
 function buildToolMetricLabels(
 	toolName: string,

--- a/src/streaming-utils.ts
+++ b/src/streaming-utils.ts
@@ -83,79 +83,29 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 
 						// Loop through the items in the line and convert to messages if applicable
 						for (const item of data) {
-							// For the raw format, we don't reshape messages, but we still record
-							// metrics and flag span errors so upstream failures stay observable,
-							// and we still synthesize `answer_id` on answer events so the
-							// get_session_updates -> create_dashboard handoff keeps working.
+							// For the raw format, we don't need to perform any post-processing, so
+							// just add the messages directly. The one exception is for answer
+							// messages, where we generate the answer_id field for convenience.
 							if (spotterResponseFormat === SpotterResponseFormat.RAW) {
-								if (item.type === "text" || item.type === "text-chunk") {
-									if (item.metadata?.format === "markdown") {
-										nTextMessagesParsed++;
-										recordUpstreamStreamMessageMetric(
-											recorder,
-											upstreamOperation,
-											item.type === "text-chunk" ? "text_chunk" : "text",
-											item.metadata?.type === "thinking",
-										);
-									} else {
-										nMessagesIgnored++;
-									}
-								} else if (item.type === "answer") {
+								recordUpstreamStreamMessageMetric(
+									recorder,
+									upstreamOperation,
+									"raw_untyped",
+									item.metadata?.type === "thinking",
+								);
+								if (item.type === "answer") {
 									nAnswerMessagesParsed++;
-									recordUpstreamStreamMessageMetric(
-										recorder,
-										upstreamOperation,
-										"answer",
-										item.metadata?.type === "thinking",
-									);
-								} else if (item.type === "notification") {
-									if (
-										item.code === "TOOL_CALL_NOTIFICATION" &&
-										item.metadata?.tool_title
-									) {
-										nTextMessagesParsed++;
-										recordUpstreamStreamMessageMetric(
-											recorder,
-											upstreamOperation,
-											"step_notification",
-											item.metadata?.type === "thinking",
-										);
-									} else {
-										nMessagesIgnored++;
-									}
-								} else if (item.type === "error") {
-									console.error(
-										"Error event in event stream, error code",
-										item.error_code,
-									);
-									recordUpstreamStreamMessageMetric(
-										recorder,
-										upstreamOperation,
-										"error",
-										false,
-									);
-									spanHasError = true;
-									span.setStatus({
-										code: SpanStatusCode.ERROR,
-										message: `Error event in event stream, error code: ${item.error_code}`,
+									newMessages.push({
+										...item,
+										answer_id: JSON.stringify({
+											session_id: item.metadata?.session_id,
+											gen_no: item.metadata?.gen_no,
+										}),
 									});
 								} else {
-									// Includes ack/search_datasets/file/conv_title (intentionally
-									// ignored upstream events) and any unrecognized event type.
-									nMessagesIgnored++;
+									nTextMessagesParsed++;
+									newMessages.push({ ...item });
 								}
-
-								newMessages.push(
-									item.type === "answer"
-										? {
-												...item,
-												answer_id: JSON.stringify({
-													session_id: item.metadata?.session_id,
-													gen_no: item.metadata?.gen_no,
-												}),
-											}
-										: { ...item },
-								);
 								continue;
 							}
 
@@ -267,7 +217,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 									text: item.display_message || "Something went wrong",
 								});
 							} else {
-								console.warn("Unknown event in event stream:", item.type);
+								console.warn("Unknown event in event stream:", item);
 								nMessagesIgnored++;
 							}
 						}
@@ -288,6 +238,7 @@ export const processSendAgentConversationMessageStreamingResponse = async (
 			}
 
 			span.setAttributes({
+				spotter_response_format: spotterResponseFormat,
 				total_messages_parsed: nTextMessagesParsed + nAnswerMessagesParsed,
 				total_text_messages_parsed: nTextMessagesParsed,
 				total_answer_messages_parsed: nAnswerMessagesParsed,

--- a/test/streaming-utils.spec.ts
+++ b/test/streaming-utils.spec.ts
@@ -206,6 +206,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			true,
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 0,
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
@@ -233,6 +234,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			true,
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 0,
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
@@ -281,6 +283,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			true,
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 0,
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
@@ -308,6 +311,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			true,
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 0,
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
@@ -343,6 +347,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			{ is_thinking: false, type: "text_chunk", text: "keep chunk" },
 		]);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 2,
 			total_text_messages_parsed: 2,
 			total_answer_messages_parsed: 0,
@@ -471,6 +476,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 0,
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
@@ -581,7 +587,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 
 		expect(consoleWarnSpy).toHaveBeenCalledWith(
 			"Unknown event in event stream:",
-			"mystery_event",
+			{ type: "mystery_event" },
 		);
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledOnce();
 	});
@@ -746,6 +752,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 		);
 
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 1,
 			total_text_messages_parsed: 1,
 			total_answer_messages_parsed: 0,
@@ -773,6 +780,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			true,
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 0,
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
@@ -800,6 +808,7 @@ describe("processSendAgentConversationMessageStreamingResponse", () => {
 			true,
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.SIMPLIFIED,
 			total_messages_parsed: 0,
 			total_text_messages_parsed: 0,
 			total_answer_messages_parsed: 0,
@@ -937,7 +946,7 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 		expect(messages[0]).not.toHaveProperty("iframe_url");
 	});
 
-	it("passes an error event through unmodified while still logging and flagging the span", async () => {
+	it("passes an error event through unmodified without special logging or span flagging", async () => {
 		const storage = makeMockStorage();
 		const item = {
 			type: "error",
@@ -948,16 +957,13 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 
 		await processRaw(reader, storage);
 
-		// Raw mode does not reshape the item (no fallback text message is built),
-		// but it still surfaces the error for observability.
+		// Raw mode does not reshape the item or apply any error-specific handling;
+		// the item is passed through untouched.
 		expect(storage.appendMessagesAndRestartTtl).toHaveBeenCalledWith(CONV_ID, [
 			item,
 		]);
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			"Error event in event stream, error code",
-			"SPOTTER_500",
-		);
-		expect(tracingState.span?.setStatus).toHaveBeenCalledWith({
+		expect(consoleErrorSpy).not.toHaveBeenCalled();
+		expect(tracingState.span?.setStatus).not.toHaveBeenCalledWith({
 			code: SpanStatusCode.ERROR,
 			message: "Error event in event stream, error code: SPOTTER_500",
 		});
@@ -1030,19 +1036,16 @@ describe("processSendAgentConversationMessageStreamingResponse — raw format", 
 
 		await processRaw(reader, storage, recorder);
 
-		// Raw mode does not reshape messages, but it still classifies each item by
-		// type so metrics/counters stay accurate for observability.
+		// Raw mode does not reshape or per-type classify messages; every item is
+		// recorded as `raw_untyped`, while parse counters stay accurate.
+		expect(recorder.count).toHaveBeenCalledTimes(2);
 		expect(recorder.count).toHaveBeenCalledWith(
 			METRIC_NAMES.upstreamStreamMessagesTotal,
 			1,
-			expect.objectContaining({ message_type: "text" }),
-		);
-		expect(recorder.count).toHaveBeenCalledWith(
-			METRIC_NAMES.upstreamStreamMessagesTotal,
-			1,
-			expect.objectContaining({ message_type: "answer" }),
+			expect.objectContaining({ message_type: "raw_untyped" }),
 		);
 		expect(tracingState.span?.setAttributes).toHaveBeenCalledWith({
+			spotter_response_format: SpotterResponseFormat.RAW,
 			total_messages_parsed: 2,
 			total_text_messages_parsed: 1,
 			total_answer_messages_parsed: 1,


### PR DESCRIPTION
- Remove extra logic to make it more maintainable
- We can add more detailed metrics if this response format sees substatial usage